### PR TITLE
Add headers so that it compiles with libboost1.74-dev

### DIFF
--- a/include/osm2rdf/osm/TagList.h
+++ b/include/osm2rdf/osm/TagList.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "boost/version.hpp"
 #if BOOST_VERSION >= 107400 && BOOST_VERSION < 107500
 #include "boost/serialization/library_version_type.hpp"
 #endif

--- a/include/osm2rdf/osm/TagList.h
+++ b/include/osm2rdf/osm/TagList.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "boost/serialization/library_version_type.hpp"
 #include "boost/serialization/unordered_map.hpp"
 #include "osmium/tags/taglist.hpp"
 

--- a/include/osm2rdf/osm/TagList.h
+++ b/include/osm2rdf/osm/TagList.h
@@ -22,7 +22,9 @@
 #include <string>
 #include <unordered_map>
 
+#if BOOST_VERSION >= 107400 && BOOST_VERSION < 107500
 #include "boost/serialization/library_version_type.hpp"
+#endif
 #include "boost/serialization/unordered_map.hpp"
 #include "osmium/tags/taglist.hpp"
 

--- a/include/osm2rdf/osm/Way.h
+++ b/include/osm2rdf/osm/Way.h
@@ -21,6 +21,7 @@
 
 #include <vector>
 
+#include "boost/version.hpp"
 #if BOOST_VERSION >= 107400 && BOOST_VERSION < 107500
 #include "boost/serialization/library_version_type.hpp"
 #endif

--- a/include/osm2rdf/osm/Way.h
+++ b/include/osm2rdf/osm/Way.h
@@ -21,6 +21,7 @@
 
 #include <vector>
 
+#include "boost/serialization/library_version_type.hpp"
 #include "boost/serialization/nvp.hpp"
 #include "boost/serialization/unordered_map.hpp"
 #include "boost/serialization/vector.hpp"

--- a/include/osm2rdf/osm/Way.h
+++ b/include/osm2rdf/osm/Way.h
@@ -21,7 +21,9 @@
 
 #include <vector>
 
+#if BOOST_VERSION >= 107400 && BOOST_VERSION < 107500
 #include "boost/serialization/library_version_type.hpp"
+#endif
 #include "boost/serialization/nvp.hpp"
 #include "boost/serialization/unordered_map.hpp"
 #include "boost/serialization/vector.hpp"


### PR DESCRIPTION
Add missing boost header to `TagList.h` and `Way.h`, thus fixing the omission of these includes in libboost1.74 (will be fixed again in 1.75 or 1.76, but we don't have that yet on Ubuntu 20.04).