### PR TITLE
Add "boost/version.hpp" header in all files checking boost version and minor clean up

### DIFF
--- a/apps/osm2rdf-stats.cpp
+++ b/apps/osm2rdf-stats.cpp
@@ -163,25 +163,25 @@ class OsmiumIdHandler : public osmium::handler::Handler {
   }
 
   static std::string idInfo(const uint64_t max) {
-    std::string s{"<= "};
+    std::string size{"<= "};
     if (max <= std::numeric_limits<uint8_t>::max()) {
-      s += " uint8_t";
-      return s;
+      size += " uint8_t";
+      return size;
     }
     if (max <= std::numeric_limits<uint16_t>::max()) {
-      s += "uint16_t";
-      return s;
+      size += "uint16_t";
+      return size;
     }
     if (max <= std::numeric_limits<uint32_t>::max()) {
-      s += "uint32_t";
-      return s;
+      size += "uint32_t";
+      return size;
     }
     if (max <= std::numeric_limits<uint64_t>::max()) {
-      s += "uint64_t";
-      return s;
+      size += "uint64_t";
+      return size;
     }
-    s += "unknown!";
-    return s;
+    size += "unknown!";
+    return size;
   }
 
  protected:

--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -52,7 +52,7 @@ struct Config {
   // case). Think of this is maximum portion of the radius that is
   // "collapsed away" by the inner simplification, or added by the outer
   // simplification
-  double simplifyGeometriesInnerOuter = 1/(3.14 * 20);
+  double simplifyGeometriesInnerOuter = 1 / (3.14 * 20);
   bool dontUseInnerOuterGeoms = false;
   bool approximateSpatialRels = false;
 
@@ -112,8 +112,8 @@ struct Config {
   [[nodiscard]] std::string getInfo(std::string_view prefix) const;
 
   // Generate a path inside the cache directory.
-  [[nodiscard]] std::filesystem::path getTempPath(const std::string& p,
-                                                  const std::string& s) const;
+  [[nodiscard]] std::filesystem::path getTempPath(
+      const std::string& path, const std::string& suffix) const;
 };
 }  // namespace osm2rdf::config
 

--- a/include/osm2rdf/geometry/Relation.h
+++ b/include/osm2rdf/geometry/Relation.h
@@ -22,6 +22,7 @@
 #include <boost/geometry/algorithms/equals.hpp>
 #include "boost/geometry/geometries/geometries.hpp"
 #include "boost/variant.hpp"
+#include "boost/version.hpp"
 #include "osm2rdf/geometry/Area.h"
 #include "osm2rdf/geometry/Node.h"
 #include "osm2rdf/geometry/Way.h"

--- a/include/osm2rdf/osm/GeometryHandler.h
+++ b/include/osm2rdf/osm/GeometryHandler.h
@@ -27,6 +27,7 @@
 
 #include "boost/archive/binary_oarchive.hpp"
 #include "boost/geometry/index/rtree.hpp"
+#include "boost/version.hpp"
 #include "gtest/gtest_prod.h"
 #include "osm2rdf/config/Config.h"
 #include "osm2rdf/geometry/Area.h"

--- a/include/osm2rdf/osm/LocationHandler.h
+++ b/include/osm2rdf/osm/LocationHandler.h
@@ -38,7 +38,7 @@ class LocationHandler : public osmium::handler::Handler {
  public:
   virtual ~LocationHandler() {}
   virtual void node(const osmium::Node& node) = 0;
-  virtual void way(osmium::Way& way) = 0;  // NOLINT
+  virtual void way(osmium::Way& way) = 0;
   [[nodiscard]] virtual osmium::Location get_node_location(
       const osmium::object_id_type id) const = 0;
   // Helper creating the correct instance.
@@ -50,9 +50,9 @@ class LocationHandlerImpl : public LocationHandler {
  public:
   explicit LocationHandlerImpl(const osm2rdf::config::Config& config);
   void node(const osmium::Node& node);
-  void way(osmium::Way& way);  // NOLINT
+  void way(osmium::Way& way);
   [[nodiscard]] osmium::Location get_node_location(
-      const osmium::object_id_type id) const;
+      const osmium::object_id_type nodeId) const;
 
  protected:
   T _index;
@@ -66,9 +66,9 @@ class LocationHandlerImpl<osmium::index::map::SparseFileArray<
  public:
   explicit LocationHandlerImpl(const osm2rdf::config::Config& config);
   void node(const osmium::Node& node);
-  void way(osmium::Way& way);  // NOLINT
+  void way(osmium::Way& way);
   [[nodiscard]] osmium::Location get_node_location(
-      const osmium::object_id_type id) const;
+      const osmium::object_id_type nodeId) const;
 
  protected:
   osm2rdf::util::CacheFile _cacheFile;
@@ -87,9 +87,9 @@ class LocationHandlerImpl<osmium::index::map::DenseFileArray<
  public:
   explicit LocationHandlerImpl(const osm2rdf::config::Config& config);
   void node(const osmium::Node& node);
-  void way(osmium::Way& way);  // NOLINT
+  void way(osmium::Way& way);
   [[nodiscard]] osmium::Location get_node_location(
-      const osmium::object_id_type id) const;
+      const osmium::object_id_type nodeId) const;
 
  protected:
   osm2rdf::util::CacheFile _cacheFile;

--- a/include/osm2rdf/osm/Relation.h
+++ b/include/osm2rdf/osm/Relation.h
@@ -24,6 +24,7 @@
 #include "RelationHandler.h"
 #include "boost/serialization/nvp.hpp"
 #include "boost/serialization/vector.hpp"
+#include "boost/version.hpp"
 #include "osm2rdf/geometry/Relation.h"
 #include "osm2rdf/osm/Box.h"
 #include "osm2rdf/osm/RelationHandler.h"

--- a/include/osm2rdf/osm/RelationHandler.h
+++ b/include/osm2rdf/osm/RelationHandler.h
@@ -32,8 +32,8 @@ class RelationHandler : public osmium::handler::Handler {
   void prepare_for_lookup();
   void setLocationHandler(osm2rdf::osm::LocationHandler* locationHandler);
   bool hasLocationHandler() const;
-  osmium::Location get_node_location(const uint64_t id) const;
-  std::vector<uint64_t> get_noderefs_of_way(const uint64_t id);
+  osmium::Location get_node_location(const uint64_t nodeId) const;
+  std::vector<uint64_t> get_noderefs_of_way(const uint64_t wayId);
 
  protected:
   osm2rdf::config::Config _config;

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -85,8 +85,7 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       }
       if (addRelationEnvelope) {
         oss << "\n"
-            << prefix
-            << osm2rdf::config::constants::ADD_RELATION_ENVELOPE_INFO;
+            << prefix << osm2rdf::config::constants::ADD_RELATION_ENVELOPE_INFO;
       }
     }
     if (noWayFacts) {
@@ -167,7 +166,8 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
     }
     if (writeGeomRelTransClosure) {
       oss << "\n"
-          << prefix << osm2rdf::config::constants::WRITE_GEOM_REl_TRANS_CLOSURE_INFO;
+          << prefix
+          << osm2rdf::config::constants::WRITE_GEOM_REl_TRANS_CLOSURE_INFO;
     }
   }
   oss << "\n" << prefix << osm2rdf::config::constants::SECTION_MISCELLANEOUS;
@@ -199,227 +199,232 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
 
 // ____________________________________________________________________________
 void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
-  popl::OptionParser op("Allowed options");
+  popl::OptionParser parser("Allowed options");
 
   auto helpOp =
-      op.add<popl::Switch>(osm2rdf::config::constants::HELP_OPTION_SHORT,
-                           osm2rdf::config::constants::HELP_OPTION_LONG,
-                           osm2rdf::config::constants::HELP_OPTION_HELP);
+      parser.add<popl::Switch>(osm2rdf::config::constants::HELP_OPTION_SHORT,
+                               osm2rdf::config::constants::HELP_OPTION_LONG,
+                               osm2rdf::config::constants::HELP_OPTION_HELP);
 
   auto storeLocationsOnDiskOp =
-      op.add<popl::Implicit<std::string>, popl::Attribute::advanced>(
+      parser.add<popl::Implicit<std::string>, popl::Attribute::advanced>(
           osm2rdf::config::constants::STORE_LOCATIONS_ON_DISK_SHORT,
           osm2rdf::config::constants::STORE_LOCATIONS_ON_DISK_LONG,
           osm2rdf::config::constants::STORE_LOCATIONS_ON_DISK_HELP, "sparse");
 
-  auto noAreasOp = op.add<popl::Switch, popl::Attribute::advanced>(
+  auto noAreasOp = parser.add<popl::Switch, popl::Attribute::advanced>(
       osm2rdf::config::constants::NO_AREA_OPTION_SHORT,
       osm2rdf::config::constants::NO_AREA_OPTION_LONG,
       osm2rdf::config::constants::NO_AREA_OPTION_HELP);
-  auto noNodesOp = op.add<popl::Switch, popl::Attribute::advanced>(
+  auto noNodesOp = parser.add<popl::Switch, popl::Attribute::advanced>(
       osm2rdf::config::constants::NO_NODE_OPTION_SHORT,
       osm2rdf::config::constants::NO_NODE_OPTION_LONG,
       osm2rdf::config::constants::NO_NODE_OPTION_HELP);
-  auto noRelationsOp = op.add<popl::Switch, popl::Attribute::advanced>(
+  auto noRelationsOp = parser.add<popl::Switch, popl::Attribute::advanced>(
       osm2rdf::config::constants::NO_RELATION_OPTION_SHORT,
       osm2rdf::config::constants::NO_RELATION_OPTION_LONG,
       osm2rdf::config::constants::NO_RELATION_OPTION_HELP);
-  auto noWaysOp = op.add<popl::Switch, popl::Attribute::advanced>(
+  auto noWaysOp = parser.add<popl::Switch, popl::Attribute::advanced>(
       osm2rdf::config::constants::NO_WAY_OPTION_SHORT,
       osm2rdf::config::constants::NO_WAY_OPTION_LONG,
       osm2rdf::config::constants::NO_WAY_OPTION_HELP);
 
-  auto noFactsOp = op.add<popl::Switch, popl::Attribute::advanced>(
+  auto noFactsOp = parser.add<popl::Switch, popl::Attribute::advanced>(
       osm2rdf::config::constants::NO_FACTS_OPTION_SHORT,
       osm2rdf::config::constants::NO_FACTS_OPTION_LONG,
       osm2rdf::config::constants::NO_FACTS_OPTION_HELP);
-  auto noAreaFactsOp = op.add<popl::Switch, popl::Attribute::expert>(
+  auto noAreaFactsOp = parser.add<popl::Switch, popl::Attribute::expert>(
       osm2rdf::config::constants::NO_AREA_FACTS_OPTION_SHORT,
       osm2rdf::config::constants::NO_AREA_FACTS_OPTION_LONG,
       osm2rdf::config::constants::NO_AREA_FACTS_OPTION_HELP);
-  auto noNodeFactsOp = op.add<popl::Switch, popl::Attribute::expert>(
+  auto noNodeFactsOp = parser.add<popl::Switch, popl::Attribute::expert>(
       osm2rdf::config::constants::NO_NODE_FACTS_OPTION_SHORT,
       osm2rdf::config::constants::NO_NODE_FACTS_OPTION_LONG,
       osm2rdf::config::constants::NO_NODE_FACTS_OPTION_HELP);
-  auto noRelationFactsOp = op.add<popl::Switch, popl::Attribute::expert>(
+  auto noRelationFactsOp = parser.add<popl::Switch, popl::Attribute::expert>(
       osm2rdf::config::constants::NO_RELATION_FACTS_OPTION_SHORT,
       osm2rdf::config::constants::NO_RELATION_FACTS_OPTION_LONG,
       osm2rdf::config::constants::NO_RELATION_FACTS_OPTION_HELP);
-  auto noWayFactsOp = op.add<popl::Switch, popl::Attribute::expert>(
+  auto noWayFactsOp = parser.add<popl::Switch, popl::Attribute::expert>(
       osm2rdf::config::constants::NO_WAY_FACTS_OPTION_SHORT,
       osm2rdf::config::constants::NO_WAY_FACTS_OPTION_LONG,
       osm2rdf::config::constants::NO_WAY_FACTS_OPTION_HELP);
 
-  auto noGeometricRelationsOp = op.add<popl::Switch, popl::Attribute::advanced>(
-      osm2rdf::config::constants::NO_GEOM_RELATIONS_OPTION_SHORT,
-      osm2rdf::config::constants::NO_GEOM_RELATIONS_OPTION_LONG,
-      osm2rdf::config::constants::NO_GEOM_RELATIONS_OPTION_HELP);
+  auto noGeometricRelationsOp =
+      parser.add<popl::Switch, popl::Attribute::advanced>(
+          osm2rdf::config::constants::NO_GEOM_RELATIONS_OPTION_SHORT,
+          osm2rdf::config::constants::NO_GEOM_RELATIONS_OPTION_LONG,
+          osm2rdf::config::constants::NO_GEOM_RELATIONS_OPTION_HELP);
   auto noAreaGeometricRelationsOp =
-      op.add<popl::Switch, popl::Attribute::expert>(
+      parser.add<popl::Switch, popl::Attribute::expert>(
           osm2rdf::config::constants::NO_AREA_GEOM_RELATIONS_OPTION_SHORT,
           osm2rdf::config::constants::NO_AREA_GEOM_RELATIONS_OPTION_LONG,
           osm2rdf::config::constants::NO_AREA_GEOM_RELATIONS_OPTION_HELP);
   auto noNodeGeometricRelationsOp =
-      op.add<popl::Switch, popl::Attribute::expert>(
+      parser.add<popl::Switch, popl::Attribute::expert>(
           osm2rdf::config::constants::NO_NODE_GEOM_RELATIONS_OPTION_SHORT,
           osm2rdf::config::constants::NO_NODE_GEOM_RELATIONS_OPTION_LONG,
           osm2rdf::config::constants::NO_NODE_GEOM_RELATIONS_OPTION_HELP);
   auto noWayGeometricRelationsOp =
-      op.add<popl::Switch, popl::Attribute::expert>(
+      parser.add<popl::Switch, popl::Attribute::expert>(
           osm2rdf::config::constants::NO_WAY_GEOM_RELATIONS_OPTION_SHORT,
           osm2rdf::config::constants::NO_WAY_GEOM_RELATIONS_OPTION_LONG,
           osm2rdf::config::constants::NO_WAY_GEOM_RELATIONS_OPTION_HELP);
   auto writeGeomRelTransClosureOp =
-      op.add<popl::Switch, popl::Attribute::expert>(
+      parser.add<popl::Switch, popl::Attribute::expert>(
           osm2rdf::config::constants::WRITE_GEOM_REl_TRANS_CLOSURE_OPTION_SHORT,
           osm2rdf::config::constants::WRITE_GEOM_REl_TRANS_CLOSURE_OPTION_LONG,
           osm2rdf::config::constants::WRITE_GEOM_REl_TRANS_CLOSURE_OPTION_HELP);
 
-  auto addAreaEnvelopeOp = op.add<popl::Switch>(
+  auto addAreaEnvelopeOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::ADD_AREA_ENVELOPE_OPTION_SHORT,
       osm2rdf::config::constants::ADD_AREA_ENVELOPE_OPTION_LONG,
       osm2rdf::config::constants::ADD_AREA_ENVELOPE_OPTION_HELP);
-  auto addAreaEnvelopeRatioOp = op.add<popl::Switch, popl::Attribute::advanced>(
-      osm2rdf::config::constants::ADD_AREA_ENVELOPE_RATIO_OPTION_SHORT,
-      osm2rdf::config::constants::ADD_AREA_ENVELOPE_RATIO_OPTION_LONG,
-      osm2rdf::config::constants::ADD_AREA_ENVELOPE_RATIO_OPTION_HELP);
-  auto addRelationBorderMembersOp = op.add<popl::Switch>(
+  auto addAreaEnvelopeRatioOp =
+      parser.add<popl::Switch, popl::Attribute::advanced>(
+          osm2rdf::config::constants::ADD_AREA_ENVELOPE_RATIO_OPTION_SHORT,
+          osm2rdf::config::constants::ADD_AREA_ENVELOPE_RATIO_OPTION_LONG,
+          osm2rdf::config::constants::ADD_AREA_ENVELOPE_RATIO_OPTION_HELP);
+  auto addRelationBorderMembersOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::ADD_RELATION_BORDER_MEMBERS_OPTION_SHORT,
       osm2rdf::config::constants::ADD_RELATION_BORDER_MEMBERS_OPTION_LONG,
       osm2rdf::config::constants::ADD_RELATION_BORDER_MEMBERS_OPTION_HELP);
 #if BOOST_VERSION >= 107800
-  auto addRelationEnvelopeOp = op.add<popl::Switch>(
+  auto addRelationEnvelopeOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::ADD_RELATION_ENVELOPE_OPTION_SHORT,
       osm2rdf::config::constants::ADD_RELATION_ENVELOPE_OPTION_LONG,
       osm2rdf::config::constants::ADD_RELATION_ENVELOPE_OPTION_HELP);
 #endif  // BOOST_VERSION >= 107800
-  auto addNodeEnvelopeOp = op.add<popl::Switch>(
+  auto addNodeEnvelopeOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::ADD_NODE_ENVELOPE_OPTION_SHORT,
       osm2rdf::config::constants::ADD_NODE_ENVELOPE_OPTION_LONG,
       osm2rdf::config::constants::ADD_NODE_ENVELOPE_OPTION_HELP);
-  auto addWayEnvelopeOp = op.add<popl::Switch>(
+  auto addWayEnvelopeOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::ADD_WAY_ENVELOPE_OPTION_SHORT,
       osm2rdf::config::constants::ADD_WAY_ENVELOPE_OPTION_LONG,
       osm2rdf::config::constants::ADD_WAY_ENVELOPE_OPTION_HELP);
-  auto addWayMetadataOp = op.add<popl::Switch>(
+  auto addWayMetadataOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::ADD_WAY_METADATA_OPTION_SHORT,
       osm2rdf::config::constants::ADD_WAY_METADATA_OPTION_LONG,
       osm2rdf::config::constants::ADD_WAY_METADATA_OPTION_HELP);
-  auto addWayNodeGeometryOp = op.add<popl::Switch>(
+  auto addWayNodeGeometryOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::ADD_WAY_NODE_GEOMETRY_OPTION_SHORT,
       osm2rdf::config::constants::ADD_WAY_NODE_GEOMETRY_OPTION_LONG,
       osm2rdf::config::constants::ADD_WAY_NODE_GEOMETRY_OPTION_HELP);
-  auto addWayNodeOrderOp = op.add<popl::Switch>(
+  auto addWayNodeOrderOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::ADD_WAY_NODE_ORDER_OPTION_SHORT,
       osm2rdf::config::constants::ADD_WAY_NODE_ORDER_OPTION_LONG,
       osm2rdf::config::constants::ADD_WAY_NODE_ORDER_OPTION_HELP);
-  auto addWayNodeSpatialMetadataOp = op.add<popl::Switch>(
+  auto addWayNodeSpatialMetadataOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::ADD_WAY_NODE_SPATIAL_METADATA_OPTION_SHORT,
       osm2rdf::config::constants::ADD_WAY_NODE_SPATIAL_METADATA_OPTION_LONG,
       osm2rdf::config::constants::ADD_WAY_NODE_SPATIAL_METADATA_OPTION_HELP);
-  auto adminRelationsOnlyOp = op.add<popl::Switch>(
+  auto adminRelationsOnlyOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::ADMIN_RELATIONS_ONLY_OPTION_SHORT,
       osm2rdf::config::constants::ADMIN_RELATIONS_ONLY_OPTION_LONG,
       osm2rdf::config::constants::ADMIN_RELATIONS_ONLY_OPTION_HELP);
-  auto skipWikiLinksOp = op.add<popl::Switch>(
+  auto skipWikiLinksOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::SKIP_WIKI_LINKS_OPTION_SHORT,
       osm2rdf::config::constants::SKIP_WIKI_LINKS_OPTION_LONG,
       osm2rdf::config::constants::SKIP_WIKI_LINKS_OPTION_HELP);
 
   auto semicolonTagKeysOp =
-      op.add<popl::Value<std::string>, popl::Attribute::advanced>(
+      parser.add<popl::Value<std::string>, popl::Attribute::advanced>(
           osm2rdf::config::constants::SEMICOLON_TAG_KEYS_OPTION_SHORT,
           osm2rdf::config::constants::SEMICOLON_TAG_KEYS_OPTION_LONG,
           osm2rdf::config::constants::SEMICOLON_TAG_KEYS_OPTION_HELP);
 
   auto simplifyGeometriesOp =
-      op.add<popl::Value<double>, popl::Attribute::expert>(
+      parser.add<popl::Value<double>, popl::Attribute::expert>(
           osm2rdf::config::constants::SIMPLIFY_GEOMETRIES_OPTION_SHORT,
           osm2rdf::config::constants::SIMPLIFY_GEOMETRIES_OPTION_LONG,
           osm2rdf::config::constants::SIMPLIFY_GEOMETRIES_OPTION_HELP,
           simplifyGeometries);
 
-  auto simplifyGeometriesInnerOuterOp = op.add<popl::Value<double>,
-                                               popl::Attribute::expert>(
+  auto simplifyGeometriesInnerOuterOp = parser.add<popl::Value<double>,
+                                                   popl::Attribute::expert>(
       osm2rdf::config::constants::SIMPLIFY_GEOMETRIES_INNER_OUTER_OPTION_SHORT,
       osm2rdf::config::constants::SIMPLIFY_GEOMETRIES_INNER_OUTER_OPTION_LONG,
       osm2rdf::config::constants::SIMPLIFY_GEOMETRIES_INNER_OUTER_OPTION_HELP,
       simplifyGeometriesInnerOuter);
-  auto dontUseInnerOuterGeomsOp = op.add<popl::Switch>(
+  auto dontUseInnerOuterGeomsOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::DONT_USE_INNER_OUTER_GEOMETRIES_OPTION_SHORT,
       osm2rdf::config::constants::DONT_USE_INNER_OUTER_GEOMETRIES_OPTION_LONG,
       osm2rdf::config::constants::DONT_USE_INNER_OUTER_GEOMETRIES_OPTION_HELP);
-  auto approximateSpatialRelsOp = op.add<popl::Switch>(
+  auto approximateSpatialRelsOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::APPROX_SPATIAL_REL_OPTION_SHORT,
       osm2rdf::config::constants::APPROX_SPATIAL_REL_OPTION_LONG,
       osm2rdf::config::constants::APPROX_SPATIAL_REL_OPTION_HELP);
-  auto simplifyWKTOp = op.add<popl::Value<uint16_t>, popl::Attribute::advanced>(
-      osm2rdf::config::constants::SIMPLIFY_WKT_OPTION_SHORT,
-      osm2rdf::config::constants::SIMPLIFY_WKT_OPTION_LONG,
-      osm2rdf::config::constants::SIMPLIFY_WKT_OPTION_HELP, simplifyWKT);
-  auto wktDeviationOp = op.add<popl::Value<double>, popl::Attribute::expert>(
-      osm2rdf::config::constants::SIMPLIFY_WKT_DEVIATION_OPTION_SHORT,
-      osm2rdf::config::constants::SIMPLIFY_WKT_DEVIATION_OPTION_LONG,
-      osm2rdf::config::constants::SIMPLIFY_WKT_DEVIATION_OPTION_HELP,
-      wktDeviation);
+  auto simplifyWKTOp =
+      parser.add<popl::Value<uint16_t>, popl::Attribute::advanced>(
+          osm2rdf::config::constants::SIMPLIFY_WKT_OPTION_SHORT,
+          osm2rdf::config::constants::SIMPLIFY_WKT_OPTION_LONG,
+          osm2rdf::config::constants::SIMPLIFY_WKT_OPTION_HELP, simplifyWKT);
+  auto wktDeviationOp =
+      parser.add<popl::Value<double>, popl::Attribute::expert>(
+          osm2rdf::config::constants::SIMPLIFY_WKT_DEVIATION_OPTION_SHORT,
+          osm2rdf::config::constants::SIMPLIFY_WKT_DEVIATION_OPTION_LONG,
+          osm2rdf::config::constants::SIMPLIFY_WKT_DEVIATION_OPTION_HELP,
+          wktDeviation);
   auto wktPrecisionOp =
-      op.add<popl::Value<uint16_t>, popl::Attribute::advanced>(
+      parser.add<popl::Value<uint16_t>, popl::Attribute::advanced>(
           osm2rdf::config::constants::WKT_PRECISION_OPTION_SHORT,
           osm2rdf::config::constants::WKT_PRECISION_OPTION_LONG,
           osm2rdf::config::constants::WKT_PRECISION_OPTION_HELP, wktPrecision);
 
-  auto writeDotFilesOp = op.add<popl::Switch, popl::Attribute::expert>(
+  auto writeDotFilesOp = parser.add<popl::Switch, popl::Attribute::expert>(
       osm2rdf::config::constants::WRITE_DAG_DOT_FILES_OPTION_SHORT,
       osm2rdf::config::constants::WRITE_DAG_DOT_FILES_OPTION_LONG,
       osm2rdf::config::constants::WRITE_DAG_DOT_FILES_OPTION_HELP);
 
-  auto writeRDFStatisticsOp = op.add<popl::Switch, popl::Attribute::advanced>(
-      osm2rdf::config::constants::WRITE_RDF_STATISTICS_OPTION_SHORT,
-      osm2rdf::config::constants::WRITE_RDF_STATISTICS_OPTION_LONG,
-      osm2rdf::config::constants::WRITE_RDF_STATISTICS_OPTION_HELP);
+  auto writeRDFStatisticsOp =
+      parser.add<popl::Switch, popl::Attribute::advanced>(
+          osm2rdf::config::constants::WRITE_RDF_STATISTICS_OPTION_SHORT,
+          osm2rdf::config::constants::WRITE_RDF_STATISTICS_OPTION_LONG,
+          osm2rdf::config::constants::WRITE_RDF_STATISTICS_OPTION_HELP);
 
-  auto outputOp = op.add<popl::Value<std::string>>(
+  auto outputOp = parser.add<popl::Value<std::string>>(
       osm2rdf::config::constants::OUTPUT_OPTION_SHORT,
       osm2rdf::config::constants::OUTPUT_OPTION_LONG,
       osm2rdf::config::constants::OUTPUT_OPTION_HELP, "");
   auto outputFormatOp =
-      op.add<popl::Value<std::string>, popl::Attribute::advanced>(
+      parser.add<popl::Value<std::string>, popl::Attribute::advanced>(
           osm2rdf::config::constants::OUTPUT_FORMAT_OPTION_SHORT,
           osm2rdf::config::constants::OUTPUT_FORMAT_OPTION_LONG,
           osm2rdf::config::constants::OUTPUT_FORMAT_OPTION_HELP, outputFormat);
-  auto outputKeepFilesOp = op.add<popl::Switch, popl::Attribute::expert>(
+  auto outputKeepFilesOp = parser.add<popl::Switch, popl::Attribute::expert>(
       osm2rdf::config::constants::OUTPUT_KEEP_FILES_OPTION_SHORT,
       osm2rdf::config::constants::OUTPUT_KEEP_FILES_OPTION_LONG,
       osm2rdf::config::constants::OUTPUT_KEEP_FILES_OPTION_HELP);
-  auto outputNoCompressOp = op.add<popl::Switch, popl::Attribute::advanced>(
+  auto outputNoCompressOp = parser.add<popl::Switch, popl::Attribute::advanced>(
       osm2rdf::config::constants::OUTPUT_NO_COMPRESS_OPTION_SHORT,
       osm2rdf::config::constants::OUTPUT_NO_COMPRESS_OPTION_LONG,
       osm2rdf::config::constants::OUTPUT_NO_COMPRESS_OPTION_HELP);
-  auto cacheOp = op.add<popl::Value<std::string>>(
+  auto cacheOp = parser.add<popl::Value<std::string>>(
       osm2rdf::config::constants::CACHE_OPTION_SHORT,
       osm2rdf::config::constants::CACHE_OPTION_LONG,
       osm2rdf::config::constants::CACHE_OPTION_HELP, cache);
 
   try {
-    op.parse(argc, argv);
+    parser.parse(argc, argv);
 
     if (helpOp->count() > 0) {
       if (helpOp->count() == 1) {
-        std::cerr << op << "\n";
+        std::cerr << parser << "\n";
       } else if (helpOp->count() == 2) {
-        std::cerr << op.help(popl::Attribute::advanced) << "\n";
+        std::cerr << parser.help(popl::Attribute::advanced) << "\n";
       } else {
-        std::cerr << op.help(popl::Attribute::expert) << "\n";
+        std::cerr << parser.help(popl::Attribute::expert) << "\n";
       }
       exit(osm2rdf::config::ExitCode::SUCCESS);
     }
 
-    if (!op.unknown_options().empty()) {
+    if (!parser.unknown_options().empty()) {
       std::cerr << "Unknown argument(s) specified:\n";
-      for (const auto& o : op.unknown_options()) {
-        std::cerr << o << "\n";
+      for (const auto& option : parser.unknown_options()) {
+        std::cerr << option << "\n";
       }
-      std::cerr << "\n" << op.help() << "\n";
+      std::cerr << "\n" << parser.help() << "\n";
       exit(osm2rdf::config::ExitCode::UNKNOWN_ARGUMENT);
     }
 
@@ -515,29 +520,29 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
     // Check cache location
     if (!std::filesystem::exists(cache)) {
       std::cerr << "Cache location does not exist: " << cache << "\n"
-                << op.help() << "\n";
+                << parser.help() << "\n";
       exit(osm2rdf::config::ExitCode::CACHE_NOT_EXISTS);
     }
     if (!std::filesystem::is_directory(cache)) {
       std::cerr << "Cache location not a directory: " << cache << "\n"
-                << op.help() << "\n";
+                << parser.help() << "\n";
       exit(osm2rdf::config::ExitCode::CACHE_NOT_DIRECTORY);
     }
 
     // Handle input
-    if (op.non_option_args().size() != 1) {
-      std::cerr << "No input specified!\n" << op.help() << "\n";
+    if (parser.non_option_args().size() != 1) {
+      std::cerr << "No input specified!\n" << parser.help() << "\n";
       exit(osm2rdf::config::ExitCode::INPUT_MISSING);
     }
-    input = op.non_option_args()[0];
+    input = parser.non_option_args()[0];
     if (!std::filesystem::exists(input)) {
       std::cerr << "Input does not exist: " << input << "\n"
-                << op.help() << "\n";
+                << parser.help() << "\n";
       exit(osm2rdf::config::ExitCode::INPUT_NOT_EXISTS);
     }
     if (std::filesystem::is_directory(input)) {
       std::cerr << "Input is a directory: " << input << "\n"
-                << op.help() << "\n";
+                << parser.help() << "\n";
       exit(osm2rdf::config::ExitCode::INPUT_IS_DIRECTORY);
     }
   } catch (const popl::invalid_option& e) {
@@ -570,8 +575,8 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
 
 // ____________________________________________________________________________
 std::filesystem::path osm2rdf::config::Config::getTempPath(
-    const std::string& p, const std::string& s) const {
-  std::filesystem::path path{cache};
-  path /= p + "-" + s;
-  return std::filesystem::absolute(path);
+    const std::string& path, const std::string& suffix) const {
+  std::filesystem::path resultPath{cache};
+  resultPath /= path + "-" + suffix;
+  return std::filesystem::absolute(resultPath);
 }

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <string>
 
+#include "boost/version.hpp"
 #include "omp.h"
 #include "osm2rdf/config/Config.h"
 #include "osm2rdf/config/Constants.h"

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 
 #include "boost/geometry.hpp"
+#include "boost/version.hpp"
 #include "osm2rdf/config/Config.h"
 #include "osm2rdf/osm/Area.h"
 #include "osm2rdf/osm/Constants.h"

--- a/src/osm/LocationHandler.cpp
+++ b/src/osm/LocationHandler.cpp
@@ -43,8 +43,8 @@ osm2rdf::osm::LocationHandler* osm2rdf::osm::LocationHandler::create(
 // ____________________________________________________________________________
 template <typename T>
 osmium::Location osm2rdf::osm::LocationHandlerImpl<T>::get_node_location(
-    const osmium::object_id_type id) const {
-  return _handler.get_node_location(id);
+    const osmium::object_id_type nodeId) const {
+  return _handler.get_node_location(nodeId);
 }
 
 // ____________________________________________________________________________
@@ -55,7 +55,7 @@ void osm2rdf::osm::LocationHandlerImpl<T>::node(const osmium::Node& node) {
 
 // ____________________________________________________________________________
 template <typename T>
-void osm2rdf::osm::LocationHandlerImpl<T>::way(osmium::Way& way) {  // NOLINT
+void osm2rdf::osm::LocationHandlerImpl<T>::way(osmium::Way& way) {
   _handler.way(way);
 }
 
@@ -81,8 +81,8 @@ osm2rdf::osm::LocationHandlerImpl<osmium::index::map::SparseFileArray<
 osmium::Location
 osm2rdf::osm::LocationHandlerImpl<osmium::index::map::SparseFileArray<
     osmium::unsigned_object_id_type, osmium::Location>>::
-    get_node_location(const osmium::object_id_type id) const {
-  return _handler.get_node_location(id);
+    get_node_location(const osmium::object_id_type nodeId) const {
+  return _handler.get_node_location(nodeId);
 }
 
 // ____________________________________________________________________________
@@ -95,7 +95,7 @@ void osm2rdf::osm::LocationHandlerImpl<osmium::index::map::SparseFileArray<
 // ____________________________________________________________________________
 void osm2rdf::osm::LocationHandlerImpl<osmium::index::map::SparseFileArray<
     osmium::unsigned_object_id_type,
-    osmium::Location>>::way(osmium::Way& way) {  // NOLINT
+    osmium::Location>>::way(osmium::Way& way) {
   _handler.way(way);
 }
 
@@ -119,7 +119,7 @@ void osm2rdf::osm::LocationHandlerImpl<osmium::index::map::DenseFileArray<
 // ____________________________________________________________________________
 void osm2rdf::osm::LocationHandlerImpl<osmium::index::map::DenseFileArray<
     osmium::unsigned_object_id_type,
-    osmium::Location>>::way(osmium::Way& way) {  // NOLINT
+    osmium::Location>>::way(osmium::Way& way) {
   _handler.way(way);
 }
 
@@ -127,6 +127,6 @@ void osm2rdf::osm::LocationHandlerImpl<osmium::index::map::DenseFileArray<
 osmium::Location
 osm2rdf::osm::LocationHandlerImpl<osmium::index::map::DenseFileArray<
     osmium::unsigned_object_id_type, osmium::Location>>::
-    get_node_location(const osmium::object_id_type id) const {
-  return _handler.get_node_location(id);
+    get_node_location(const osmium::object_id_type nodeId) const {
+  return _handler.get_node_location(nodeId);
 }

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -17,6 +17,7 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "boost/version.hpp"
 #include "osm2rdf/osm/FactHandler.h"
 #include "osm2rdf/osm/GeometryHandler.h"
 #include "osm2rdf/osm/LocationHandler.h"

--- a/src/osm/Relation.cpp
+++ b/src/osm/Relation.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "boost/geometry.hpp"
+#include "boost/version.hpp"
 #include "osm2rdf/osm/Relation.h"
 #include "osm2rdf/osm/RelationHandler.h"
 #include "osm2rdf/osm/RelationMember.h"

--- a/src/osm/RelationHandler.cpp
+++ b/src/osm/RelationHandler.cpp
@@ -45,14 +45,14 @@ bool osm2rdf::osm::RelationHandler::hasLocationHandler() const {
 
 // ____________________________________________________________________________
 osmium::Location osm2rdf::osm::RelationHandler::get_node_location(
-    const uint64_t id) const {
-  return _locationHandler->get_node_location(id);
+    const uint64_t nodeId) const {
+  return _locationHandler->get_node_location(nodeId);
 }
 
 // ____________________________________________________________________________
 std::vector<uint64_t> osm2rdf::osm::RelationHandler::get_noderefs_of_way(
-    const uint64_t id) {
-  return _ways[id];
+    const uint64_t wayId) {
+  return _ways[wayId];
 }
 
 // ____________________________________________________________________________

--- a/src/osm/Way.cpp
+++ b/src/osm/Way.cpp
@@ -56,10 +56,10 @@ osm2rdf::osm::Way::Way(const osmium::Way& way) {
     _nodes.emplace_back(nodeRef);
 
     // implicit boost::geometry::unique
-		if (_geom.size() == 0 || (nodeRef.lon() != _geom.back().get<0>() ||
-				nodeRef.lat() != _geom.back().get<1>())) {
+    if (_geom.empty() || (nodeRef.lon() != _geom.back().get<0>() ||
+                          nodeRef.lat() != _geom.back().get<1>())) {
       boost::geometry::append(_geom, Location{nodeRef.lon(), nodeRef.lat()});
-		}
+    }
   }
   _envelope = osm2rdf::geometry::Box({lonMin, latMin}, {lonMax, latMax});
 }

--- a/src/osm/Way.cpp
+++ b/src/osm/Way.cpp
@@ -17,10 +17,11 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "osm2rdf/geometry/Way.h"
+
 #include <vector>
 
 #include "boost/geometry.hpp"
-#include "osm2rdf/geometry/Way.h"
 #include "osm2rdf/osm/Box.h"
 #include "osm2rdf/osm/Node.h"
 #include "osm2rdf/osm/TagList.h"

--- a/src/util/DirectedGraph.cpp
+++ b/src/util/DirectedGraph.cpp
@@ -29,8 +29,8 @@
 template <typename T>
 void osm2rdf::util::DirectedGraph<T>::addEdge(T src, T dst) {
   _adjacency[src].push_back(dst);
-  if (_adjacency.count(dst) == 0) {
-    _adjacency[dst].size();
+  if (_adjacency.find(dst) == _adjacency.end()) {
+    _adjacency[dst] = {};
   }
   _numEdges++;
 }
@@ -52,15 +52,15 @@ std::vector<T> osm2rdf::util::DirectedGraph<T>::findSuccessors(T src) const {
 template <typename T>
 void osm2rdf::util::DirectedGraph<T>::findSuccessorsHelper(
     T src, std::vector<T>* tmp) const {
-  const auto& it = _adjacency.find(src);
-  if (it == _adjacency.end()) {
+  const auto& entry = _adjacency.find(src);
+  if (entry == _adjacency.end()) {
     return;
   }
 
-  // Copy direct parents.
-  tmp->insert(tmp->end(), it->second.begin(), it->second.end());
-  // Add parents parents.
-  for (const auto& dst : it->second) {
+  // Copy direct successors.
+  tmp->insert(tmp->end(), entry->second.begin(), entry->second.end());
+  // Recursively add all successors.
+  for (const auto& dst : entry->second) {
     findSuccessorsHelper(dst, tmp);
   }
 }
@@ -72,11 +72,11 @@ std::vector<T> osm2rdf::util::DirectedGraph<T>::findSuccessorsFast(
   if (!_preparedFast) {
     throw std::runtime_error("findSuccessorsFast not prepared");
   }
-  const auto& it = _successors.find(src);
-  if (it == _successors.end()) {
+  const auto& entry = _successors.find(src);
+  if (entry == _successors.end()) {
     return std::vector<T>();
   }
-  return it->second;
+  return entry->second;
 }
 
 // ____________________________________________________________________________

--- a/tests/geometry/Relation.cpp
+++ b/tests/geometry/Relation.cpp
@@ -22,6 +22,7 @@
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
+#include "boost/version.hpp"
 
 #include "gtest/gtest.h"
 

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -18,6 +18,7 @@
 
 #include "osm2rdf/osm/FactHandler.h"
 
+#include "boost/version.hpp"
 #include "gmock/gmock-matchers.h"
 #include "gtest/gtest.h"
 #include "osm2rdf/osm/Node.h"


### PR DESCRIPTION
In this PR we add the "boost/version.hpp" header in all files checking boost version. It happened on fedora that the config option "--add-relation-envelope" was not found even though boost 1.78 is installed.
This PR also contains some minor code cleanup in various places, mostly small renames which should not alter the behavior.