### PR TITLE
Add missing header

### DIFF
--- a/src/osm/Node.cpp
+++ b/src/osm/Node.cpp
@@ -18,6 +18,7 @@
 
 #include "osm2rdf/osm/Node.h"
 
+#include "boost/geometry.hpp"
 #include "boost/geometry/algorithms/envelope.hpp"
 #include "osm2rdf/geometry/Box.h"
 #include "osm2rdf/geometry/Global.h"


### PR DESCRIPTION
This PR adds a missing `#include "boost/geometry.hpp"` in `src/osm/Node.cpp` which made builds on fedora fail with boost 1.76 and gcc 12.1.1