### PR TITLE
Fix symmetric intersect and contains relation

### DIFF
--- a/include/osm2rdf/osm/GeometryHandler.h
+++ b/include/osm2rdf/osm/GeometryHandler.h
@@ -218,8 +218,8 @@ typedef std::vector<osm2rdf::osm::Relation::id_t> RelationRelationList;
 // Relation: envelope, osm id, geometry, node list, way list, relation list
 #if BOOST_VERSION >= 107800
 typedef std::tuple<osm2rdf::geometry::Box, osm2rdf::osm::Way::id_t,
-                   osm2rdf::geometry::Relation, RelationNodeList, RelationWayList,
-                   RelationRelationList>
+                   osm2rdf::geometry::Relation, RelationNodeList,
+                   RelationWayList, RelationRelationList>
     SpatialRelationValue;
 #endif  // BOOST_VERSION >= 107800
 
@@ -344,7 +344,9 @@ class GeometryHandler {
 
   std::string areaNS(AreaFromType type) const;
 
-  void writeTransitiveClosure(const std::vector<osm2rdf::osm::Area::id_t>& successors, const std::string& entryIRI, const std::string& rel);
+  void writeTransitiveClosure(
+      const std::vector<osm2rdf::osm::Area::id_t>& successors,
+      const std::string& entryIRI, const std::string& rel, bool symmetric);
 
   void getBoxIds(
       const osm2rdf::geometry::Area& area, const osm2rdf::geometry::Area& inner,

--- a/include/osm2rdf/osm/GeometryHandler.h
+++ b/include/osm2rdf/osm/GeometryHandler.h
@@ -346,7 +346,12 @@ class GeometryHandler {
 
   void writeTransitiveClosure(
       const std::vector<osm2rdf::osm::Area::id_t>& successors,
-      const std::string& entryIRI, const std::string& rel, bool symmetric);
+      const std::string& entryIRI, const std::string& rel,
+      const std::string& symmRel);
+
+  void writeTransitiveClosure(
+      const std::vector<osm2rdf::osm::Area::id_t>& successors,
+      const std::string& entryIRI, const std::string& rel);
 
   void getBoxIds(
       const osm2rdf::geometry::Area& area, const osm2rdf::geometry::Area& inner,

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -752,6 +752,7 @@ void GeometryHandler<W>::dumpNamedAreaRelations() {
 
       _writer->writeTriple(areaIRI, IRI__OSM2RDF_CONTAINS_AREA, entryIRI);
       _writer->writeTriple(areaIRI, IRI__OSM2RDF_INTERSECTS_AREA, entryIRI);
+      _writer->writeTriple(entryIRI, IRI__OSM2RDF_INTERSECTS_AREA, areaIRI);
 
       // transitive closure
       const auto& successors = _directedAreaGraph.findSuccessorsFast(areaId);
@@ -759,9 +760,10 @@ void GeometryHandler<W>::dumpNamedAreaRelations() {
       skip.insert(areaId);
       skip.insert(successors.begin(), successors.end());
 
-      writeTransitiveClosure(successors, entryIRI,
-                             IRI__OSM2RDF_INTERSECTS_AREA);
-      writeTransitiveClosure(successors, entryIRI, IRI__OSM2RDF_CONTAINS_AREA);
+      writeTransitiveClosure(successors, entryIRI, IRI__OSM2RDF_INTERSECTS_AREA,
+                             true);
+      writeTransitiveClosure(successors, entryIRI, IRI__OSM2RDF_CONTAINS_AREA,
+                             false);
     }
 
     // intersect relation, use R-Tree
@@ -793,9 +795,10 @@ void GeometryHandler<W>::dumpNamedAreaRelations() {
 
         // transitive closure
         writeTransitiveClosure(successors, entryIRI,
-                               IRI__OSM2RDF_INTERSECTS_AREA);
+                               IRI__OSM2RDF_INTERSECTS_AREA, true);
 
         _writer->writeTriple(areaIRI, IRI__OSM2RDF_INTERSECTS_AREA, entryIRI);
+        _writer->writeTriple(entryIRI, IRI__OSM2RDF_INTERSECTS_AREA, areaIRI);
       }
     }
 
@@ -912,10 +915,12 @@ void GeometryHandler<W>::dumpUnnamedAreaRelations() {
 
           // transitive closure
           writeTransitiveClosure(successors, entryIRI,
-                                 IRI__OSM2RDF_INTERSECTS_NON_AREA);
+                                 IRI__OSM2RDF_INTERSECTS_NON_AREA, true);
 
           _writer->writeTriple(areaIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
                                entryIRI);
+          _writer->writeTriple(entryIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
+                               areaIRI);
         }
 
         if (geomRelInf.intersects == NO) {
@@ -933,7 +938,7 @@ void GeometryHandler<W>::dumpUnnamedAreaRelations() {
 
             // transitive closure
             writeTransitiveClosure(successors, entryIRI,
-                                   IRI__OSM2RDF_CONTAINS_NON_AREA);
+                                   IRI__OSM2RDF_CONTAINS_NON_AREA, false);
 
             _writer->writeTriple(areaIRI, IRI__OSM2RDF_CONTAINS_NON_AREA,
                                  entryIRI);
@@ -1109,13 +1114,16 @@ GeometryHandler<W>::dumpNodeRelations() {
 
         // transitive closure
         writeTransitiveClosure(successors, nodeIRI,
-                               IRI__OSM2RDF_INTERSECTS_NON_AREA);
+                               IRI__OSM2RDF_INTERSECTS_NON_AREA, true);
         writeTransitiveClosure(successors, nodeIRI,
-                               IRI__OSM2RDF_CONTAINS_NON_AREA);
+                               IRI__OSM2RDF_CONTAINS_NON_AREA, false);
 
         _writer->writeTriple(
             areaIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,
             nodeIRI);
+        _writer->writeTriple(
+            nodeIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,
+            areaIRI);
         _writer->writeTriple(
             areaIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,
             nodeIRI);
@@ -1271,10 +1279,12 @@ void GeometryHandler<W>::dumpWayRelations(
 
           // transitive closure
           writeTransitiveClosure(successors, wayIRI,
-                                 IRI__OSM2RDF_INTERSECTS_NON_AREA);
+                                 IRI__OSM2RDF_INTERSECTS_NON_AREA, true);
 
           _writer->writeTriple(areaIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
                                wayIRI);
+          _writer->writeTriple(wayIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
+                               areaIRI);
         } else if (skipNodeContained.find(areaId) != skipNodeContained.end()) {
           intersectStats.skippedByNodeContained();
           geomRelInf.intersects = YES;
@@ -1288,10 +1298,12 @@ void GeometryHandler<W>::dumpWayRelations(
 
           // transitive closure
           writeTransitiveClosure(successors, wayIRI,
-                                 IRI__OSM2RDF_INTERSECTS_NON_AREA);
+                                 IRI__OSM2RDF_INTERSECTS_NON_AREA, true);
 
           _writer->writeTriple(areaIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
                                wayIRI);
+          _writer->writeTriple(wayIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
+                               areaIRI);
         } else if (wayIntersectsArea(way, area, &geomRelInf, &intersectStats)) {
           const auto& successors =
               _directedAreaGraph.findSuccessorsFast(areaId);
@@ -1302,10 +1314,12 @@ void GeometryHandler<W>::dumpWayRelations(
 
           // transitive closure
           writeTransitiveClosure(successors, wayIRI,
-                                 IRI__OSM2RDF_INTERSECTS_NON_AREA);
+                                 IRI__OSM2RDF_INTERSECTS_NON_AREA, true);
 
           _writer->writeTriple(areaIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
                                wayIRI);
+          _writer->writeTriple(wayIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
+                               areaIRI);
         }
 
         if (geomRelInf.intersects == NO) {
@@ -1344,7 +1358,7 @@ void GeometryHandler<W>::dumpWayRelations(
 
           // transitive closure
           writeTransitiveClosure(successors, wayIRI,
-                                 IRI__OSM2RDF_CONTAINS_NON_AREA);
+                                 IRI__OSM2RDF_CONTAINS_NON_AREA, false);
 
           _writer->writeTriple(areaIRI, IRI__OSM2RDF_CONTAINS_NON_AREA, wayIRI);
         }
@@ -2524,7 +2538,7 @@ uint8_t GeometryHandler<W>::borderContained(Way::id_t wayId,
 template <typename W>
 void GeometryHandler<W>::writeTransitiveClosure(
     const std::vector<osm2rdf::osm::Area::id_t>& successors,
-    const std::string& entryIRI, const std::string& rel) {
+    const std::string& entryIRI, const std::string& rel, bool symmetric) {
   // transitive closure
   if (_config.writeGeomRelTransClosure) {
     for (const auto& succ : successors) {
@@ -2535,6 +2549,9 @@ void GeometryHandler<W>::writeTransitiveClosure(
           _writer->generateIRI(areaNS(succAreaFromType), succAreaId);
 
       _writer->writeTriple(succAreaIRI, rel, entryIRI);
+      if (symmetric) {
+        _writer->writeTriple(entryIRI, rel, succAreaIRI);
+      }
     }
   }
 }

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -776,9 +776,8 @@ void GeometryHandler<W>::dumpNamedAreaRelations() {
       skip.insert(successors.begin(), successors.end());
 
       writeTransitiveClosure(successors, entryIRI, IRI__OSM2RDF_INTERSECTS_AREA,
-                             true);
-      writeTransitiveClosure(successors, entryIRI, IRI__OSM2RDF_CONTAINS_AREA,
-                             false);
+                             IRI__OSM2RDF_INTERSECTS_AREA);
+      writeTransitiveClosure(successors, entryIRI, IRI__OSM2RDF_CONTAINS_AREA);
     }
 
     // intersect relation, use R-Tree
@@ -810,7 +809,8 @@ void GeometryHandler<W>::dumpNamedAreaRelations() {
 
         // transitive closure
         writeTransitiveClosure(successors, entryIRI,
-                               IRI__OSM2RDF_INTERSECTS_AREA, true);
+                               IRI__OSM2RDF_INTERSECTS_AREA,
+                               IRI__OSM2RDF_INTERSECTS_AREA);
 
         _writer->writeTriple(areaIRI, IRI__OSM2RDF_INTERSECTS_AREA, entryIRI);
         _writer->writeTriple(entryIRI, IRI__OSM2RDF_INTERSECTS_AREA, areaIRI);
@@ -932,7 +932,8 @@ void GeometryHandler<W>::dumpUnnamedAreaRelations() {
 
           // transitive closure
           writeTransitiveClosure(successors, entryIRI,
-                                 IRI__OSM2RDF_INTERSECTS_NON_AREA, true);
+                                 IRI__OSM2RDF_INTERSECTS_NON_AREA,
+                                 IRI__OSM2RDF_INTERSECTS_NON_AREA);
 
           _writer->writeTriple(areaIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
                                entryIRI);
@@ -955,7 +956,7 @@ void GeometryHandler<W>::dumpUnnamedAreaRelations() {
 
             // transitive closure
             writeTransitiveClosure(successors, entryIRI,
-                                   IRI__OSM2RDF_CONTAINS_NON_AREA, false);
+                                   IRI__OSM2RDF_CONTAINS_NON_AREA);
 
             _writer->writeTriple(areaIRI, IRI__OSM2RDF_CONTAINS_NON_AREA,
                                  entryIRI);
@@ -1062,14 +1063,15 @@ GeometryHandler<W>::dumpNodeRelations() {
 
     progressBar.update(entryCount);
 
-#pragma omp parallel for shared(                                       \
-        std::cout, osm2rdf::ttl::constants::NAMESPACE__OSM_NODE,       \
-            osm2rdf::ttl::constants::NAMESPACE__OSM_WAY,               \
-            osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION,          \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,   \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA, \
-            nodeData, progressBar, ia, entryCount)                     \
-    reduction(+ : stats) default(none) schedule(dynamic)
+#pragma omp parallel for shared(                                             \
+        std::cout, osm2rdf::ttl::constants::NAMESPACE__OSM_NODE,             \
+            osm2rdf::ttl::constants::NAMESPACE__OSM_WAY,                     \
+            osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION,                \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,         \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,       \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA, nodeData, \
+            progressBar, ia, entryCount) reduction(+ : stats) default(none)  \
+    schedule(dynamic)
     for (size_t i = 0; i < _numNodes; i++) {
       SpatialNodeValue node;
 #pragma omp critical(loadEntry)
@@ -1131,15 +1133,16 @@ GeometryHandler<W>::dumpNodeRelations() {
 
         // transitive closure
         writeTransitiveClosure(successors, nodeIRI,
-                               IRI__OSM2RDF_INTERSECTS_NON_AREA, true);
+                               IRI__OSM2RDF_INTERSECTS_NON_AREA,
+                               IRI__OSM2RDF_INTERSECTS_AREA);
         writeTransitiveClosure(successors, nodeIRI,
-                               IRI__OSM2RDF_CONTAINS_NON_AREA, false);
+                               IRI__OSM2RDF_CONTAINS_NON_AREA);
 
         _writer->writeTriple(
             areaIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,
             nodeIRI);
         _writer->writeTriple(
-            nodeIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,
+            nodeIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA,
             areaIRI);
         _writer->writeTriple(
             areaIRI, osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,
@@ -1215,6 +1218,7 @@ void GeometryHandler<W>::dumpWayRelations(
         std::cout, std::cerr, osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, \
             nodeData, osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION,    \
             osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,     \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA,     \
             osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,       \
             progressBar, entryCount, ia)                                   \
     reduction(+ : intersectStats, containsStats) default(none)             \
@@ -1297,12 +1301,12 @@ void GeometryHandler<W>::dumpWayRelations(
 
           // transitive closure
           writeTransitiveClosure(successors, wayIRI,
-                                 IRI__OSM2RDF_INTERSECTS_NON_AREA, true);
+                                 IRI__OSM2RDF_INTERSECTS_NON_AREA,
+                                 IRI__OSM2RDF_INTERSECTS_AREA);
 
           _writer->writeTriple(areaIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
                                wayIRI);
-          _writer->writeTriple(wayIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
-                               areaIRI);
+          _writer->writeTriple(wayIRI, IRI__OSM2RDF_INTERSECTS_AREA, areaIRI);
         } else if (skipNodeContained.find(areaId) != skipNodeContained.end()) {
           intersectStats.skippedByNodeContained();
           geomRelInf.intersects = YES;
@@ -1316,12 +1320,12 @@ void GeometryHandler<W>::dumpWayRelations(
 
           // transitive closure
           writeTransitiveClosure(successors, wayIRI,
-                                 IRI__OSM2RDF_INTERSECTS_NON_AREA, true);
+                                 IRI__OSM2RDF_INTERSECTS_NON_AREA,
+                                 IRI__OSM2RDF_INTERSECTS_AREA);
 
           _writer->writeTriple(areaIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
                                wayIRI);
-          _writer->writeTriple(wayIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
-                               areaIRI);
+          _writer->writeTriple(wayIRI, IRI__OSM2RDF_INTERSECTS_AREA, areaIRI);
         } else if (wayIntersectsArea(way, area, &geomRelInf, &intersectStats)) {
           const auto& successors =
               _directedAreaGraph.findSuccessorsFast(areaId);
@@ -1332,12 +1336,12 @@ void GeometryHandler<W>::dumpWayRelations(
 
           // transitive closure
           writeTransitiveClosure(successors, wayIRI,
-                                 IRI__OSM2RDF_INTERSECTS_NON_AREA, true);
+                                 IRI__OSM2RDF_INTERSECTS_NON_AREA,
+                                 IRI__OSM2RDF_INTERSECTS_AREA);
 
           _writer->writeTriple(areaIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
                                wayIRI);
-          _writer->writeTriple(wayIRI, IRI__OSM2RDF_INTERSECTS_NON_AREA,
-                               areaIRI);
+          _writer->writeTriple(wayIRI, IRI__OSM2RDF_INTERSECTS_AREA, areaIRI);
         }
 
         if (geomRelInf.intersects == NO) {
@@ -1376,7 +1380,7 @@ void GeometryHandler<W>::dumpWayRelations(
 
           // transitive closure
           writeTransitiveClosure(successors, wayIRI,
-                                 IRI__OSM2RDF_CONTAINS_NON_AREA, false);
+                                 IRI__OSM2RDF_CONTAINS_NON_AREA);
 
           _writer->writeTriple(areaIRI, IRI__OSM2RDF_CONTAINS_NON_AREA, wayIRI);
         }
@@ -2556,7 +2560,8 @@ uint8_t GeometryHandler<W>::borderContained(Way::id_t wayId,
 template <typename W>
 void GeometryHandler<W>::writeTransitiveClosure(
     const std::vector<osm2rdf::osm::Area::id_t>& successors,
-    const std::string& entryIRI, const std::string& rel, bool symmetric) {
+    const std::string& entryIRI, const std::string& rel,
+    const std::string& symmRel) {
   // transitive closure
   if (_config.writeGeomRelTransClosure) {
     for (const auto& succ : successors) {
@@ -2567,9 +2572,26 @@ void GeometryHandler<W>::writeTransitiveClosure(
           _writer->generateIRI(areaNS(succAreaFromType), succAreaId);
 
       _writer->writeTriple(succAreaIRI, rel, entryIRI);
-      if (symmetric) {
-        _writer->writeTriple(entryIRI, rel, succAreaIRI);
-      }
+      _writer->writeTriple(entryIRI, symmRel, succAreaIRI);
+    }
+  }
+}
+
+// ____________________________________________________________________________
+template <typename W>
+void GeometryHandler<W>::writeTransitiveClosure(
+    const std::vector<osm2rdf::osm::Area::id_t>& successors,
+    const std::string& entryIRI, const std::string& rel) {
+  // transitive closure
+  if (_config.writeGeomRelTransClosure) {
+    for (const auto& succ : successors) {
+      auto succIdx = _spatialStorageAreaIndex[succ];
+      const auto& succAreaId = std::get<3>(_spatialStorageArea[succIdx]);
+      const auto& succAreaFromType = std::get<5>(_spatialStorageArea[succIdx]);
+      const auto& succAreaIRI =
+          _writer->generateIRI(areaNS(succAreaFromType), succAreaId);
+
+      _writer->writeTriple(succAreaIRI, rel, entryIRI);
     }
   }
 }

--- a/tests/osm/GeometryHandler.cpp
+++ b/tests/osm/GeometryHandler.cpp
@@ -1803,7 +1803,7 @@ TEST(OSM_GeometryHandler, dumpNodeRelationsSimpleIntersects) {
   const std::string printedData = coutBuffer.str();
   ASSERT_EQ(
       "osmway:13 osm2rdf:intersects_nonarea osmnode:42 .\n"
-      "osmnode:42 osm2rdf:intersects_nonarea osmway:13 .\n"
+      "osmnode:42 osm2rdf:intersects_area osmway:13 .\n"
       "osmway:13 osm2rdf:contains_nonarea osmnode:42 .\n",
       printedData);
 
@@ -1924,7 +1924,7 @@ TEST(OSM_GeometryHandler, dumpNodeRelationsSimpleContains) {
   const std::string printedData = coutBuffer.str();
   ASSERT_EQ(
       "osmway:11 osm2rdf:intersects_nonarea osmnode:42 .\n"
-      "osmnode:42 osm2rdf:intersects_nonarea osmway:11 .\n"
+      "osmnode:42 osm2rdf:intersects_area osmway:11 .\n"
       "osmway:11 osm2rdf:contains_nonarea osmnode:42 .\n",
       printedData);
 
@@ -2215,9 +2215,9 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleIntersects) {
   const std::string printedData = coutBuffer.str();
   ASSERT_EQ(
       "osmway:11 osm2rdf:intersects_nonarea osmway:42 .\n"
-      "osmway:42 osm2rdf:intersects_nonarea osmway:11 .\n"
+      "osmway:42 osm2rdf:intersects_area osmway:11 .\n"
       "osmway:13 osm2rdf:intersects_nonarea osmway:42 .\n"
-      "osmway:42 osm2rdf:intersects_nonarea osmway:13 .\n"
+      "osmway:42 osm2rdf:intersects_area osmway:13 .\n"
       "osmway:12 osm2rdf:contains_nonarea osmway:42 .\n",
       printedData);
 
@@ -2339,7 +2339,7 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleContains) {
   const std::string printedData = coutBuffer.str();
   ASSERT_EQ(
       "osmway:11 osm2rdf:intersects_nonarea osmway:42 .\n"
-      "osmway:42 osm2rdf:intersects_nonarea osmway:11 .\n"
+      "osmway:42 osm2rdf:intersects_area osmway:11 .\n"
       "osmway:11 osm2rdf:contains_nonarea osmway:42 .\n",
       printedData);
 
@@ -2625,12 +2625,12 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleContainsWithNodeInfo) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr("osmway:11 osm2rdf:intersects_nonarea osmnode:2 .\n"
-                           "osmnode:2 osm2rdf:intersects_nonarea osmway:11 .\n"
+                           "osmnode:2 osm2rdf:intersects_area osmway:11 .\n"
                            "osmway:11 osm2rdf:contains_nonarea osmnode:2 .\n"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr("osmway:11 osm2rdf:intersects_nonarea osmway:42 .\n"
-                           "osmway:42 osm2rdf:intersects_nonarea osmway:11 .\n"
+                           "osmway:42 osm2rdf:intersects_area osmway:11 .\n"
                            "osmway:11 osm2rdf:contains_nonarea osmway:42 .\n"));
 
   // Reset std::cerr and std::cout


### PR DESCRIPTION
@lehmann-4178656ch, I have to open another PR for this branch - I noticed that the symmetric intersect relations are wrong for ways - if `WAY INTERSECTS_AREA AREA`, then we should write `AREA INTERSECTS_NONAREA WAY`, not `AREA INTERSECTS_AREA WAY`. This PR fixes this.