### PR TITLE
Handle keys suffixed with :wikidata and :wikipedia like wikidata and wikipedia keys

### DIFF
--- a/include/osm2rdf/osm/FactHandler.h
+++ b/include/osm2rdf/osm/FactHandler.h
@@ -67,6 +67,8 @@ class FactHandler {
   FRIEND_TEST(OSM_FactHandler, writeTagListWikipediaWithoutLang);
   FRIEND_TEST(OSM_FactHandler, writeTagListSkipWikiLinks);
 
+  bool hasSuffix(const std::string& s, const std::string& suffix) const;
+
   const osm2rdf::config::Config _config;
   osm2rdf::ttl::Writer<W>* _writer;
 };

--- a/include/osm2rdf/ttl/Constants.h
+++ b/include/osm2rdf/ttl/Constants.h
@@ -58,7 +58,6 @@ inline std::string IRI__OSM_NODE;
 inline std::string IRI__OSM_RELATION;
 inline std::string IRI__OSM_TAG;
 inline std::string IRI__OSM_WAY;
-inline std::string IRI__OSM_WIKIPEDIA;
 
 inline std::string IRI__RDF_TYPE;
 

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -373,7 +373,7 @@ void osm2rdf::osm::FactHandler<W>::writeTagList(
     }
     // Handling for wiki tags
     if (!_config.skipWikiLinks) {
-      if (key == "wikidata") {
+      if (key == "wikidata" || hasSuffix(key, ":wikidata")) {
         // Only take first wikidata entry if ; is found
         auto end = value.find(';');
         if (end != std::string::npos) {
@@ -392,19 +392,23 @@ void osm2rdf::osm::FactHandler<W>::writeTagList(
                 osm2rdf::ttl::constants::NAMESPACE__WIKIDATA_ENTITY, value));
         tagTripleCount++;
       }
-      if (key == "wikipedia") {
+      if (key == "wikipedia" || hasSuffix(key, ":wikipedia")) {
         auto pos = value.find(':');
         if (pos != std::string::npos) {
           std::string lang = value.substr(0, pos);
           std::string entry = value.substr(pos + 1);
           _writer->writeTriple(
-              s, osm2rdf::ttl::constants::IRI__OSM_WIKIPEDIA,
+              s,
+              _writer->generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM,
+                                   key),
               _writer->generateIRI("https://" + lang + ".wikipedia.org/wiki/",
                                    entry));
           tagTripleCount++;
         } else {
           _writer->writeTriple(
-              s, osm2rdf::ttl::constants::IRI__OSM_WIKIPEDIA,
+              s,
+              _writer->generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM,
+                                   key),
               _writer->generateIRI("https://www.wikipedia.org/wiki/", value));
           tagTripleCount++;
         }
@@ -418,6 +422,16 @@ void osm2rdf::osm::FactHandler<W>::writeTagList(
       _writer->generateLiteral(
           std::to_string(tagTripleCount),
           "^^" + osm2rdf::ttl::constants::IRI__XSD_INTEGER));
+}
+
+// ____________________________________________________________________________
+template <typename W>
+bool osm2rdf::osm::FactHandler<W>::hasSuffix(const std::string& s,
+                                             const std::string& suffix) const {
+  if (s.size() < suffix.size()) {
+    return false;
+  }
+  return strcmp(s.c_str() + s.size() - suffix.size(), suffix.c_str()) == 0;
 }
 
 // ____________________________________________________________________________

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -103,8 +103,6 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, "tag");
   osm2rdf::ttl::constants::IRI__OSM_WAY =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, "way");
-  osm2rdf::ttl::constants::IRI__OSM_WIKIPEDIA =
-      generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, "wikipedia");
   osm2rdf::ttl::constants::IRI__RDF_TYPE =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__RDF, "type");
 

--- a/tests/E2E.cpp
+++ b/tests/E2E.cpp
@@ -138,6 +138,11 @@ TEST(E2E, singleNodeWithTags) {
                "  <tag k=\"wikidata\" v=\"Q2833\"/>\n"
                "  <tag k=\"wikipedia\" v=\"de:Freiburg im Breisgau\"/>\n"
                "</node>\n";
+  inputFile << "<node id=\"925950614\" lat=\"47.9878947\" lon=\"7.8704212\" "
+               "visible=\"true\" version=\"1\">"
+               "  <tag k=\"brand:wikidata\" v=\"Q41171672\"/>\n"
+               "  <tag k=\"brand:wikipedia\" v=\"en:Aldi\"/>\n"
+               "</node>\n";
   inputFile << "</osm>" << std::endl;
 
   osm2rdf::util::Output output{config, config.output};
@@ -155,7 +160,7 @@ TEST(E2E, singleNodeWithTags) {
   ASSERT_THAT(printedState,
               ::testing::HasSubstr("areas seen:0 dumped: 0 geometry: 0\n"));
   ASSERT_THAT(printedState,
-              ::testing::HasSubstr("nodes seen:1 dumped: 1 geometry: 1\n"));
+              ::testing::HasSubstr("nodes seen:2 dumped: 2 geometry: 2\n"));
   ASSERT_THAT(printedState,
               ::testing::HasSubstr("relations seen:0 dumped: 0 geometry: 0\n"));
   ASSERT_THAT(printedState,
@@ -163,6 +168,8 @@ TEST(E2E, singleNodeWithTags) {
   const auto printedData = coutBuffer.str();
   ASSERT_THAT(printedData,
               ::testing::HasSubstr("osmnode:240092010 rdf:type osm:node .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr("osmnode:925950614 rdf:type osm:node .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "osmnode:240092010 geo:hasGeometry \"POINT(7.8494005 "
@@ -194,6 +201,19 @@ TEST(E2E, singleNodeWithTags) {
       ::testing::HasSubstr(
           "osmnode:240092010 osm:wikipedia "
           "<https://de.wikipedia.org/wiki/Freiburg%20im%20Breisgau> .\n"));
+
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr(
+                  "osmnode:925950614 osmkey:brand:wikidata \"Q41171672\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr(
+                  "osmnode:925950614 osm:brand:wikidata wd:Q41171672 .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr("osmnode:925950614 osmkey:brand:wikipedia "
+                                   "\"en:Aldi\" .\n"));
+  ASSERT_THAT(printedData,
+              ::testing::HasSubstr("osmnode:925950614 osm:brand:wikipedia "
+                                   "<https://en.wikipedia.org/wiki/Aldi> .\n"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);


### PR DESCRIPTION
With this PR, a tag like "brand:wikidata=Q524757" gets translated into a relation `<node> <osm:brand:wikidata> wd:Q524757`, similar to a tag like `wikidata=Q524757`. Note that "brand:wikidata=Q524757"  is *not* translated into `<node> <osm:wikidata> wd:Q524757`, as there might be multiple wikidata IDs (one for the brand, one for the building, etc).

Wikipedia tags are handled exactly the same.