### PR TITLE
Rdf prefix cleanup

### DIFF
--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -62,7 +62,6 @@ struct Config {
   double minimalAreaEnvelopeRatio = -1.0;
 
   // Default settings for data
-  std::string osm2rdfPrefix = "osmadd";
   std::unordered_set<std::string> semicolonTagKeys;
 
   // Dot

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -266,12 +266,6 @@ const static inline std::string SEMICOLON_TAG_KEYS_OPTION_LONG =
     "split-tag-key-by-semicolon";
 const static inline std::string SEMICOLON_TAG_KEYS_OPTION_HELP = "";
 
-const static inline std::string osm2rdf_PREFIX_INFO = "Prefix for osm2rdf-iris";
-const static inline std::string osm2rdf_PREFIX_OPTION_SHORT = "";
-const static inline std::string osm2rdf_PREFIX_OPTION_LONG = "oms2ttl-prefix";
-const static inline std::string osm2rdf_PREFIX_OPTION_HELP =
-    "Prefix for own IRIs";
-
 const static inline std::string WKT_PRECISION_INFO =
     "Dumping WKT with precision: ";
 const static inline std::string WKT_PRECISION_OPTION_SHORT = "";

--- a/include/osm2rdf/ttl/Constants.h
+++ b/include/osm2rdf/ttl/Constants.h
@@ -26,12 +26,13 @@ namespace osm2rdf::ttl::constants {
 // Real constants
 const static inline std::string NAMESPACE__GEOSPARQL = "geo";
 const static inline std::string NAMESPACE__OPENGIS = "ogc";
-const static inline std::string NAMESPACE__OSM_META = "osmm";
+const static inline std::string NAMESPACE__OSM_META = "osmmeta";
 const static inline std::string NAMESPACE__OSM_NODE = "osmnode";
 const static inline std::string NAMESPACE__OSM_RELATION = "osmrel";
-const static inline std::string NAMESPACE__OSM_TAG = "osmt";
+const static inline std::string NAMESPACE__OSM_TAG = "osmkey";
 const static inline std::string NAMESPACE__OSM_WAY = "osmway";
 const static inline std::string NAMESPACE__OSM = "osm";
+const static inline std::string NAMESPACE__OSM2RDF = "osm2rdf";
 const static inline std::string NAMESPACE__RDF = "rdf";
 const static inline std::string NAMESPACE__WIKIDATA_ENTITY = "wd";
 const static inline std::string NAMESPACE__XML_SCHEMA = "xsd";
@@ -40,10 +41,10 @@ const static inline std::string NAMESPACE__XML_SCHEMA = "xsd";
 inline std::string IRI__GEOSPARQL__HAS_GEOMETRY;
 inline std::string IRI__GEOSPARQL__WKT_LITERAL;
 
-inline std::string IRI__OGC_CONTAINS_NON_AREA;
-inline std::string IRI__OGC_CONTAINS_AREA;
-inline std::string IRI__OGC_INTERSECTS_NON_AREA;
-inline std::string IRI__OGC_INTERSECTS_AREA;
+inline std::string IRI__OSM2RDF_CONTAINS_NON_AREA;
+inline std::string IRI__OSM2RDF_CONTAINS_AREA;
+inline std::string IRI__OSM2RDF_INTERSECTS_NON_AREA;
+inline std::string IRI__OSM2RDF_INTERSECTS_AREA;
 
 inline std::string IRI__OSM_META__POS;
 inline std::string IRI__OSMWAY_IS_CLOSED;

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -45,9 +45,6 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       << prefix << osm2rdf::config::constants::CACHE_INFO << "         "
       << cache;
   oss << "\n" << prefix << osm2rdf::config::constants::SECTION_FACTS;
-  oss << "\n"
-      << prefix << osm2rdf::config::constants::osm2rdf_PREFIX_INFO << ": "
-      << osm2rdfPrefix;
   if (noFacts) {
     oss << "\n" << prefix << osm2rdf::config::constants::NO_FACTS_INFO;
   } else {
@@ -309,12 +306,6 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
           osm2rdf::config::constants::SEMICOLON_TAG_KEYS_OPTION_SHORT,
           osm2rdf::config::constants::SEMICOLON_TAG_KEYS_OPTION_LONG,
           osm2rdf::config::constants::SEMICOLON_TAG_KEYS_OPTION_HELP);
-  auto osm2rdfPrefixOp =
-      op.add<popl::Value<std::string>, popl::Attribute::advanced>(
-          osm2rdf::config::constants::osm2rdf_PREFIX_OPTION_SHORT,
-          osm2rdf::config::constants::osm2rdf_PREFIX_OPTION_LONG,
-          osm2rdf::config::constants::osm2rdf_PREFIX_OPTION_HELP,
-          osm2rdfPrefix);
 
   auto simplifyGeometriesOp =
       op.add<popl::Value<uint16_t>, popl::Attribute::expert>(
@@ -437,7 +428,6 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
     addWayNodeOrder |= addWayNodeGeometry;
     addWayNodeOrder |= addWayNodeSpatialMetadata;
 
-    osm2rdfPrefix = osm2rdfPrefixOp->value();
     if (semicolonTagKeysOp->is_set()) {
       for (size_t i = 0; i < semicolonTagKeysOp->count(); ++i) {
         semicolonTagKeys.insert(semicolonTagKeysOp->value(i));

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -423,10 +423,10 @@ void osm2rdf::osm::GeometryHandler<W>::dumpNamedAreaRelations() {
 #pragma omp parallel for shared( \
     vertices, osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, \
     osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION, \
-    osm2rdf::ttl::constants::IRI__OGC_CONTAINS_AREA, \
-    osm2rdf::ttl::constants::IRI__OGC_CONTAINS_NON_AREA, \
-    osm2rdf::ttl::constants::IRI__OGC_INTERSECTS_AREA, \
-    osm2rdf::ttl::constants::IRI__OGC_INTERSECTS_NON_AREA, progressBar, \
+    osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_AREA, \
+    osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA, \
+    osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA, \
+    osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA, progressBar, \
     entryCount) default(none) schedule(static)
   for (size_t i = 0; i < vertices.size(); i++) {
     const auto id = vertices[i];
@@ -448,9 +448,9 @@ void osm2rdf::osm::GeometryHandler<W>::dumpNamedAreaRelations() {
           areaObjId);
 
       _writer->writeTriple(
-          areaIRI, osm2rdf::ttl::constants::IRI__OGC_CONTAINS_AREA, entryIRI);
+          areaIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_AREA, entryIRI);
       _writer->writeTriple(
-          areaIRI, osm2rdf::ttl::constants::IRI__OGC_INTERSECTS_AREA, entryIRI);
+          areaIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA, entryIRI);
     }
 #pragma omp critical(progress)
     progressBar.update(entryCount++);
@@ -500,8 +500,8 @@ void osm2rdf::osm::GeometryHandler<W>::dumpUnnamedAreaRelations() {
 #pragma omp parallel for shared( \
     osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, \
     osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION, \
-    osm2rdf::ttl::constants::IRI__OGC_INTERSECTS_NON_AREA, \
-    osm2rdf::ttl::constants::IRI__OGC_CONTAINS_NON_AREA, \
+    osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA, \
+    osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA, \
     progressBar, entryCount, ia) reduction(+:areas,intersectsSkippedByDAG, \
     containsSkippedByDAG, intersectsChecks, intersectsOk, containsChecks, \
     containsOk, containsOkEnvelope)      \
@@ -578,7 +578,7 @@ void osm2rdf::osm::GeometryHandler<W>::dumpUnnamedAreaRelations() {
             skipIntersects.insert(newSkip);
           }
           _writer->writeTriple(
-              areaIRI, osm2rdf::ttl::constants::IRI__OGC_INTERSECTS_NON_AREA,
+              areaIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,
               entryIRI);
         }
 
@@ -629,7 +629,7 @@ void osm2rdf::osm::GeometryHandler<W>::dumpUnnamedAreaRelations() {
             skipContains.insert(newSkip);
           }
           _writer->writeTriple(
-              areaIRI, osm2rdf::ttl::constants::IRI__OGC_CONTAINS_NON_AREA,
+              areaIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,
               entryIRI);
         }
       }
@@ -693,8 +693,8 @@ osm2rdf::osm::GeometryHandler<W>::dumpNodeRelations() {
     osm2rdf::ttl::constants::NAMESPACE__OSM_NODE, \
     osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, \
     osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION,\
-    osm2rdf::ttl::constants::IRI__OGC_CONTAINS_NON_AREA, \
-    osm2rdf::ttl::constants::IRI__OGC_INTERSECTS_NON_AREA, nodeData, \
+    osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA, \
+    osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA, nodeData, \
     progressBar, entryCount, ia) reduction(+:checks, \
     skippedByDAG, contains, containsOk) default(none) schedule(dynamic)
     for (size_t i = 0; i < _numNodes; i++) {
@@ -756,10 +756,10 @@ osm2rdf::osm::GeometryHandler<W>::dumpNodeRelations() {
                         : osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION,
             areaObjId);
         _writer->writeTriple(
-            areaIRI, osm2rdf::ttl::constants::IRI__OGC_INTERSECTS_NON_AREA,
+            areaIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,
             nodeIRI);
         _writer->writeTriple(areaIRI,
-                             osm2rdf::ttl::constants::IRI__OGC_CONTAINS_NON_AREA,
+                             osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,
                              nodeIRI);
       }
 #pragma omp critical(nodeDataChange)
@@ -819,8 +819,8 @@ void osm2rdf::osm::GeometryHandler<W>::dumpWayRelations(
 #pragma omp parallel for shared( \
     osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, nodeData, \
     osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION, \
-    osm2rdf::ttl::constants::IRI__OGC_INTERSECTS_NON_AREA, \
-    osm2rdf::ttl::constants::IRI__OGC_CONTAINS_NON_AREA, \
+    osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA, \
+    osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA, \
     progressBar, entryCount, ia) reduction(+:areas,intersectsSkippedByDAG, containsSkippedByDAG, skippedInDAG, \
     intersectsByNodeInfo, intersectsChecks, intersectsOk, containsChecks, containsOk, containsOkEnvelope)    \
     default(none) schedule(dynamic)
@@ -898,7 +898,7 @@ void osm2rdf::osm::GeometryHandler<W>::dumpWayRelations(
             skipIntersects.insert(newSkip);
           }
           _writer->writeTriple(
-              areaIRI, osm2rdf::ttl::constants::IRI__OGC_INTERSECTS_NON_AREA,
+              areaIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,
               wayIRI);
         } else {
           intersectsChecks++;
@@ -924,7 +924,7 @@ void osm2rdf::osm::GeometryHandler<W>::dumpWayRelations(
             skipIntersects.insert(newSkip);
           }
           _writer->writeTriple(
-              areaIRI, osm2rdf::ttl::constants::IRI__OGC_INTERSECTS_NON_AREA,
+              areaIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,
               wayIRI);
         }
         if (!doesIntersect) {
@@ -974,7 +974,7 @@ void osm2rdf::osm::GeometryHandler<W>::dumpWayRelations(
             skipContains.insert(newSkip);
           }
           _writer->writeTriple(
-              areaIRI, osm2rdf::ttl::constants::IRI__OGC_CONTAINS_NON_AREA,
+              areaIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,
               wayIRI);
         }
       }

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -47,6 +47,9 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
        "http://www.w3.org/1999/02/22-rdf-syntax-ns#"},
       {osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
        "http://www.opengis.net/rdf#"},
+      // own prefix
+      {osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
+       "https://osm2rdf.cs.uni-freiburg.de/rdf#"},
       // osm prefixes
       {osm2rdf::ttl::constants::NAMESPACE__OSM,
        "https://www.openstreetmap.org/"},
@@ -68,14 +71,14 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__GEOSPARQL, "hasGeometry");
   osm2rdf::ttl::constants::IRI__GEOSPARQL__WKT_LITERAL =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__GEOSPARQL, "wktLiteral");
-  osm2rdf::ttl::constants::IRI__OGC_CONTAINS_AREA =
-      generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS, "contains_area");
-  osm2rdf::ttl::constants::IRI__OGC_CONTAINS_NON_AREA = generateIRI(
-      osm2rdf::ttl::constants::NAMESPACE__OPENGIS, "contains_nonarea");
-  osm2rdf::ttl::constants::IRI__OGC_INTERSECTS_AREA = generateIRI(
-      osm2rdf::ttl::constants::NAMESPACE__OPENGIS, "intersects_area");
-  osm2rdf::ttl::constants::IRI__OGC_INTERSECTS_NON_AREA = generateIRI(
-      osm2rdf::ttl::constants::NAMESPACE__OPENGIS, "intersects_nonarea");
+  osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_AREA =
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF, "contains_area");
+  osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA = generateIRI(
+      osm2rdf::ttl::constants::NAMESPACE__OSM2RDF, "contains_nonarea");
+  osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA = generateIRI(
+      osm2rdf::ttl::constants::NAMESPACE__OSM2RDF, "intersects_area");
+  osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA = generateIRI(
+      osm2rdf::ttl::constants::NAMESPACE__OSM2RDF, "intersects_nonarea");
   osm2rdf::ttl::constants::IRI__OSM_META__POS =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_META, "pos");
   osm2rdf::ttl::constants::IRI__OSMWAY_IS_CLOSED =

--- a/tests/E2E.cpp
+++ b/tests/E2E.cpp
@@ -169,26 +169,26 @@ TEST(E2E, singleNodeWithTags) {
                   "47.9960901)\"^^geo:wktLiteral .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
-                  "osmnode:240092010 osmt:alt_name \"Freiburg i. Br.\" .\n"));
+                  "osmnode:240092010 osmkey:alt_name \"Freiburg i. Br.\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmnode:240092010 osmkey:name \"Freiburg im Breisgau\" .\n"));
   ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmnode:240092010 osmt:name \"Freiburg im Breisgau\" .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr("osmnode:240092010 osmt:name:ja "
+              ::testing::HasSubstr("osmnode:240092010 osmkey:name:ja "
                                    "\"\xE3\x83\x95\xE3\x83\xA9\xE3\x82\xA4\xE3"
                                    "\x83\x96\xE3\x83\xAB\xE3\x82\xAF\" .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
-                  "osmnode:240092010 osmt:short_name \"Freiburg\" .\n"));
+                  "osmnode:240092010 osmkey:short_name \"Freiburg\" .\n"));
   ASSERT_THAT(
       printedData,
-      ::testing::HasSubstr("osmnode:240092010 osmt:wikidata \"Q2833\" .\n"));
+      ::testing::HasSubstr("osmnode:240092010 osmkey:wikidata \"Q2833\" .\n"));
   ASSERT_THAT(printedData, ::testing::HasSubstr(
                                "osmnode:240092010 osm:wikidata wd:Q2833 .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr(
-          "osmnode:240092010 osmt:wikipedia \"de:Freiburg im Breisgau\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr("osmnode:240092010 osmkey:wikipedia "
+                                   "\"de:Freiburg im Breisgau\" .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
@@ -265,32 +265,33 @@ TEST(E2E, singleWayWithTagsAndNodes) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 osmt:addr:city \"Freiburg im Breisgau\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:addr:housenumber \"51\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:addr:postcode \"79110\" .\n"));
+          "osmway:98284318 osmkey:addr:city \"Freiburg im Breisgau\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr(
+                  "osmway:98284318 osmkey:addr:housenumber \"51\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr(
+                  "osmway:98284318 osmkey:addr:postcode \"79110\" .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 osmt:addr:street \"Georges-Köhler-Allee\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:building \"university\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:building:levels \"4\" .\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:98284318 osmt:name \"Gebäude 51\" .\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:98284318 osmt:roof:levels \"1\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:roof:shape \"hipped\" .\n"));
+          "osmway:98284318 osmkey:addr:street \"Georges-Köhler-Allee\" .\n"));
   ASSERT_THAT(printedData,
-              ::testing::HasSubstr("osmway:98284318 osmt:source:outline "
+              ::testing::HasSubstr(
+                  "osmway:98284318 osmkey:building \"university\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:98284318 osmkey:building:levels \"4\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:98284318 osmkey:name \"Gebäude 51\" .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(
+                               "osmway:98284318 osmkey:roof:levels \"1\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:98284318 osmkey:roof:shape \"hipped\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr("osmway:98284318 osmkey:source:outline "
                                    "\"maps4bw (LGL, www.lgl-bw.de)\" .\n"));
   // No nodes -> no real geometry
   ASSERT_THAT(printedData,
@@ -380,10 +381,10 @@ TEST(E2E, osmWikiExample) {
   const auto printedData = coutBuffer.str();
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
-                  "osmnode:1831881213 osmt:traffic_sign \"city_limit\" .\n"));
+                  "osmnode:1831881213 osmkey:traffic_sign \"city_limit\" .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
-                  "osmway:26659127 osmt:name \"Pastower Straße\" .\n"));
+                  "osmway:26659127 osmkey:name \"Pastower Straße\" .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr("osmway:26659127 geo:hasGeometry \"LINESTRING("));
@@ -537,32 +538,32 @@ TEST(E2E, building51NT) {
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "<https://www.openstreetmap.org/way/98284318> "
-                  "<http://www.opengis.net/rdf#intersects_nonarea> "
+                  "<https://osm2rdf.cs.uni-freiburg.de/rdf#intersects_nonarea> "
                   "<https://www.openstreetmap.org/node/2110601105> .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "<https://www.openstreetmap.org/way/98284318> "
-                  "<http://www.opengis.net/rdf#contains_nonarea> "
+                  "<https://osm2rdf.cs.uni-freiburg.de/rdf#contains_nonarea> "
                   "<https://www.openstreetmap.org/node/2110601105> .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "<https://www.openstreetmap.org/way/98284318> "
-                  "<http://www.opengis.net/rdf#intersects_nonarea> "
+                  "<https://osm2rdf.cs.uni-freiburg.de/rdf#intersects_nonarea> "
                   "<https://www.openstreetmap.org/node/2110601134> .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "<https://www.openstreetmap.org/way/98284318> "
-                  "<http://www.opengis.net/rdf#contains_nonarea> "
+                  "<https://osm2rdf.cs.uni-freiburg.de/rdf#contains_nonarea> "
                   "<https://www.openstreetmap.org/node/2110601134> .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "<https://www.openstreetmap.org/way/98284318> "
-                  "<http://www.opengis.net/rdf#intersects_nonarea> "
+                  "<https://osm2rdf.cs.uni-freiburg.de/rdf#intersects_nonarea> "
                   "<https://www.openstreetmap.org/node/5190342871> .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "<https://www.openstreetmap.org/way/98284318> "
-                  "<http://www.opengis.net/rdf#contains_nonarea> "
+                  "<https://osm2rdf.cs.uni-freiburg.de/rdf#contains_nonarea> "
                   "<https://www.openstreetmap.org/node/5190342871> .\n"));
 
   // Reset std::cerr and std::cout
@@ -646,32 +647,33 @@ TEST(E2E, building51TTL) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 osmt:addr:city \"Freiburg im Breisgau\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:addr:housenumber \"51\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:addr:postcode \"79110\" .\n"));
+          "osmway:98284318 osmkey:addr:city \"Freiburg im Breisgau\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr(
+                  "osmway:98284318 osmkey:addr:housenumber \"51\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr(
+                  "osmway:98284318 osmkey:addr:postcode \"79110\" .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 osmt:addr:street \"Georges-Köhler-Allee\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:building \"university\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:building:levels \"4\" .\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:98284318 osmt:name \"Gebäude 51\" .\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:98284318 osmt:roof:levels \"1\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:roof:shape \"hipped\" .\n"));
+          "osmway:98284318 osmkey:addr:street \"Georges-Köhler-Allee\" .\n"));
   ASSERT_THAT(printedData,
-              ::testing::HasSubstr("osmway:98284318 osmt:source:outline "
+              ::testing::HasSubstr(
+                  "osmway:98284318 osmkey:building \"university\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:98284318 osmkey:building:levels \"4\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:98284318 osmkey:name \"Gebäude 51\" .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(
+                               "osmway:98284318 osmkey:roof:levels \"1\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:98284318 osmkey:roof:shape \"hipped\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr("osmway:98284318 osmkey:source:outline "
                                    "\"maps4bw (LGL, www.lgl-bw.de)\" .\n"));
   ASSERT_THAT(
       printedData,
@@ -684,27 +686,27 @@ TEST(E2E, building51TTL) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:intersects_nonarea osmnode:2110601105 .\n"));
+          "osmway:98284318 osm2rdf:intersects_nonarea osmnode:2110601105 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:contains_nonarea osmnode:2110601105 .\n"));
+          "osmway:98284318 osm2rdf:contains_nonarea osmnode:2110601105 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:intersects_nonarea osmnode:2110601134 .\n"));
+          "osmway:98284318 osm2rdf:intersects_nonarea osmnode:2110601134 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:contains_nonarea osmnode:2110601134 .\n"));
+          "osmway:98284318 osm2rdf:contains_nonarea osmnode:2110601134 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:intersects_nonarea osmnode:5190342871 .\n"));
+          "osmway:98284318 osm2rdf:intersects_nonarea osmnode:5190342871 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:contains_nonarea osmnode:5190342871 .\n"));
+          "osmway:98284318 osm2rdf:contains_nonarea osmnode:5190342871 .\n"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -787,32 +789,33 @@ TEST(E2E, building51QLEVER) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 osmt:addr:city \"Freiburg im Breisgau\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:addr:housenumber \"51\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:addr:postcode \"79110\" .\n"));
+          "osmway:98284318 osmkey:addr:city \"Freiburg im Breisgau\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr(
+                  "osmway:98284318 osmkey:addr:housenumber \"51\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr(
+                  "osmway:98284318 osmkey:addr:postcode \"79110\" .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 osmt:addr:street \"Georges-Köhler-Allee\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:building \"university\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:building:levels \"4\" .\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:98284318 osmt:name \"Gebäude 51\" .\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:98284318 osmt:roof:levels \"1\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:roof:shape \"hipped\" .\n"));
+          "osmway:98284318 osmkey:addr:street \"Georges-Köhler-Allee\" .\n"));
   ASSERT_THAT(printedData,
-              ::testing::HasSubstr("osmway:98284318 osmt:source:outline "
+              ::testing::HasSubstr(
+                  "osmway:98284318 osmkey:building \"university\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:98284318 osmkey:building:levels \"4\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:98284318 osmkey:name \"Gebäude 51\" .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(
+                               "osmway:98284318 osmkey:roof:levels \"1\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:98284318 osmkey:roof:shape \"hipped\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr("osmway:98284318 osmkey:source:outline "
                                    "\"maps4bw (LGL, www.lgl-bw.de)\" .\n"));
   ASSERT_THAT(
       printedData,
@@ -825,27 +828,27 @@ TEST(E2E, building51QLEVER) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:intersects_nonarea osmnode:2110601105 .\n"));
+          "osmway:98284318 osm2rdf:intersects_nonarea osmnode:2110601105 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:contains_nonarea osmnode:2110601105 .\n"));
+          "osmway:98284318 osm2rdf:contains_nonarea osmnode:2110601105 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:intersects_nonarea osmnode:2110601134 .\n"));
+          "osmway:98284318 osm2rdf:intersects_nonarea osmnode:2110601134 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:contains_nonarea osmnode:2110601134 .\n"));
+          "osmway:98284318 osm2rdf:contains_nonarea osmnode:2110601134 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:intersects_nonarea osmnode:5190342871 .\n"));
+          "osmway:98284318 osm2rdf:intersects_nonarea osmnode:5190342871 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:contains_nonarea osmnode:5190342871 .\n"));
+          "osmway:98284318 osm2rdf:contains_nonarea osmnode:5190342871 .\n"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -925,16 +928,16 @@ TEST(E2E, tf) {
               ::testing::HasSubstr("osmway:4498466 rdf:type osm:way .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
-                  "osmway:4498466 osmt:name \"Technische Fakultät\" .\n"));
+                  "osmway:4498466 osmkey:name \"Technische Fakultät\" .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:4498466 osmt:int_name \"Faculty of Engineering\" .\n"));
+          "osmway:4498466 osmkey:int_name \"Faculty of Engineering\" .\n"));
   ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:4498466 osmt:operator "
+                               "osmway:4498466 osmkey:operator "
                                "\"Albert-Ludwigs-Universität Freiburg\" .\n"));
   ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:4498466 osmt:wheelchair \"yes\" .\n"));
+                               "osmway:4498466 osmkey:wheelchair \"yes\" .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr("osmway:4498466 geo:hasGeometry \"LINESTRING(7"));
@@ -1042,32 +1045,33 @@ TEST(E2E, building51inTF) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 osmt:addr:city \"Freiburg im Breisgau\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:addr:housenumber \"51\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:addr:postcode \"79110\" .\n"));
+          "osmway:98284318 osmkey:addr:city \"Freiburg im Breisgau\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr(
+                  "osmway:98284318 osmkey:addr:housenumber \"51\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr(
+                  "osmway:98284318 osmkey:addr:postcode \"79110\" .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 osmt:addr:street \"Georges-Köhler-Allee\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:building \"university\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:building:levels \"4\" .\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:98284318 osmt:name \"Gebäude 51\" .\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:98284318 osmt:roof:levels \"1\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:98284318 osmt:roof:shape \"hipped\" .\n"));
+          "osmway:98284318 osmkey:addr:street \"Georges-Köhler-Allee\" .\n"));
   ASSERT_THAT(printedData,
-              ::testing::HasSubstr("osmway:98284318 osmt:source:outline "
+              ::testing::HasSubstr(
+                  "osmway:98284318 osmkey:building \"university\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:98284318 osmkey:building:levels \"4\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:98284318 osmkey:name \"Gebäude 51\" .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(
+                               "osmway:98284318 osmkey:roof:levels \"1\" .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:98284318 osmkey:roof:shape \"hipped\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr("osmway:98284318 osmkey:source:outline "
                                    "\"maps4bw (LGL, www.lgl-bw.de)\" .\n"));
   ASSERT_THAT(
       printedData,
@@ -1079,16 +1083,16 @@ TEST(E2E, building51inTF) {
               ::testing::HasSubstr("osmway:4498466 rdf:type osm:way .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
-                  "osmway:4498466 osmt:name \"Technische Fakultät\" .\n"));
+                  "osmway:4498466 osmkey:name \"Technische Fakultät\" .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:4498466 osmt:int_name \"Faculty of Engineering\" .\n"));
+          "osmway:4498466 osmkey:int_name \"Faculty of Engineering\" .\n"));
   ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:4498466 osmt:operator "
+                               "osmway:4498466 osmkey:operator "
                                "\"Albert-Ludwigs-Universität Freiburg\" .\n"));
   ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:4498466 osmt:wheelchair \"yes\" .\n"));
+                               "osmway:4498466 osmkey:wheelchair \"yes\" .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr("osmway:4498466 geo:hasGeometry \"LINESTRING(7"));
@@ -1097,34 +1101,35 @@ TEST(E2E, building51inTF) {
                   "osmway:4498466 geo:hasGeometry \"MULTIPOLYGON(((7"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
-                  "osmway:4498466 ogc:contains_area osmway:98284318 .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:4498466 ogc:intersects_area osmway:98284318 .\n"));
+                  "osmway:4498466 osm2rdf:contains_area osmway:98284318 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:intersects_nonarea osmnode:2110601105 .\n"));
+          "osmway:4498466 osm2rdf:intersects_area osmway:98284318 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:contains_nonarea osmnode:2110601105 .\n"));
+          "osmway:98284318 osm2rdf:intersects_nonarea osmnode:2110601105 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:intersects_nonarea osmnode:2110601134 .\n"));
+          "osmway:98284318 osm2rdf:contains_nonarea osmnode:2110601105 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:contains_nonarea osmnode:2110601134 .\n"));
+          "osmway:98284318 osm2rdf:intersects_nonarea osmnode:2110601134 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:intersects_nonarea osmnode:5190342871 .\n"));
+          "osmway:98284318 osm2rdf:contains_nonarea osmnode:2110601134 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osmway:98284318 ogc:contains_nonarea osmnode:5190342871 .\n"));
+          "osmway:98284318 osm2rdf:intersects_nonarea osmnode:5190342871 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osmway:98284318 osm2rdf:contains_nonarea osmnode:5190342871 .\n"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);

--- a/tests/config/Config.cpp
+++ b/tests/config/Config.cpp
@@ -53,7 +53,6 @@ void assertDefaultConfig(const osm2rdf::config::Config& config) {
   ASSERT_FALSE(config.skipWikiLinks);
 
   ASSERT_EQ(0, config.semicolonTagKeys.size());
-  ASSERT_EQ("osmadd", config.osm2rdfPrefix);
 
   ASSERT_FALSE(config.writeDAGDotFiles);
 
@@ -831,22 +830,6 @@ TEST(CONFIG_Config, fromArgsSimplifyWKTPrecisionLong) {
   config.fromArgs(argc, argv);
   ASSERT_EQ("", config.output.string());
   ASSERT_EQ(2, config.wktPrecision);
-}
-
-// ____________________________________________________________________________
-TEST(CONFIG_Config, fromArgsosm2rdfPrefixLong) {
-  osm2rdf::config::Config config;
-  assertDefaultConfig(config);
-  osm2rdf::util::CacheFile cf("/tmp/dummyInput");
-
-  const auto arg = "--" + osm2rdf::config::constants::osm2rdf_PREFIX_OPTION_LONG;
-  const int argc = 4;
-  char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
-                      const_cast<char*>("foo"),
-                      const_cast<char*>("/tmp/dummyInput")};
-  config.fromArgs(argc, argv);
-  ASSERT_EQ("", config.output.string());
-  ASSERT_EQ("foo", config.osm2rdfPrefix);
 }
 
 // ____________________________________________________________________________

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -237,7 +237,7 @@ TEST(OSM_FactHandler, areaAddSortMetadata) {
   ASSERT_EQ(
       "osmway:21 geo:hasGeometry \"MULTIPOLYGON(((48.0 7.5,48.0 7.6,48.1 "
       "7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral .\n"
-      "osmway:21 osmm:area \"0.010000000000\"^^xsd:double .\n",
+      "osmway:21 osmmeta:area \"0.010000000000\"^^xsd:double .\n",
       buffer.str());
 
   // Cleanup
@@ -287,8 +287,8 @@ TEST(OSM_FactHandler, areaAddAreaEnvelopeRatioRectangle) {
   ASSERT_EQ(
       "osmway:21 geo:hasGeometry \"MULTIPOLYGON(((48.0 7.5,48.0 7.6,48.1 "
       "7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral .\n"
-      "osmway:21 osmm:area \"0.010000000000\"^^xsd:double .\n"
-      "osmway:21 osmm:area_envelope_ratio \"1.000000\"^^xsd:double .\n",
+      "osmway:21 osmmeta:area \"0.010000000000\"^^xsd:double .\n"
+      "osmway:21 osmmeta:area_envelope_ratio \"1.000000\"^^xsd:double .\n",
       buffer.str());
 
   // Cleanup
@@ -338,8 +338,8 @@ TEST(OSM_FactHandler, areaAddAreaEnvelopeRatioDiamond) {
   ASSERT_EQ(
       "osmway:21 geo:hasGeometry \"MULTIPOLYGON(((0.5 0.0,0.0 0.5,0.5 1.0,1.0 "
       "0.5,0.5 0.0)))\"^^geo:wktLiteral .\n"
-      "osmway:21 osmm:area \"0.500000000000\"^^xsd:double .\n"
-      "osmway:21 osmm:area_envelope_ratio \"0.500000\"^^xsd:double .\n",
+      "osmway:21 osmmeta:area \"0.500000000000\"^^xsd:double .\n"
+      "osmway:21 osmmeta:area_envelope_ratio \"0.500000\"^^xsd:double .\n",
       buffer.str());
 
   // Cleanup
@@ -383,8 +383,8 @@ TEST(OSM_FactHandler, node) {
   ASSERT_EQ(
       "osmnode:42 rdf:type osm:node .\n"
       "osmnode:42 geo:hasGeometry \"POINT(7.5 48.0)\"^^geo:wktLiteral .\n"
-      "osmnode:42 osmt:city \"Freiburg\" .\n"
-      "osmnode:42 osmm:facts \"1\"^^xsd:integer .\n",
+      "osmnode:42 osmkey:city \"Freiburg\" .\n"
+      "osmnode:42 osmmeta:facts \"1\"^^xsd:integer .\n",
       buffer.str());
 
   // Cleanup
@@ -429,8 +429,8 @@ TEST(OSM_FactHandler, nodeAddEnvelope) {
   ASSERT_EQ(
       "osmnode:42 rdf:type osm:node .\n"
       "osmnode:42 geo:hasGeometry \"POINT(7.5 48.0)\"^^geo:wktLiteral .\n"
-      "osmnode:42 osmt:city \"Freiburg\" .\n"
-      "osmnode:42 osmm:facts \"1\"^^xsd:integer .\n"
+      "osmnode:42 osmkey:city \"Freiburg\" .\n"
+      "osmnode:42 osmmeta:facts \"1\"^^xsd:integer .\n"
       "osmnode:42 osm:envelope \"POLYGON((7.5 48.0,7.5 48.0,7.5 48.0,7.5 "
       "48.0,7.5 48.0))\"^^geo:wktLiteral .\n",
       buffer.str());
@@ -478,8 +478,8 @@ TEST(OSM_FactHandler, relation) {
 
   ASSERT_EQ(
       "osmrel:42 rdf:type osm:relation .\n"
-      "osmrel:42 osmt:city \"Freiburg\" .\n"
-      "osmrel:42 osmm:facts \"1\"^^xsd:integer .\n"
+      "osmrel:42 osmkey:city \"Freiburg\" .\n"
+      "osmrel:42 osmmeta:facts \"1\"^^xsd:integer .\n"
       "osmrel:42 osmrel:member _:0 .\n"
       "_:0 osm:id osmnode:1 .\n"
       "_:0 osm:role \"label\" .\n"
@@ -534,8 +534,8 @@ TEST(OSM_FactHandler, way) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
-      "osmway:42 osmt:city \"Freiburg\" .\n"
-      "osmway:42 osmm:facts \"1\"^^xsd:integer .\n"
+      "osmway:42 osmkey:city \"Freiburg\" .\n"
+      "osmway:42 osmmeta:facts \"1\"^^xsd:integer .\n"
       "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
       "7.6)\"^^geo:wktLiteral .\n",
       buffer.str());
@@ -581,14 +581,14 @@ TEST(OSM_FactHandler, wayAddSortMetadata) {
   output.flush();
   output.close();
 
-  // osmm:length should be a multiple of sqrt(2)
+  // osmmeta:length should be a multiple of sqrt(2)
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
-      "osmway:42 osmt:city \"Freiburg\" .\n"
-      "osmway:42 osmm:facts \"1\"^^xsd:integer .\n"
+      "osmway:42 osmkey:city \"Freiburg\" .\n"
+      "osmway:42 osmmeta:facts \"1\"^^xsd:integer .\n"
       "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
       "7.6)\"^^geo:wktLiteral .\n"
-      "osmway:42 osmm:length \"0.141421\"^^xsd:double .\n",
+      "osmway:42 osmmeta:length \"0.141421\"^^xsd:double .\n",
       buffer.str());
 
   // Cleanup
@@ -635,8 +635,8 @@ TEST(OSM_FactHandler, wayAddWayEnvelope) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
-      "osmway:42 osmt:city \"Freiburg\" .\n"
-      "osmway:42 osmm:facts \"1\"^^xsd:integer .\n"
+      "osmway:42 osmkey:city \"Freiburg\" .\n"
+      "osmway:42 osmmeta:facts \"1\"^^xsd:integer .\n"
       "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
       "7.6)\"^^geo:wktLiteral .\n"
       "osmway:42 osm:envelope \"POLYGON((48.0 7.5,48.0 7.6,48.1 7.6,48.1 "
@@ -688,16 +688,16 @@ TEST(OSM_FactHandler, wayAddWayNodeGeoemtry) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
-      "osmway:42 osmt:city \"Freiburg\" .\n"
-      "osmway:42 osmm:facts \"1\"^^xsd:integer .\n"
+      "osmway:42 osmkey:city \"Freiburg\" .\n"
+      "osmway:42 osmmeta:facts \"1\"^^xsd:integer .\n"
       "osmway:42 osmway:node _:0 .\n"
       "_:0 osmway:node osmnode:1 .\n"
-      "_:0 osmm:pos \"1\"^^xsd:integer .\n"
+      "_:0 osmmeta:pos \"1\"^^xsd:integer .\n"
       "osmnode:1 rdf:type osm:node .\n"
       "osmnode:1 geo:hasGeometry \"POINT(48.0 7.5)\"^^geo:wktLiteral .\n"
       "osmway:42 osmway:node _:1 .\n"
       "_:1 osmway:node osmnode:2 .\n"
-      "_:1 osmm:pos \"2\"^^xsd:integer .\n"
+      "_:1 osmmeta:pos \"2\"^^xsd:integer .\n"
       "osmnode:2 rdf:type osm:node .\n"
       "osmnode:2 geo:hasGeometry \"POINT(48.1 7.6)\"^^geo:wktLiteral .\n"
       "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
@@ -748,14 +748,14 @@ TEST(OSM_FactHandler, wayAddWayNodeOrder) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
-      "osmway:42 osmt:city \"Freiburg\" .\n"
-      "osmway:42 osmm:facts \"1\"^^xsd:integer .\n"
+      "osmway:42 osmkey:city \"Freiburg\" .\n"
+      "osmway:42 osmmeta:facts \"1\"^^xsd:integer .\n"
       "osmway:42 osmway:node _:0 .\n"
       "_:0 osmway:node osmnode:1 .\n"
-      "_:0 osmm:pos \"1\"^^xsd:integer .\n"
+      "_:0 osmmeta:pos \"1\"^^xsd:integer .\n"
       "osmway:42 osmway:node _:1 .\n"
       "_:1 osmway:node osmnode:2 .\n"
-      "_:1 osmm:pos \"2\"^^xsd:integer .\n"
+      "_:1 osmmeta:pos \"2\"^^xsd:integer .\n"
       "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
       "7.6)\"^^geo:wktLiteral .\n",
       buffer.str());
@@ -805,14 +805,14 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataShortWay) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
-      "osmway:42 osmt:city \"Freiburg\" .\n"
-      "osmway:42 osmm:facts \"1\"^^xsd:integer .\n"
+      "osmway:42 osmkey:city \"Freiburg\" .\n"
+      "osmway:42 osmmeta:facts \"1\"^^xsd:integer .\n"
       "osmway:42 osmway:node _:0 .\n"
       "_:0 osmway:node osmnode:1 .\n"
-      "_:0 osmm:pos \"1\"^^xsd:integer .\n"
+      "_:0 osmmeta:pos \"1\"^^xsd:integer .\n"
       "osmway:42 osmway:node _:1 .\n"
       "_:1 osmway:node osmnode:2 .\n"
-      "_:1 osmm:pos \"2\"^^xsd:integer .\n"
+      "_:1 osmmeta:pos \"2\"^^xsd:integer .\n"
       "_:0 osmway:next_node osmnode:2 .\n"
       "_:0 osmway:next_node_distance \"15657.137001\"^^xsd:decimal .\n"
       "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
@@ -866,24 +866,24 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataLongerWay) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
-      "osmway:42 osmt:city \"Freiburg\" .\n"
-      "osmway:42 osmm:facts \"1\"^^xsd:integer .\n"
+      "osmway:42 osmkey:city \"Freiburg\" .\n"
+      "osmway:42 osmmeta:facts \"1\"^^xsd:integer .\n"
       "osmway:42 osmway:node _:0 .\n"
       "_:0 osmway:node osmnode:1 .\n"
-      "_:0 osmm:pos \"1\"^^xsd:integer .\n"
+      "_:0 osmmeta:pos \"1\"^^xsd:integer .\n"
       "osmway:42 osmway:node _:1 .\n"
       "_:1 osmway:node osmnode:2 .\n"
-      "_:1 osmm:pos \"2\"^^xsd:integer .\n"
+      "_:1 osmmeta:pos \"2\"^^xsd:integer .\n"
       "_:0 osmway:next_node osmnode:2 .\n"
       "_:0 osmway:next_node_distance \"15657.137001\"^^xsd:decimal .\n"
       "osmway:42 osmway:node _:2 .\n"
       "_:2 osmway:node osmnode:4 .\n"
-      "_:2 osmm:pos \"3\"^^xsd:integer .\n"
+      "_:2 osmmeta:pos \"3\"^^xsd:integer .\n"
       "_:1 osmway:next_node osmnode:4 .\n"
       "_:1 osmway:next_node_distance \"11119.490351\"^^xsd:decimal .\n"
       "osmway:42 osmway:node _:3 .\n"
       "_:3 osmway:node osmnode:3 .\n"
-      "_:3 osmm:pos \"4\"^^xsd:integer .\n"
+      "_:3 osmmeta:pos \"4\"^^xsd:integer .\n"
       "_:2 osmway:next_node osmnode:3 .\n"
       "_:2 osmway:next_node_distance \"11024.108103\"^^xsd:decimal .\n"
       "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 7.6,48.1 7.5,48.0 "
@@ -934,8 +934,8 @@ TEST(OSM_FactHandler, wayAddWayMetaData) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
-      "osmway:42 osmt:city \"Freiburg\" .\n"
-      "osmway:42 osmm:facts \"1\"^^xsd:integer .\n"
+      "osmway:42 osmkey:city \"Freiburg\" .\n"
+      "osmway:42 osmmeta:facts \"1\"^^xsd:integer .\n"
       "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
       "7.6)\"^^geo:wktLiteral .\n"
       "osmway:42 osmway:is_closed \"no\" .\n"
@@ -1288,10 +1288,10 @@ TEST(OSM_FactHandler, writeTag_KeyNotIRI) {
   dh.writeTag(subject, osm2rdf::osm::Tag{tagKey, tagValue});
   const std::string expected = subject +
                                " osm:tag _:0 .\n"
-                               "_:0 osmt:key \"" +
+                               "_:0 osmkey:key \"" +
                                tagKey +
                                "\" .\n"
-                               "_:0 osmt:value \"" +
+                               "_:0 osmkey:value \"" +
                                tagValue + "\" .\n";
   output.flush();
   output.close();

--- a/tests/osm/GeometryHandler.cpp
+++ b/tests/osm/GeometryHandler.cpp
@@ -940,7 +940,7 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimple) {
       ::testing::HasSubstr(
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 14) +
           " " +
-          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
+          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
                              "contains_area") +
           " " +
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 12)));
@@ -949,7 +949,7 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimple) {
       ::testing::HasSubstr(
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 14) +
           " " +
-          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
+          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
                              "intersects_area") +
           " " +
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 12)));
@@ -958,7 +958,7 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimple) {
       ::testing::HasSubstr(
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 12) +
           " " +
-          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
+          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
                              "contains_area") +
           " " +
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 13)));
@@ -967,7 +967,7 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimple) {
       ::testing::HasSubstr(
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 12) +
           " " +
-          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
+          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
                              "intersects_area") +
           " " +
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 13)));
@@ -976,7 +976,7 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimple) {
       ::testing::HasSubstr(
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 12) +
           " " +
-          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
+          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
                              "contains_area") +
           " " +
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 11)));
@@ -985,7 +985,7 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimple) {
       ::testing::HasSubstr(
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 12) +
           " " +
-          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
+          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
                              "intersects_area") +
           " " +
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 11)));
@@ -1099,7 +1099,7 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimpleOpenMP) {
       ::testing::HasSubstr(
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 14) +
           " " +
-          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
+          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
                              "contains_area") +
           " " +
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 12)));
@@ -1108,7 +1108,7 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimpleOpenMP) {
       ::testing::HasSubstr(
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 14) +
           " " +
-          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
+          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
                              "intersects_area") +
           " " +
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 12)));
@@ -1117,7 +1117,7 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimpleOpenMP) {
       ::testing::HasSubstr(
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 12) +
           " " +
-          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
+          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
                              "contains_area") +
           " " +
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 13)));
@@ -1126,7 +1126,7 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimpleOpenMP) {
       ::testing::HasSubstr(
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 12) +
           " " +
-          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
+          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
                              "intersects_area") +
           " " +
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 13)));
@@ -1135,7 +1135,7 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimpleOpenMP) {
       ::testing::HasSubstr(
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 12) +
           " " +
-          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
+          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
                              "contains_area") +
           " " +
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 11)));
@@ -1144,7 +1144,7 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimpleOpenMP) {
       ::testing::HasSubstr(
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 12) +
           " " +
-          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS,
+          writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
                              "intersects_area") +
           " " +
           writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, 11)));
@@ -1440,9 +1440,9 @@ TEST(OSM_GeometryHandler, dumpUnnamedAreaRelationsSimpleIntersects) {
                            "                           contains: 3 contains "
                            "envelope: 1 yes: 1\n"));
   ASSERT_EQ(
-      "osmway:11 ogc:intersects_nonarea osmrel:15 .\n"
-      "osmway:13 ogc:intersects_nonarea osmrel:15 .\n"
-      "osmway:12 ogc:contains_nonarea osmrel:15 .\n",
+      "osmway:11 osm2rdf:intersects_nonarea osmrel:15 .\n"
+      "osmway:13 osm2rdf:intersects_nonarea osmrel:15 .\n"
+      "osmway:12 osm2rdf:contains_nonarea osmrel:15 .\n",
       printedData);
 
   // Reset std::cerr and std::cout
@@ -1563,8 +1563,8 @@ TEST(OSM_GeometryHandler, dumpUnnamedAreaRelationsSimpleContainsOnly) {
                            "                           contains: 1 contains "
                            "envelope: 1 yes: 1\n"));
   ASSERT_EQ(
-      "osmway:11 ogc:intersects_nonarea osmrel:15 .\n"
-      "osmway:11 ogc:contains_nonarea osmrel:15 .\n",
+      "osmway:11 osm2rdf:intersects_nonarea osmrel:15 .\n"
+      "osmway:11 osm2rdf:contains_nonarea osmrel:15 .\n",
       printedData);
 
   // Reset std::cerr and std::cout
@@ -1846,8 +1846,8 @@ TEST(OSM_GeometryHandler, dumpNodeRelationsSimpleIntersects) {
                   "                           1 checks performed\n"
                   "                           contains: 1 yes: 1\n"));
   ASSERT_EQ(
-      "osmway:13 ogc:intersects_nonarea osmnode:42 .\n"
-      "osmway:13 ogc:contains_nonarea osmnode:42 .\n",
+      "osmway:13 osm2rdf:intersects_nonarea osmnode:42 .\n"
+      "osmway:13 osm2rdf:contains_nonarea osmnode:42 .\n",
       printedData);
 
   // Reset std::cerr and std::cout
@@ -1960,8 +1960,8 @@ TEST(OSM_GeometryHandler, dumpNodeRelationsSimpleContains) {
                   "                           1 checks performed\n"
                   "                           contains: 1 yes: 1\n"));
   ASSERT_EQ(
-      "osmway:11 ogc:intersects_nonarea osmnode:42 .\n"
-      "osmway:11 ogc:contains_nonarea osmnode:42 .\n",
+      "osmway:11 osm2rdf:intersects_nonarea osmnode:42 .\n"
+      "osmway:11 osm2rdf:contains_nonarea osmnode:42 .\n",
       printedData);
 
   // Reset std::cerr and std::cout
@@ -2249,9 +2249,9 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleIntersects) {
                   "                           contains: 3 contains envelope: 1 "
                   "yes: 1\n"));
   ASSERT_EQ(
-      "osmway:11 ogc:intersects_nonarea osmway:42 .\n"
-      "osmway:13 ogc:intersects_nonarea osmway:42 .\n"
-      "osmway:12 ogc:contains_nonarea osmway:42 .\n",
+      "osmway:11 osm2rdf:intersects_nonarea osmway:42 .\n"
+      "osmway:13 osm2rdf:intersects_nonarea osmway:42 .\n"
+      "osmway:12 osm2rdf:contains_nonarea osmway:42 .\n",
       printedData);
 
   // Reset std::cerr and std::cout
@@ -2370,8 +2370,8 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleContains) {
                   "                           contains: 1 contains envelope: 1 "
                   "yes: 1\n"));
   ASSERT_EQ(
-      "osmway:11 ogc:intersects_nonarea osmway:42 .\n"
-      "osmway:11 ogc:contains_nonarea osmway:42 .\n",
+      "osmway:11 osm2rdf:intersects_nonarea osmway:42 .\n"
+      "osmway:11 osm2rdf:contains_nonarea osmway:42 .\n",
       printedData);
 
   // Reset std::cerr and std::cout
@@ -2503,16 +2503,19 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleIntersectsWithNodeInfo) {
                   "skipped by DAG\n"
                   "                           contains: 3 contains envelope: 1 "
                   "yes: 1\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:13 ogc:intersects_nonarea osmnode:1 .\n"
-                               "osmway:13 ogc:contains_nonarea osmnode:1 .\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:11 ogc:intersects_nonarea osmnode:2 .\n"
-                               "osmway:11 ogc:contains_nonarea osmnode:2 .\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:11 ogc:intersects_nonarea osmway:42 .\n"
-                               "osmway:13 ogc:intersects_nonarea osmway:42 .\n"
-                               "osmway:12 ogc:contains_nonarea osmway:42 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:13 osm2rdf:intersects_nonarea osmnode:1 .\n"
+                           "osmway:13 osm2rdf:contains_nonarea osmnode:1 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:11 osm2rdf:intersects_nonarea osmnode:2 .\n"
+                           "osmway:11 osm2rdf:contains_nonarea osmnode:2 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:11 osm2rdf:intersects_nonarea osmway:42 .\n"
+                           "osmway:13 osm2rdf:intersects_nonarea osmway:42 .\n"
+                           "osmway:12 osm2rdf:contains_nonarea osmway:42 .\n"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -2638,12 +2641,14 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleContainsWithNodeInfo) {
                   "skipped by DAG\n"
                   "                           contains: 1 contains envelope: 1 "
                   "yes: 1\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:11 ogc:intersects_nonarea osmnode:2 .\n"
-                               "osmway:11 ogc:contains_nonarea osmnode:2 .\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "osmway:11 ogc:intersects_nonarea osmway:42 .\n"
-                               "osmway:11 ogc:contains_nonarea osmway:42 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:11 osm2rdf:intersects_nonarea osmnode:2 .\n"
+                           "osmway:11 osm2rdf:contains_nonarea osmnode:2 .\n"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr("osmway:11 osm2rdf:intersects_nonarea osmway:42 .\n"
+                           "osmway:11 osm2rdf:contains_nonarea osmway:42 .\n"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);


### PR DESCRIPTION
* Removes the unused option `--oms2ttl-prefix`.
* Improves naming of prefixes to improve clarity e.g. `osmm` -> `osmmeta`.