### PR TITLE
Make compilation of osm2rdf the default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@
 
 DOCKER:=$(shell which podman || which wharfer || which docker)
 
+osm2rdf: build
+	cmake --build build --target osm2rdf
+
 all: compile checkstyle test benchmark
 
 clean:


### PR DESCRIPTION
So far, the default target (which is also invoked in the Dockerfile) was
to compile everything and run all tests and the benchmark. This took a
very long time, whereas compiling only the osm2rdf binary (what most
people will want) is relatively fast.

Now, by default, make without target and the Dockerfile compile only the
osm2rdf binary.