### PR TITLE
extend option --store-locations-on-disk to accept optional parameters…

### DIFF
--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -31,7 +31,7 @@ namespace osm2rdf::config {
 
 struct Config {
   // Select what to do
-  bool storeLocationsOnDisk = false;
+  std::string storeLocationsOnDisk;
 
   bool noFacts = false;
   bool noAreaFacts = false;

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -79,12 +79,12 @@ const static inline std::string OUTPUT_NO_COMPRESS_OPTION_HELP =
     "Do not compress output";
 
 const static inline std::string STORE_LOCATIONS_ON_DISK_INFO =
-    "Storing locations osmium locations on disk";
+    "Storing locations osmium locations on disk:";
 const static inline std::string STORE_LOCATIONS_ON_DISK_SHORT = "";
 const static inline std::string STORE_LOCATIONS_ON_DISK_LONG =
     "store-locations-on-disk";
 const static inline std::string STORE_LOCATIONS_ON_DISK_HELP =
-    "Store locations on disk - slower but reduced ram usage";
+    "Store locations on disk, optional valid values: sparse (default), dense";
 
 const static inline std::string NO_FACTS_INFO = "Not dumping facts";
 const static inline std::string NO_FACTS_OPTION_SHORT = "";

--- a/include/osm2rdf/osm/LocationHandler.h
+++ b/include/osm2rdf/osm/LocationHandler.h
@@ -25,6 +25,7 @@
 #include "osmium/handler/node_locations_for_ways.hpp"
 #include "osmium/index/map/flex_mem.hpp"
 #include "osmium/index/map/sparse_file_array.hpp"
+#include "osmium/index/map/dense_file_array.hpp"
 #include "osmium/osm/node.hpp"
 #include "osmium/osm/relation.hpp"
 #include "osmium/osm/types.hpp"
@@ -71,10 +72,31 @@ class LocationHandlerImpl<osmium::index::map::SparseFileArray<
       _handler;
 };
 
+template <>
+class LocationHandlerImpl<osmium::index::map::DenseFileArray<
+    osmium::unsigned_object_id_type, osmium::Location>>
+    : public LocationHandler {
+ public:
+  explicit LocationHandlerImpl(const osm2rdf::config::Config& config);
+  void node(const osmium::Node& node);
+  void way(osmium::Way& way);  // NOLINT
+ protected:
+  osm2rdf::util::CacheFile _cacheFile;
+  osmium::index::map::DenseFileArray<osmium::unsigned_object_id_type,
+                                      osmium::Location>
+      _index;
+  osmium::handler::NodeLocationsForWays<osmium::index::map::DenseFileArray<
+      osmium::unsigned_object_id_type, osmium::Location>>
+      _handler;
+};
+
 using LocationHandlerRAM = LocationHandlerImpl<osmium::index::map::FlexMem<
     osmium::unsigned_object_id_type, osmium::Location>>;
-using LocationHandlerFS =
+using LocationHandlerFSSparse =
     LocationHandlerImpl<osmium::index::map::SparseFileArray<
+        osmium::unsigned_object_id_type, osmium::Location>>;
+using LocationHandlerFSDense =
+    LocationHandlerImpl<osmium::index::map::DenseFileArray<
         osmium::unsigned_object_id_type, osmium::Location>>;
 
 }  // namespace osm2rdf::osm

--- a/tests/config/Config.cpp
+++ b/tests/config/Config.cpp
@@ -16,10 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "osm2rdf/config/Config.h"
-
 #include "gmock/gmock-matchers.h"
 #include "gtest/gtest.h"
+#include "osm2rdf/config/Config.h"
 #include "osm2rdf/config/Constants.h"
 #include "osm2rdf/config/ExitCode.h"
 #include "osm2rdf/util/CacheFile.h"
@@ -30,7 +29,7 @@ namespace osm2rdf::config {
 void assertDefaultConfig(const osm2rdf::config::Config& config) {
   ASSERT_FALSE(config.noFacts);
   ASSERT_FALSE(config.noGeometricRelations);
-  ASSERT_FALSE(config.storeLocationsOnDisk);
+  ASSERT_TRUE(config.storeLocationsOnDisk.empty());
 
   ASSERT_FALSE(config.noAreaFacts);
   ASSERT_FALSE(config.noNodeFacts);
@@ -404,7 +403,7 @@ TEST(CONFIG_Config, fromArgsNoGeometricRelationsLong) {
 }
 
 // ____________________________________________________________________________
-TEST(CONFIG_Config, fromArgsStoreLocationsOnDiskLong) {
+TEST(CONFIG_Config, fromArgsStoreLocationsOnDiskLongImplicit) {
   osm2rdf::config::Config config;
   assertDefaultConfig(config);
   osm2rdf::util::CacheFile cf("/tmp/dummyInput");
@@ -416,7 +415,41 @@ TEST(CONFIG_Config, fromArgsStoreLocationsOnDiskLong) {
                       const_cast<char*>("/tmp/dummyInput")};
   config.fromArgs(argc, argv);
   ASSERT_EQ("", config.output.string());
-  ASSERT_TRUE(config.storeLocationsOnDisk);
+  ASSERT_EQ("sparse", config.storeLocationsOnDisk);
+}
+
+// ____________________________________________________________________________
+TEST(CONFIG_Config, fromArgsStoreLocationsOnDiskLongSparse) {
+  osm2rdf::config::Config config;
+  assertDefaultConfig(config);
+  osm2rdf::util::CacheFile cf("/tmp/dummyInput");
+
+  const auto arg = "--" +
+                   osm2rdf::config::constants::STORE_LOCATIONS_ON_DISK_LONG +
+                   "=sparse";
+  const int argc = 3;
+  char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
+                      const_cast<char*>("/tmp/dummyInput")};
+  config.fromArgs(argc, argv);
+  ASSERT_EQ("", config.output.string());
+  ASSERT_EQ("sparse", config.storeLocationsOnDisk);
+}
+
+// ____________________________________________________________________________
+TEST(CONFIG_Config, fromArgsStoreLocationsOnDiskLongDense) {
+  osm2rdf::config::Config config;
+  assertDefaultConfig(config);
+  osm2rdf::util::CacheFile cf("/tmp/dummyInput");
+
+  const auto arg = "--" +
+                   osm2rdf::config::constants::STORE_LOCATIONS_ON_DISK_LONG +
+                   "=dense";
+  const int argc = 3;
+  char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
+                      const_cast<char*>("/tmp/dummyInput")};
+  config.fromArgs(argc, argv);
+  ASSERT_EQ("", config.output.string());
+  ASSERT_EQ("dense", config.storeLocationsOnDisk);
 }
 
 // ____________________________________________________________________________
@@ -1305,8 +1338,9 @@ TEST(CONFIG_Config, getInfoOutputKeepFiles) {
 
   const std::string res = config.getInfo("");
 
-  ASSERT_THAT(res, ::testing::HasSubstr(
-                       osm2rdf::config::constants::OUTPUT_KEEP_FILES_OPTION_INFO));
+  ASSERT_THAT(res,
+              ::testing::HasSubstr(
+                  osm2rdf::config::constants::OUTPUT_KEEP_FILES_OPTION_INFO));
 }
 
 }  // namespace osm2rdf::config


### PR DESCRIPTION
… "dense" and "sparse" (default: "sparse"). This does not change the existing behavior of this option.