### PR TITLE
Basic GeoJSON output

### DIFF
--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -92,12 +92,12 @@ struct Config {
   bool writeRDFStatistics = false;
   std::filesystem::path rdfStatisticsPath;
 
-  // Output modifiers
-  uint16_t simplifyWKT = 250;
-  double wktDeviation = 5;
-  uint16_t wktPrecision = 7;
+  // Geometry output modifiers
+  uint16_t geometriesDumpMinNumPointsForSimplification = 250;
+  double geometriesDumpDeviation = 5;
+  uint16_t geometriesDumpPrecision = 7;
 
-  // Transitive clouse
+  // Transitive closure
   bool writeGeomRelTransClosure = false;
 
   // Output, empty for stdout

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -195,7 +195,8 @@ const static inline std::string ADD_AREA_ENVELOPE_RATIO_OPTION_HELP =
 
 const static inline std::string ADD_AREA_ORIENTED_BOUNDING_BOX_INFO =
     "Adding area oriented-bounding-boxes";
-const static inline std::string ADD_AREA_ORIENTED_BOUNDING_BOX_OPTION_SHORT = "";
+const static inline std::string ADD_AREA_ORIENTED_BOUNDING_BOX_OPTION_SHORT =
+    "";
 const static inline std::string ADD_AREA_ORIENTED_BOUNDING_BOX_OPTION_LONG =
     "add-area-oriented-bounding-box";
 const static inline std::string ADD_AREA_ORIENTED_BOUNDING_BOX_OPTION_HELP =
@@ -227,7 +228,8 @@ const static inline std::string ADD_NODE_ENVELOPE_OPTION_HELP =
 
 const static inline std::string ADD_NODE_ORIENTED_BOUNDING_BOX_INFO =
     "Adding node oriented-bounding-boxes";
-const static inline std::string ADD_NODE_ORIENTED_BOUNDING_BOX_OPTION_SHORT = "";
+const static inline std::string ADD_NODE_ORIENTED_BOUNDING_BOX_OPTION_SHORT =
+    "";
 const static inline std::string ADD_NODE_ORIENTED_BOUNDING_BOX_OPTION_LONG =
     "add-node-oriented-bounding-box";
 const static inline std::string ADD_NODE_ORIENTED_BOUNDING_BOX_OPTION_HELP =
@@ -249,7 +251,8 @@ const static inline std::string ADD_RELATION_CONVEX_HULL_OPTION_LONG =
 const static inline std::string ADD_RELATION_CONVEX_HULL_OPTION_HELP =
     "Add convex hull to relations";
 
-const static inline std::string ADD_RELATION_ENVELOPE_INFO = "Adding relation envelopes";
+const static inline std::string ADD_RELATION_ENVELOPE_INFO =
+    "Adding relation envelopes";
 const static inline std::string ADD_RELATION_ENVELOPE_OPTION_SHORT = "";
 const static inline std::string ADD_RELATION_ENVELOPE_OPTION_LONG =
     "add-relation-envelope";
@@ -258,7 +261,8 @@ const static inline std::string ADD_RELATION_ENVELOPE_OPTION_HELP =
 
 const static inline std::string ADD_RELATION_ORIENTED_BOUNDING_BOX_INFO =
     "Adding relation oriented-bounding-boxes";
-const static inline std::string ADD_RELATION_ORIENTED_BOUNDING_BOX_OPTION_SHORT = "";
+const static inline std::string
+    ADD_RELATION_ORIENTED_BOUNDING_BOX_OPTION_SHORT = "";
 const static inline std::string ADD_RELATION_ORIENTED_BOUNDING_BOX_OPTION_LONG =
     "add-relation-oriented-bounding-box";
 const static inline std::string ADD_RELATION_ORIENTED_BOUNDING_BOX_OPTION_HELP =
@@ -341,7 +345,7 @@ const static inline std::string SIMPLIFY_GEOMETRIES_OPTION_SHORT = "";
 const static inline std::string SIMPLIFY_GEOMETRIES_OPTION_LONG =
     "simplify-geometries";
 const static inline std::string SIMPLIFY_GEOMETRIES_OPTION_HELP =
-    "Factor for geometry simplifaction, 0 to disable; will be multiplied with "
+    "Factor for geometry simplification, 0 to disable; will be multiplied with "
     "the geometry "
     "perimeter or length. This only affects "
     "relationship calculations and not the geometry dump";
@@ -369,26 +373,29 @@ const static inline std::string DONT_USE_INNER_OUTER_GEOMETRIES_OPTION_HELP =
 
 const static inline std::string APPROX_SPATIAL_REL_INFO =
     "Approximate spatial relations using inner/outer simplified geometries.";
-const static inline std::string APPROX_SPATIAL_REL_OPTION_SHORT =
-    "";
+const static inline std::string APPROX_SPATIAL_REL_OPTION_SHORT = "";
 const static inline std::string APPROX_SPATIAL_REL_OPTION_LONG =
     "approximate-spatial-relations";
-const static inline std::string APPROX_SPATIAL_REL_OPTION_HELP = "Use "
-  "simplified inner/outer geometries for approximate calcuation of spatial "
-  "relations";
+const static inline std::string APPROX_SPATIAL_REL_OPTION_HELP =
+    "Use "
+    "simplified inner/outer geometries for approximate calcuation of spatial "
+    "relations";
 
-const static inline std::string SIMPLIFY_WKT_INFO = "Simplifying WKT";
-const static inline std::string SIMPLIFY_WKT_OPTION_SHORT = "s";
-const static inline std::string SIMPLIFY_WKT_OPTION_LONG = "simplify-wkt";
-const static inline std::string SIMPLIFY_WKT_OPTION_HELP =
-    "Simplify WKT-Geometries over this number of nodes, 0 to disable";
+const static inline std::string SIMPLIFY_GEOMETRIES_DUMP_INFO =
+    "Simplifying output geometries";
+const static inline std::string SIMPLIFY_GEOMETRIES_DUMP_OPTION_SHORT = "s";
+const static inline std::string SIMPLIFY_GEOMETRIES_DUMP_OPTION_LONG =
+    "simplify-geometries-dump";
+const static inline std::string SIMPLIFY_GEOMETRIES_DUMP_OPTION_HELP =
+    "Simplify dumped geometries with more than this number of nodes, 0 to "
+    "disable";
 
-const static inline std::string SIMPLIFY_WKT_DEVIATION_INFO =
-    "Simplifying wkt geometries with factor: ";
-const static inline std::string SIMPLIFY_WKT_DEVIATION_OPTION_SHORT = "";
-const static inline std::string SIMPLIFY_WKT_DEVIATION_OPTION_LONG =
-    "simplify-wkt-deviation";
-const static inline std::string SIMPLIFY_WKT_DEVIATION_OPTION_HELP =
+const static inline std::string GEOMETRIES_DUMP_DEVIATION_INFO =
+    "Simplifying dumped geometries with factor: ";
+const static inline std::string GEOMETRIES_DUMP_DEVIATION_OPTION_SHORT = "";
+const static inline std::string GEOMETRIES_DUMP_DEVIATION_OPTION_LONG =
+    "geometries-dump-deviation";
+const static inline std::string GEOMETRIES_DUMP_DEVIATION_OPTION_HELP =
     "Same effect as simplify-geometries but for the simplification of dumped "
     "geometries";
 
@@ -406,12 +413,13 @@ const static inline std::string SEMICOLON_TAG_KEYS_OPTION_LONG =
     "split-tag-key-by-semicolon";
 const static inline std::string SEMICOLON_TAG_KEYS_OPTION_HELP = "";
 
-const static inline std::string WKT_PRECISION_INFO =
-    "Dumping WKT with precision: ";
-const static inline std::string WKT_PRECISION_OPTION_SHORT = "";
-const static inline std::string WKT_PRECISION_OPTION_LONG = "wkt-precision";
-const static inline std::string WKT_PRECISION_OPTION_HELP =
-    "Precision (number of decimal digits) for WKT coordinates";
+const static inline std::string GEOMETRIES_DUMP_PRECISION_INFO =
+    "Dumping geometries with precision: ";
+const static inline std::string GEOMETRIES_DUMP_PRECISION_OPTION_SHORT = "";
+const static inline std::string GEOMETRIES_DUMP_PRECISION_OPTION_LONG =
+    "geometries-dump-precision";
+const static inline std::string GEOMETRIES_DUMP_PRECISION_OPTION_HELP =
+    "Precision (number of decimal digits) for dumped geometry coordinates";
 
 const static inline std::string WRITE_DAG_DOT_FILES_INFO =
     "Storing DAG states as .dot files";

--- a/include/osm2rdf/osm/FactHandler.h
+++ b/include/osm2rdf/osm/FactHandler.h
@@ -39,20 +39,32 @@ class FactHandler {
   void relation(const osm2rdf::osm::Relation& relation);
   void way(const osm2rdf::osm::Way& way);
 
-  template <typename G>
-  void writeBoostGeometry(const std::string& s, const std::string& p,
-                          const G& g);
-  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWay);
-  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWaySimplify1);
-  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWaySimplify2);
-  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWaySimplify3);
-
  protected:
+  template <typename G>
+  G simplifyGeometry(const G& g);
+  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWktWaySimplify1);
+  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWktWaySimplify2);
+  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWktWaySimplify3);
 
-  void writeBox(const std::string& s, const std::string& p,
-                const osm2rdf::geometry::Box& box);
-  FRIEND_TEST(OSM_FactHandler, writeBoxPrecision1);
-  FRIEND_TEST(OSM_FactHandler, writeBoxPrecision2);
+  template <typename G>
+  void writeBoostGeometryWkt(const std::string& s, const std::string& p,
+                             const G& g);
+  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWktWay);
+  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWktPrecision1);
+  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWktPrecision2);
+  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWktWaySimplify1);
+  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWktWaySimplify2);
+  FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWktWaySimplify3);
+
+  template <typename G>
+  void writeBoostGeometryGeoJson(const std::string& s, const std::string& p,
+                                 const G& geom);
+  void writeBoostGeometryGeoJson(const std::string& s, const std::string& p,
+                                 const osm2rdf::geometry::Relation & geom);
+  template <typename G>
+  std::string convertBoostGeometryToGeoJson(const G& geom);
+  template <typename G>
+  std::string convertBoostGeometryToWKT(const G& geom);
 
   void writeTag(const std::string& s, const osm2rdf::osm::Tag& tag);
   FRIEND_TEST(OSM_FactHandler, writeTag_AdminLevel);

--- a/include/osm2rdf/ttl/Constants.h
+++ b/include/osm2rdf/ttl/Constants.h
@@ -38,9 +38,11 @@ const static inline std::string NAMESPACE__WIKIDATA_ENTITY = "wd";
 const static inline std::string NAMESPACE__XML_SCHEMA = "xsd";
 
 // Generated constants (depending on output format)
-inline std::string IRI__GEOSPARQL__HAS_SERIALIZATION;
+inline std::string IRI__GEOSPARQL__AS_GEOJSON;
 inline std::string IRI__GEOSPARQL__AS_WKT;
+inline std::string IRI__GEOSPARQL__GEOJSON_LITERAL;
 inline std::string IRI__GEOSPARQL__HAS_GEOMETRY;
+inline std::string IRI__GEOSPARQL__HAS_SERIALIZATION;
 inline std::string IRI__GEOSPARQL__WKT_LITERAL;
 
 inline std::string IRI__OSM2RDF_CONTAINS_NON_AREA;

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -145,18 +145,18 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
             << osm2rdf::config::constants::ADD_WAY_NODE_SPATIAL_METADATA_INFO;
       }
     }
-    if (simplifyWKT > 0) {
-      oss << "\n" << prefix << osm2rdf::config::constants::SIMPLIFY_WKT_INFO;
+    if (geometriesDumpMinNumPointsForSimplification > 0) {
+      oss << "\n" << prefix << osm2rdf::config::constants::SIMPLIFY_GEOMETRIES_DUMP_INFO;
       oss << "\n"
-          << prefix << osm2rdf::config::constants::SIMPLIFY_WKT_DEVIATION_INFO
-          << std::to_string(wktDeviation);
+          << prefix << osm2rdf::config::constants::GEOMETRIES_DUMP_DEVIATION_INFO
+          << std::to_string(geometriesDumpDeviation);
     }
     if (skipWikiLinks) {
       oss << "\n" << prefix << osm2rdf::config::constants::SKIP_WIKI_LINKS_INFO;
     }
     oss << "\n"
-        << prefix << osm2rdf::config::constants::WKT_PRECISION_INFO
-        << std::to_string(wktPrecision);
+        << prefix << osm2rdf::config::constants::GEOMETRIES_DUMP_PRECISION_INFO
+        << std::to_string(geometriesDumpPrecision);
     if (!semicolonTagKeys.empty()) {
       oss << "\n"
           << prefix << osm2rdf::config::constants::SEMICOLON_TAG_KEYS_INFO;
@@ -425,20 +425,22 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
       osm2rdf::config::constants::APPROX_SPATIAL_REL_OPTION_HELP);
   auto simplifyWKTOp =
       parser.add<popl::Value<uint16_t>, popl::Attribute::advanced>(
-          osm2rdf::config::constants::SIMPLIFY_WKT_OPTION_SHORT,
-          osm2rdf::config::constants::SIMPLIFY_WKT_OPTION_LONG,
-          osm2rdf::config::constants::SIMPLIFY_WKT_OPTION_HELP, simplifyWKT);
+          osm2rdf::config::constants::SIMPLIFY_GEOMETRIES_DUMP_OPTION_SHORT,
+          osm2rdf::config::constants::SIMPLIFY_GEOMETRIES_DUMP_OPTION_LONG,
+          osm2rdf::config::constants::SIMPLIFY_GEOMETRIES_DUMP_OPTION_HELP,
+          geometriesDumpMinNumPointsForSimplification);
   auto wktDeviationOp =
       parser.add<popl::Value<double>, popl::Attribute::expert>(
-          osm2rdf::config::constants::SIMPLIFY_WKT_DEVIATION_OPTION_SHORT,
-          osm2rdf::config::constants::SIMPLIFY_WKT_DEVIATION_OPTION_LONG,
-          osm2rdf::config::constants::SIMPLIFY_WKT_DEVIATION_OPTION_HELP,
-          wktDeviation);
+          osm2rdf::config::constants::GEOMETRIES_DUMP_DEVIATION_OPTION_SHORT,
+          osm2rdf::config::constants::GEOMETRIES_DUMP_DEVIATION_OPTION_LONG,
+          osm2rdf::config::constants::GEOMETRIES_DUMP_DEVIATION_OPTION_HELP,
+      geometriesDumpDeviation);
   auto wktPrecisionOp =
       parser.add<popl::Value<uint16_t>, popl::Attribute::advanced>(
-          osm2rdf::config::constants::WKT_PRECISION_OPTION_SHORT,
-          osm2rdf::config::constants::WKT_PRECISION_OPTION_LONG,
-          osm2rdf::config::constants::WKT_PRECISION_OPTION_HELP, wktPrecision);
+          osm2rdf::config::constants::GEOMETRIES_DUMP_PRECISION_OPTION_SHORT,
+          osm2rdf::config::constants::GEOMETRIES_DUMP_PRECISION_OPTION_LONG,
+          osm2rdf::config::constants::GEOMETRIES_DUMP_PRECISION_OPTION_HELP,
+          geometriesDumpPrecision);
 
   auto writeDotFilesOp = parser.add<popl::Switch, popl::Attribute::expert>(
       osm2rdf::config::constants::WRITE_DAG_DOT_FILES_OPTION_SHORT,
@@ -552,9 +554,9 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
     simplifyGeometriesInnerOuter = simplifyGeometriesInnerOuterOp->value();
     dontUseInnerOuterGeoms = dontUseInnerOuterGeomsOp->value();
     approximateSpatialRels = approximateSpatialRelsOp->value();
-    simplifyWKT = simplifyWKTOp->value();
-    wktDeviation = wktDeviationOp->value();
-    wktPrecision = wktPrecisionOp->value();
+    geometriesDumpMinNumPointsForSimplification = simplifyWKTOp->value();
+    geometriesDumpDeviation = wktDeviationOp->value();
+    geometriesDumpPrecision = wktPrecisionOp->value();
 
     addWayNodeOrder |= addWayNodeGeometry;
     addWayNodeOrder |= addWayNodeSpatialMetadata;

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -17,6 +17,8 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "osm2rdf/osm/FactHandler.h"
+
 #include <iomanip>
 #include <iostream>
 
@@ -25,7 +27,6 @@
 #include "osm2rdf/config/Config.h"
 #include "osm2rdf/osm/Area.h"
 #include "osm2rdf/osm/Constants.h"
-#include "osm2rdf/osm/FactHandler.h"
 #include "osm2rdf/osm/Node.h"
 #include "osm2rdf/osm/Relation.h"
 #include "osm2rdf/osm/Way.h"
@@ -33,13 +34,15 @@
 
 using osm2rdf::osm::constants::AREA_PRECISION;
 using osm2rdf::osm::constants::BASE_SIMPLIFICATION_FACTOR;
+using osm2rdf::ttl::constants::IRI__GEOSPARQL__AS_GEOJSON;
 using osm2rdf::ttl::constants::IRI__GEOSPARQL__AS_WKT;
+using osm2rdf::ttl::constants::IRI__GEOSPARQL__GEOJSON_LITERAL;
 using osm2rdf::ttl::constants::IRI__GEOSPARQL__HAS_GEOMETRY;
 using osm2rdf::ttl::constants::IRI__GEOSPARQL__WKT_LITERAL;
+using osm2rdf::ttl::constants::IRI__OSM2RDF__POS;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__CONVEX_HULL;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__ENVELOPE;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__OBB;
-using osm2rdf::ttl::constants::IRI__OSM2RDF__POS;
 using osm2rdf::ttl::constants::IRI__OSM_NODE;
 using osm2rdf::ttl::constants::IRI__OSM_RELATION;
 using osm2rdf::ttl::constants::IRI__OSM_TAG;
@@ -78,25 +81,28 @@ void osm2rdf::osm::FactHandler<W>::area(const osm2rdf::osm::Area& area) {
       area.fromWay() ? NAMESPACE__OSM_WAY : NAMESPACE__OSM_RELATION,
       area.objId());
 
+  auto geom = simplifyGeometry(area.geom());
   if (!_config.hasGeometryAsWkt) {
     const std::string& geomObj = _writer->generateIRI(
         NAMESPACE__OSM2RDF_GEOM, (area.fromWay() ? "wayarea_" : "relarea_") +
-                                std::to_string(area.objId()));
-
+                                     std::to_string(area.objId()));
     _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
-    writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, area.geom());
+    writeBoostGeometryWkt(geomObj, IRI__GEOSPARQL__AS_WKT, geom);
+    writeBoostGeometryGeoJson(geomObj, IRI__GEOSPARQL__AS_GEOJSON, geom);
   } else {
-    writeBoostGeometry(subj, IRI__GEOSPARQL__HAS_GEOMETRY, area.geom());
+    writeBoostGeometryWkt(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geom);
   }
 
   if (_config.addAreaConvexHull) {
-    writeBoostGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, area.convexHull());
+    writeBoostGeometryWkt(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL,
+                          area.convexHull());
   }
   if (_config.addAreaEnvelope) {
-    writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, area.envelope());
+    writeBoostGeometryWkt(subj, IRI__OSM2RDF_GEOM__ENVELOPE, area.envelope());
   }
   if (_config.addAreaOrientedBoundingBox) {
-    writeBoostGeometry(subj, IRI__OSM2RDF_GEOM__OBB, area.orientedBoundingBox());
+    writeBoostGeometryWkt(subj, IRI__OSM2RDF_GEOM__OBB,
+                          area.orientedBoundingBox());
   }
 
   if (_config.addSortMetadata) {
@@ -127,26 +133,29 @@ void osm2rdf::osm::FactHandler<W>::node(const osm2rdf::osm::Node& node) {
 
   _writer->writeTriple(subj, IRI__RDF_TYPE, IRI__OSM_NODE);
 
+  auto geom = node.geom();
   if (!_config.hasGeometryAsWkt) {
     const std::string& geomObj = _writer->generateIRI(
         NAMESPACE__OSM2RDF_GEOM, "node_" + std::to_string(node.id()));
-
     _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
-    writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, node.geom());
+    writeBoostGeometryWkt(geomObj, IRI__GEOSPARQL__AS_WKT, geom);
+    writeBoostGeometryGeoJson(geomObj, IRI__GEOSPARQL__AS_GEOJSON, geom);
   } else {
-    writeBoostGeometry(subj, IRI__GEOSPARQL__HAS_GEOMETRY, node.geom());
+    writeBoostGeometryWkt(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geom);
   }
 
   writeTagList(subj, node.tags());
 
   if (_config.addNodeConvexHull) {
-    writeBoostGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, node.convexHull());
+    writeBoostGeometryWkt(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL,
+                          node.convexHull());
   }
   if (_config.addNodeEnvelope) {
-    writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, node.envelope());
+    writeBoostGeometryWkt(subj, IRI__OSM2RDF_GEOM__ENVELOPE, node.envelope());
   }
   if (_config.addNodeOrientedBoundingBox) {
-    writeBoostGeometry(subj, IRI__OSM2RDF_GEOM__OBB, node.orientedBoundingBox());
+    writeBoostGeometryWkt(subj, IRI__OSM2RDF_GEOM__OBB,
+                          node.orientedBoundingBox());
   }
 }
 
@@ -201,27 +210,29 @@ void osm2rdf::osm::FactHandler<W>::relation(
 
 #if BOOST_VERSION >= 107800
   if (relation.hasGeometry()) {
+    auto geom = simplifyGeometry(relation.geom());
     if (!_config.hasGeometryAsWkt) {
       const std::string& geomObj = _writer->generateIRI(
           NAMESPACE__OSM2RDF_GEOM, "relation_" + std::to_string(relation.id()));
-
       _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
-      writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, relation.geom());
+      writeBoostGeometryWkt(geomObj, IRI__GEOSPARQL__AS_WKT, geom);
+      writeBoostGeometryGeoJson(geomObj, IRI__GEOSPARQL__AS_GEOJSON, geom);
     } else {
-      writeBoostGeometry(subj, IRI__GEOSPARQL__HAS_GEOMETRY, relation.geom());
+      writeBoostGeometryWkt(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geom);
     }
 
     if (_config.addRelationConvexHull) {
-      writeBoostGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL,
-                         relation.convexHull());
+      writeBoostGeometryWkt(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL,
+                            relation.convexHull());
     }
     if (_config.addRelationEnvelope) {
-      writeBox(subj, osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__ENVELOPE,
-               relation.envelope());
+      writeBoostGeometryWkt(
+          subj, osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__ENVELOPE,
+          relation.envelope());
     }
     if (_config.addRelationOrientedBoundingBox) {
-      writeBoostGeometry(subj, IRI__OSM2RDF_GEOM__OBB,
-                         relation.orientedBoundingBox());
+      writeBoostGeometryWkt(subj, IRI__OSM2RDF_GEOM__OBB,
+                            relation.orientedBoundingBox());
     }
 
     _writer->writeTriple(
@@ -259,19 +270,21 @@ void osm2rdf::osm::FactHandler<W>::way(const osm2rdf::osm::Way& way) {
                                          "^^" + IRI__XSD_INTEGER));
 
       if (_config.addWayNodeGeometry) {
-        const std::string& subj =
+        const std::string& nSubj =
             _writer->generateIRI(NAMESPACE__OSM_NODE, node.id());
 
-        _writer->writeTriple(subj, IRI__RDF_TYPE, IRI__OSM_NODE);
+        _writer->writeTriple(nSubj, IRI__RDF_TYPE, IRI__OSM_NODE);
 
         if (!_config.hasGeometryAsWkt) {
           const std::string& geomObj = _writer->generateIRI(
               NAMESPACE__OSM2RDF_GEOM, "node_" + std::to_string(node.id()));
-
-          _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
-          writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, node.geom());
+          _writer->writeTriple(nSubj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
+          writeBoostGeometryWkt(geomObj, IRI__GEOSPARQL__AS_WKT, node.geom());
+          writeBoostGeometryGeoJson(geomObj, IRI__GEOSPARQL__AS_GEOJSON,
+                                    node.geom());
         } else {
-          writeBoostGeometry(subj, IRI__GEOSPARQL__HAS_GEOMETRY, node.geom());
+          writeBoostGeometryWkt(nSubj, IRI__GEOSPARQL__HAS_GEOMETRY,
+                                node.geom());
         }
       }
 
@@ -305,25 +318,28 @@ void osm2rdf::osm::FactHandler<W>::way(const osm2rdf::osm::Way& way) {
   osm2rdf::geometry::Linestring locations{way.geom()};
   size_t numUniquePoints = locations.size();
 
+  auto geom = simplifyGeometry(way.geom());
   if (!_config.hasGeometryAsWkt) {
     const std::string& geomObj = _writer->generateIRI(
         NAMESPACE__OSM2RDF, "way_" + std::to_string(way.id()));
-
     _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
-    writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, locations);
+    writeBoostGeometryWkt(geomObj, IRI__GEOSPARQL__AS_WKT, geom);
+    writeBoostGeometryGeoJson(geomObj, IRI__GEOSPARQL__AS_GEOJSON, geom);
   } else {
-    writeBoostGeometry(subj, IRI__GEOSPARQL__HAS_GEOMETRY, locations);
+    writeBoostGeometryWkt(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geom);
   }
 
   if (_config.addWayConvexHull) {
-    writeBoostGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, way.convexHull());
+    writeBoostGeometryWkt(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL,
+                          way.convexHull());
   }
   if (_config.addWayEnvelope) {
-    writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, way.envelope());
+    writeBoostGeometryWkt(subj, IRI__OSM2RDF_GEOM__ENVELOPE, way.envelope());
   }
 
   if (_config.addWayOrientedBoundingBox) {
-    writeBoostGeometry(subj, IRI__OSM2RDF_GEOM__OBB, way.orientedBoundingBox());
+    writeBoostGeometryWkt(subj, IRI__OSM2RDF_GEOM__OBB,
+                          way.orientedBoundingBox());
   }
 
   if (_config.addWayMetadata) {
@@ -351,43 +367,118 @@ void osm2rdf::osm::FactHandler<W>::way(const osm2rdf::osm::Way& way) {
 // ____________________________________________________________________________
 template <typename W>
 template <typename G>
-void osm2rdf::osm::FactHandler<W>::writeBoostGeometry(const std::string& subj,
-                                                      const std::string& pred,
-                                                      const G& geom) {
-  std::ostringstream wkt;
-  wkt << std::fixed << std::setprecision(_config.geometriesDumpPrecision);
+G osm2rdf::osm::FactHandler<W>::simplifyGeometry(const G& geom) {
   if (_config.geometriesDumpMinNumPointsForSimplification > 0 &&
-      boost::geometry::num_points(geom) > _config.geometriesDumpMinNumPointsForSimplification) {
-    G simplifiedGeom;
+      boost::geometry::num_points(geom) >
+          _config.geometriesDumpMinNumPointsForSimplification) {
     auto perimeter_or_length = std::max(boost::geometry::perimeter(geom),
                                         boost::geometry::length(geom));
+    G simplifiedGeom;
     do {
       boost::geometry::simplify(geom, simplifiedGeom,
                                 BASE_SIMPLIFICATION_FACTOR *
-                                    perimeter_or_length * _config.geometriesDumpDeviation);
+                                    perimeter_or_length *
+                                    _config.geometriesDumpDeviation);
       perimeter_or_length /= 2;
     } while ((boost::geometry::is_empty(simplifiedGeom) ||
               !boost::geometry::is_valid(simplifiedGeom)) &&
              perimeter_or_length >= BASE_SIMPLIFICATION_FACTOR);
-    wkt << boost::geometry::wkt(simplifiedGeom);
-  } else {
-    wkt << boost::geometry::wkt(geom);
+    return simplifiedGeom;
   }
-  _writer->writeTriple(subj, pred,
-                       "\"" + wkt.str() + "\"^^" + IRI__GEOSPARQL__WKT_LITERAL);
+  return geom;
 }
 
 // ____________________________________________________________________________
 template <typename W>
-void osm2rdf::osm::FactHandler<W>::writeBox(const std::string& subj,
-                                            const std::string& pred,
-                                            const osm2rdf::geometry::Box& box) {
-  // Box can not be simplified -> output directly.
-  std::ostringstream wkt;
-  wkt << std::fixed << std::setprecision(_config.geometriesDumpPrecision)
-      << boost::geometry::wkt(box);
+template <typename G>
+void osm2rdf::osm::FactHandler<W>::writeBoostGeometryWkt(
+    const std::string& subj, const std::string& pred, const G& geom) {
   _writer->writeTriple(subj, pred,
-                       "\"" + wkt.str() + "\"^^" + IRI__GEOSPARQL__WKT_LITERAL);
+                       "\"" + convertBoostGeometryToWKT(geom) + "\"^^" +
+                           IRI__GEOSPARQL__WKT_LITERAL);
+}
+
+// ____________________________________________________________________________
+template <typename W>
+template <typename G>
+void osm2rdf::osm::FactHandler<W>::writeBoostGeometryGeoJson(
+    const std::string& subj, const std::string& pred, const G& geom) {
+  _writer->writeTriple(
+      subj, pred,
+      _writer->STRING_LITERAL_QUOTE(convertBoostGeometryToGeoJson(geom)) +
+          "^^" + IRI__GEOSPARQL__GEOJSON_LITERAL);
+}
+
+// ____________________________________________________________________________
+template <typename W>
+void osm2rdf::osm::FactHandler<W>::writeBoostGeometryGeoJson(
+    const std::string& subj, const std::string& pred,
+    const osm2rdf::geometry::Relation& geom) {
+  std::ostringstream tmp;
+  tmp << "{\"type\": \"GeometryCollection\", \"geometries\": [";
+  bool firstDone = false;
+  for (const osm2rdf::geometry::RelationGeometryParts_t& part : geom) {
+    if (firstDone) {
+      tmp << ",";
+    }
+    switch (part.which()) {
+      case 0:
+        tmp << convertBoostGeometryToGeoJson(
+            boost::get<osm2rdf::geometry::Node>(part));
+        break;
+      case 1:
+        tmp << convertBoostGeometryToGeoJson(
+            boost::get<osm2rdf::geometry::Way>(part));
+        break;
+      case 2:
+        tmp << convertBoostGeometryToGeoJson(
+            boost::get<osm2rdf::geometry::Area>(part));
+        break;
+    }
+    firstDone = true;
+  }
+  tmp << "]}";
+
+  _writer->writeTriple(subj, pred,
+                       _writer->STRING_LITERAL_QUOTE(tmp.str()) + "^^" +
+                           IRI__GEOSPARQL__GEOJSON_LITERAL);
+}
+
+// ____________________________________________________________________________
+template <typename W>
+template <typename G>
+std::string osm2rdf::osm::FactHandler<W>::convertBoostGeometryToGeoJson(
+    const G& geom) {
+  std::ostringstream tmp;
+  tmp << std::fixed << std::setprecision(_config.geometriesDumpPrecision);
+  tmp << "{\"type\": \"";
+  if constexpr (std::is_same_v<G, osm2rdf::geometry::Box>) {
+    tmp << "Polygon";
+  } else if constexpr (std::is_same_v<G, osm2rdf::geometry::Linestring>) {
+    tmp << "LineString";
+  } else if constexpr (std::is_same_v<G, osm2rdf::geometry::Location>) {
+    tmp << "Point";
+  } else if constexpr (std::is_same_v<G, osm2rdf::geometry::Polygon>) {
+    tmp << "Polygon";
+  } else if constexpr (std::is_same_v<G, osm2rdf::geometry::MultiPolygon>) {
+    tmp << "MultiPolygon";
+  } else {
+    tmp << "!Unknown!";
+  }
+  tmp << "\", \"coordinates:\" ";
+  tmp << boost::geometry::dsv(geom, ",", "[", "]", ",", "[", "]", ",") << "}";
+  return tmp.str();
+}
+
+// ____________________________________________________________________________
+template <typename W>
+template <typename G>
+std::string osm2rdf::osm::FactHandler<W>::convertBoostGeometryToWKT(
+    const G& geom) {
+  std::ostringstream tmp;
+  tmp << std::fixed << std::setprecision(_config.geometriesDumpPrecision);
+  tmp << boost::geometry::wkt(geom);
+  return tmp.str();
 }
 
 // ____________________________________________________________________________

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -354,27 +354,27 @@ template <typename G>
 void osm2rdf::osm::FactHandler<W>::writeBoostGeometry(const std::string& subj,
                                                       const std::string& pred,
                                                       const G& geom) {
-  std::ostringstream tmp;
-  tmp << std::fixed << std::setprecision(_config.wktPrecision);
-  if (_config.simplifyWKT > 0 &&
-      boost::geometry::num_points(geom) > _config.simplifyWKT) {
+  std::ostringstream wkt;
+  wkt << std::fixed << std::setprecision(_config.geometriesDumpPrecision);
+  if (_config.geometriesDumpMinNumPointsForSimplification > 0 &&
+      boost::geometry::num_points(geom) > _config.geometriesDumpMinNumPointsForSimplification) {
     G simplifiedGeom;
     auto perimeter_or_length = std::max(boost::geometry::perimeter(geom),
                                         boost::geometry::length(geom));
     do {
       boost::geometry::simplify(geom, simplifiedGeom,
                                 BASE_SIMPLIFICATION_FACTOR *
-                                    perimeter_or_length * _config.wktDeviation);
+                                    perimeter_or_length * _config.geometriesDumpDeviation);
       perimeter_or_length /= 2;
     } while ((boost::geometry::is_empty(simplifiedGeom) ||
               !boost::geometry::is_valid(simplifiedGeom)) &&
              perimeter_or_length >= BASE_SIMPLIFICATION_FACTOR);
-    tmp << boost::geometry::wkt(simplifiedGeom);
+    wkt << boost::geometry::wkt(simplifiedGeom);
   } else {
-    tmp << boost::geometry::wkt(geom);
+    wkt << boost::geometry::wkt(geom);
   }
   _writer->writeTriple(subj, pred,
-                       "\"" + tmp.str() + "\"^^" + IRI__GEOSPARQL__WKT_LITERAL);
+                       "\"" + wkt.str() + "\"^^" + IRI__GEOSPARQL__WKT_LITERAL);
 }
 
 // ____________________________________________________________________________
@@ -383,11 +383,11 @@ void osm2rdf::osm::FactHandler<W>::writeBox(const std::string& subj,
                                             const std::string& pred,
                                             const osm2rdf::geometry::Box& box) {
   // Box can not be simplified -> output directly.
-  std::ostringstream tmp;
-  tmp << std::fixed << std::setprecision(_config.wktPrecision)
+  std::ostringstream wkt;
+  wkt << std::fixed << std::setprecision(_config.geometriesDumpPrecision)
       << boost::geometry::wkt(box);
   _writer->writeTriple(subj, pred,
-                       "\"" + tmp.str() + "\"^^" + IRI__GEOSPARQL__WKT_LITERAL);
+                       "\"" + wkt.str() + "\"^^" + IRI__GEOSPARQL__WKT_LITERAL);
 }
 
 // ____________________________________________________________________________

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -88,9 +88,9 @@ GeometryHandler<W>::GeometryHandler(const osm2rdf::config::Config& config,
   unlink(_tmpPathNodes.c_str());
   unlink(_tmpPathWays.c_str());
 
-  _fsUnnamedAreas << std::fixed << std::setprecision(_config.wktPrecision);
-  _fsWays << std::fixed << std::setprecision(_config.wktPrecision);
-  _fsNodes << std::fixed << std::setprecision(_config.wktPrecision);
+  _fsUnnamedAreas << std::fixed << std::setprecision(_config.geometriesDumpPrecision);
+  _fsWays << std::fixed << std::setprecision(_config.geometriesDumpPrecision);
+  _fsNodes << std::fixed << std::setprecision(_config.geometriesDumpPrecision);
 }
 
 // ___________________________________________________________________________

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -68,12 +68,16 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
        "https://www.openstreetmap.org/way/"}};
 
   // Generate constants
+  osm2rdf::ttl::constants::IRI__GEOSPARQL__AS_WKT =
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__GEOSPARQL, "asWKT");
+  osm2rdf::ttl::constants::IRI__GEOSPARQL__AS_GEOJSON =
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__GEOSPARQL, "asGeoJSON");
+  osm2rdf::ttl::constants::IRI__GEOSPARQL__GEOJSON_LITERAL = generateIRI(
+      osm2rdf::ttl::constants::NAMESPACE__GEOSPARQL, "geoJSONLiteral");
   osm2rdf::ttl::constants::IRI__GEOSPARQL__HAS_GEOMETRY =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__GEOSPARQL, "hasGeometry");
   osm2rdf::ttl::constants::IRI__GEOSPARQL__HAS_SERIALIZATION = generateIRI(
       osm2rdf::ttl::constants::NAMESPACE__GEOSPARQL, "hasSerialization");
-  osm2rdf::ttl::constants::IRI__GEOSPARQL__AS_WKT =
-      generateIRI(osm2rdf::ttl::constants::NAMESPACE__GEOSPARQL, "asWKT");
   osm2rdf::ttl::constants::IRI__GEOSPARQL__WKT_LITERAL =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__GEOSPARQL, "wktLiteral");
   osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_AREA =

--- a/tests/config/Config.cpp
+++ b/tests/config/Config.cpp
@@ -71,9 +71,9 @@ void assertDefaultConfig(const osm2rdf::config::Config& config) {
   ASSERT_FALSE(config.writeRDFStatistics);
 
   ASSERT_EQ(0, config.simplifyGeometries);
-  ASSERT_EQ(250, config.simplifyWKT);
-  ASSERT_EQ(5, config.wktDeviation);
-  ASSERT_EQ(7, config.wktPrecision);
+  ASSERT_EQ(250, config.geometriesDumpMinNumPointsForSimplification);
+  ASSERT_EQ(5, config.geometriesDumpDeviation);
+  ASSERT_EQ(7, config.geometriesDumpPrecision);
 
   ASSERT_EQ(osm2rdf::util::OutputMergeMode::CONCATENATE, config.mergeOutput);
   ASSERT_TRUE(config.outputCompress);
@@ -341,7 +341,7 @@ TEST(CONFIG_Config, fromArgsInvalidValue) {
   osm2rdf::util::CacheFile dummyInput("/tmp/dummyInput");
 
   const auto arg =
-      "--" + osm2rdf::config::constants::SIMPLIFY_WKT_DEVIATION_OPTION_LONG;
+      "--" + osm2rdf::config::constants::GEOMETRIES_DUMP_DEVIATION_OPTION_LONG;
   const int argc = 4;
   char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
                       const_cast<char*>("/tmp/output"),
@@ -989,52 +989,52 @@ TEST(CONFIG_Config, fromArgsSimplifyGeometriesLong) {
 }
 
 // ____________________________________________________________________________
-TEST(CONFIG_Config, fromArgsSimplifyWKTLong) {
+TEST(CONFIG_Config, fromArgsSimplifyGeometriesDumpLong) {
   osm2rdf::config::Config config;
   assertDefaultConfig(config);
   osm2rdf::util::CacheFile cf("/tmp/dummyInput");
 
-  const auto arg = "--" + osm2rdf::config::constants::SIMPLIFY_WKT_OPTION_LONG;
+  const auto arg = "--" + osm2rdf::config::constants::SIMPLIFY_GEOMETRIES_DUMP_OPTION_LONG;
   const int argc = 4;
   char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
                       const_cast<char*>("25"),
                       const_cast<char*>("/tmp/dummyInput")};
   config.fromArgs(argc, argv);
   ASSERT_EQ("", config.output.string());
-  ASSERT_EQ(25, config.simplifyWKT);
+  ASSERT_EQ(25, config.geometriesDumpMinNumPointsForSimplification);
 }
 
 // ____________________________________________________________________________
-TEST(CONFIG_Config, fromArgsSimplifyWKTDeviationLong) {
+TEST(CONFIG_Config, fromArgsGeometriesDumpDeviationLong) {
   osm2rdf::config::Config config;
   assertDefaultConfig(config);
   osm2rdf::util::CacheFile cf("/tmp/dummyInput");
 
   const auto arg =
-      "--" + osm2rdf::config::constants::SIMPLIFY_WKT_DEVIATION_OPTION_LONG;
+      "--" + osm2rdf::config::constants::GEOMETRIES_DUMP_DEVIATION_OPTION_LONG;
   const int argc = 4;
   char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
                       const_cast<char*>("25"),
                       const_cast<char*>("/tmp/dummyInput")};
   config.fromArgs(argc, argv);
   ASSERT_EQ("", config.output.string());
-  ASSERT_EQ(25, config.wktDeviation);
+  ASSERT_EQ(25, config.geometriesDumpDeviation);
 }
 
 // ____________________________________________________________________________
-TEST(CONFIG_Config, fromArgsSimplifyWKTPrecisionLong) {
+TEST(CONFIG_Config, fromArgsGeometriesDumpPrecisionLong) {
   osm2rdf::config::Config config;
   assertDefaultConfig(config);
   osm2rdf::util::CacheFile cf("/tmp/dummyInput");
 
-  const auto arg = "--" + osm2rdf::config::constants::WKT_PRECISION_OPTION_LONG;
+  const auto arg = "--" + osm2rdf::config::constants::GEOMETRIES_DUMP_PRECISION_OPTION_LONG;
   const int argc = 4;
   char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
                       const_cast<char*>("2"),
                       const_cast<char*>("/tmp/dummyInput")};
   config.fromArgs(argc, argv);
   ASSERT_EQ("", config.output.string());
-  ASSERT_EQ(2, config.wktPrecision);
+  ASSERT_EQ(2, config.geometriesDumpPrecision);
 }
 
 // ____________________________________________________________________________
@@ -1426,14 +1426,14 @@ TEST(CONFIG_Config, getInfoSimplifyGeometries) {
 }
 
 // ____________________________________________________________________________
-TEST(CONFIG_Config, getInfoSimplifyWKT) {
+TEST(CONFIG_Config, getInfoSimplifyGeometriesDump) {
   osm2rdf::config::Config config;
   assertDefaultConfig(config);
-  config.simplifyWKT = 250;
+  config.geometriesDumpMinNumPointsForSimplification = 250;
 
   const std::string res = config.getInfo("");
   ASSERT_THAT(
-      res, ::testing::HasSubstr(osm2rdf::config::constants::SIMPLIFY_WKT_INFO));
+      res, ::testing::HasSubstr(osm2rdf::config::constants::SIMPLIFY_GEOMETRIES_DUMP_INFO));
 }
 
 // ____________________________________________________________________________

--- a/tests/issues/Issue15.cpp
+++ b/tests/issues/Issue15.cpp
@@ -46,7 +46,7 @@ TEST(Issue15, Relation_8291361_expected) {
   // Problem in FactHandler::writeBoostGeometry
   // assert(!boost::geometry::is_empty(geom));
   // Disabling simplifyWKT to ensure error does not trigger
-  config.simplifyWKT = 0;
+  config.geometriesDumpMinNumPointsForSimplification = 0;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -146,7 +146,7 @@ TEST(Issue15, Way_201387026_expected) {
   // Problem in FactHandler::writeBoostGeometry
   // assert(!boost::geometry::is_empty(geom));
   // Disabling simplifyWKT to ensure error does not trigger
-  config.simplifyWKT = 0;
+  config.geometriesDumpMinNumPointsForSimplification = 0;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();

--- a/tests/issues/Issue24.cpp
+++ b/tests/issues/Issue24.cpp
@@ -116,7 +116,11 @@ TEST(Issue24, areaFromWayHasGeometryAsGeoSPARQL) {
   ASSERT_EQ(
       "osmway:21 geo:hasGeometry osm2rdfgeom:wayarea_21 "
       ".\nosm2rdfgeom:wayarea_21 geo:asWKT \"MULTIPOLYGON(((48.0 7.5,48.0 "
-      "7.6,48.1 7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral .\n",
+      "7.6,48.1 7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral "
+      ".\nosm2rdfgeom:wayarea_21 geo:asGeoJSON \"{\\\"type\\\": "
+      "\\\"MultiPolygon\\\", \\\"coordinates:\\\" "
+      "[[[[48.0,7.5],[48.0,7.6],[48.1,7.6],[48.1,7.5],[48.0,7.5]]]]}\"^^geo:"
+      "geoJSONLiteral .\n",
       buffer.str());
 
   // Cleanup
@@ -215,7 +219,11 @@ TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
   ASSERT_EQ(
       "osmrel:10 geo:hasGeometry osm2rdfgeom:relarea_10 "
       ".\nosm2rdfgeom:relarea_10 geo:asWKT \"MULTIPOLYGON(((48.0 7.5,48.0 "
-      "7.6,48.1 7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral .\n",
+      "7.6,48.1 7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral "
+      ".\nosm2rdfgeom:relarea_10 geo:asGeoJSON \"{\\\"type\\\": "
+      "\\\"MultiPolygon\\\", \\\"coordinates:\\\" "
+      "[[[[48.0,7.5],[48.0,7.6],[48.1,7.6],[48.1,7.5],[48.0,7.5]]]]}\"^^geo:"
+      "geoJSONLiteral .\n",
       buffer.str());
 
   // Cleanup
@@ -303,7 +311,9 @@ TEST(Issue24, nodeHasGeometryAsGeoSPARQL) {
   ASSERT_EQ(
       "osmnode:42 rdf:type osm:node .\n"
       "osmnode:42 geo:hasGeometry osm2rdfgeom:node_42 .\n"
-      "osm2rdfgeom:node_42 geo:asWKT \"POINT(7.5 48.0)\"^^geo:wktLiteral .\n"
+      "osm2rdfgeom:node_42 geo:asWKT \"POINT(7.5 48.0)\"^^geo:wktLiteral "
+      ".\nosm2rdfgeom:node_42 geo:asGeoJSON \"{\\\"type\\\": \\\"Point\\\", "
+      "\\\"coordinates:\\\" [7.5,48.0]}\"^^geo:geoJSONLiteral .\n"
       "osmnode:42 osm2rdf:facts \"0\"^^xsd:integer .\n",
       buffer.str());
 
@@ -477,7 +487,12 @@ TEST(Issue24, relationWithGeometryHasGeometryAsGeoSPARQL) {
       "_:0_0 osm2rdf:pos \"0\"^^xsd:integer .\n"
       "osmrel:42 geo:hasGeometry osm2rdfgeom:relation_42 "
       ".\nosm2rdfgeom:relation_42 geo:asWKT \"GEOMETRYCOLLECTION(POINT(7.5 "
-      "48.0),LINESTRING(7.5 48.0,7.6 48.0))\"^^geo:wktLiteral .\nosmrel:42 "
+      "48.0),LINESTRING(7.5 48.0,7.6 48.0))\"^^geo:wktLiteral "
+      ".\nosm2rdfgeom:relation_42 geo:asGeoJSON \"{\\\"type\\\": "
+      "\\\"GeometryCollection\\\", \\\"geometries\\\": [{\\\"type\\\": "
+      "\\\"Point\\\", \\\"coordinates:\\\" [7.5,48.0]},{\\\"type\\\": "
+      "\\\"LineString\\\", \\\"coordinates:\\\" "
+      "[[7.5,48.0],[7.6,48.0]]}]}\"^^geo:geoJSONLiteral .\nosmrel:42 "
       "osm2rdf:completeGeometry \"yes\" .\n",
       buffer.str());
 
@@ -576,7 +591,9 @@ TEST(Issue24, wayHasGeometryAsGeoSPARQL) {
       "osmway:42 osm2rdf:facts \"0\"^^xsd:integer .\n"
       "osmway:42 geo:hasGeometry osm2rdf:way_42 .\n"
       "osm2rdf:way_42 geo:asWKT \"LINESTRING(48.0 7.5,48.1 "
-      "7.6)\"^^geo:wktLiteral .\n",
+      "7.6)\"^^geo:wktLiteral .\n"
+      "osm2rdf:way_42 geo:asGeoJSON \"{\\\"type\\\": \\\"LineString\\\", "
+      "\\\"coordinates:\\\" [[48.0,7.5],[48.1,7.6]]}\"^^geo:geoJSONLiteral .\n",
       buffer.str());
 
   // Cleanup

--- a/tests/issues/Issue24.cpp
+++ b/tests/issues/Issue24.cpp
@@ -36,7 +36,7 @@ TEST(Issue24, areaFromWayHasGeometryAsWkt) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
 
   osm2rdf::util::Output output{config, config.output};
@@ -85,7 +85,7 @@ TEST(Issue24, areaFromWayHasGeometryAsGeoSPARQL) {
   config.hasGeometryAsWkt = false;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
 
   osm2rdf::util::Output output{config, config.output};
@@ -135,7 +135,7 @@ TEST(Issue24, areaFromRelationHasGeometryAsWkt) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
 
   osm2rdf::util::Output output{config, config.output};
@@ -184,7 +184,7 @@ TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
   config.hasGeometryAsWkt = false;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
 
   osm2rdf::util::Output output{config, config.output};
@@ -234,7 +234,7 @@ TEST(Issue24, nodeHasGeometryAsWkt) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -278,7 +278,7 @@ TEST(Issue24, nodeHasGeometryAsGeoSPARQL) {
   config.hasGeometryAsWkt = false;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -324,7 +324,7 @@ TEST(Issue24, relationWithGeometryHasGeometryAsWkt) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -410,7 +410,7 @@ TEST(Issue24, relationWithGeometryHasGeometryAsGeoSPARQL) {
   config.hasGeometryAsWkt = false;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -498,7 +498,7 @@ TEST(Issue24, wayHasGeometryAsWkt) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
 
   osm2rdf::util::Output output{config, config.output};
@@ -546,7 +546,7 @@ TEST(Issue24, wayHasGeometryAsGeoSPARQL) {
   config.hasGeometryAsWkt = false;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
 
   osm2rdf::util::Output output{config, config.output};

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -1841,7 +1841,7 @@ TEST(OSM_FactHandler, wayAddWayMetaData) {
 }
 
 // ____________________________________________________________________________
-TEST(OSM_FactHandler, writeBoostGeometryWay) {
+TEST(OSM_FactHandler, writeBoostGeometryWktWay) {
   // Capture std::cout
   std::stringstream buffer;
   std::streambuf* sbuf = std::cout.rdbuf();
@@ -1866,7 +1866,7 @@ TEST(OSM_FactHandler, writeBoostGeometryWay) {
   way.push_back(osm2rdf::geometry::Location{0, 80});
   way.push_back(osm2rdf::geometry::Location{0, 1000});
 
-  dh.writeBoostGeometry(subject, predicate, way);
+  dh.writeBoostGeometryWkt(subject, predicate, way);
   output.flush();
   output.close();
 
@@ -1880,7 +1880,7 @@ TEST(OSM_FactHandler, writeBoostGeometryWay) {
 }
 
 // ____________________________________________________________________________
-TEST(OSM_FactHandler, writeBoostGeometryWaySimplify1) {
+TEST(OSM_FactHandler, writeBoostGeometryWktWaySimplify1) {
   // Capture std::cout
   std::stringstream buffer;
   std::streambuf* sbuf = std::cout.rdbuf();
@@ -1912,7 +1912,7 @@ TEST(OSM_FactHandler, writeBoostGeometryWaySimplify1) {
   way.push_back(osm2rdf::geometry::Location{0, 500});
   way.push_back(osm2rdf::geometry::Location{0, 1000});
 
-  dh.writeBoostGeometry(subject, predicate, way);
+  dh.writeBoostGeometryWkt(subject, predicate, dh.simplifyGeometry(way));
   output.flush();
   output.close();
 
@@ -1926,7 +1926,7 @@ TEST(OSM_FactHandler, writeBoostGeometryWaySimplify1) {
 }
 
 // ____________________________________________________________________________
-TEST(OSM_FactHandler, writeBoostGeometryWaySimplify2) {
+TEST(OSM_FactHandler, writeBoostGeometryWktWaySimplify2) {
   // Capture std::cout
   std::stringstream buffer;
   std::streambuf* sbuf = std::cout.rdbuf();
@@ -1954,7 +1954,7 @@ TEST(OSM_FactHandler, writeBoostGeometryWaySimplify2) {
   way.push_back(osm2rdf::geometry::Location{0, 80});
   way.push_back(osm2rdf::geometry::Location{100, 1000});
 
-  dh.writeBoostGeometry(subject, predicate, way);
+  dh.writeBoostGeometryWkt(subject, predicate, dh.simplifyGeometry(way));
   output.flush();
   output.close();
 
@@ -1968,7 +1968,7 @@ TEST(OSM_FactHandler, writeBoostGeometryWaySimplify2) {
 }
 
 // ____________________________________________________________________________
-TEST(OSM_FactHandler, writeBoostGeometryWaySimplify3) {
+TEST(OSM_FactHandler, writeBoostGeometryWktWaySimplify3) {
   // Capture std::cout
   std::stringstream buffer;
   std::streambuf* sbuf = std::cout.rdbuf();
@@ -1997,7 +1997,7 @@ TEST(OSM_FactHandler, writeBoostGeometryWaySimplify3) {
   way.push_back(osm2rdf::geometry::Location{0, 80});
   way.push_back(osm2rdf::geometry::Location{100, 1000});
 
-  dh.writeBoostGeometry(subject, predicate, way);
+  dh.writeBoostGeometryWkt(subject, predicate, dh.simplifyGeometry(way));
   output.flush();
   output.close();
 
@@ -2011,7 +2011,7 @@ TEST(OSM_FactHandler, writeBoostGeometryWaySimplify3) {
 }
 
 // ____________________________________________________________________________
-TEST(OSM_FactHandler, writeBoxPrecision1) {
+TEST(OSM_FactHandler, writeBoostGeometryWktPrecision1) {
   // Capture std::cout
   std::stringstream buffer;
   std::streambuf* sbuf = std::cout.rdbuf();
@@ -2035,7 +2035,7 @@ TEST(OSM_FactHandler, writeBoxPrecision1) {
   box.min_corner() = osm2rdf::geometry::Location{50, 50};
   box.max_corner() = osm2rdf::geometry::Location{200, 200};
 
-  dh.writeBox(subject, predicate, box);
+  dh.writeBoostGeometryWkt(subject, predicate, box);
   output.flush();
   output.close();
 
@@ -2051,7 +2051,7 @@ TEST(OSM_FactHandler, writeBoxPrecision1) {
 }
 
 // ____________________________________________________________________________
-TEST(OSM_FactHandler, writeBoxPrecision2) {
+TEST(OSM_FactHandler, writeBoostGeometryWktPrecision2) {
   // Capture std::cout
   std::stringstream buffer;
   std::streambuf* sbuf = std::cout.rdbuf();
@@ -2075,7 +2075,7 @@ TEST(OSM_FactHandler, writeBoxPrecision2) {
   box.min_corner() = osm2rdf::geometry::Location{50, 50};
   box.max_corner() = osm2rdf::geometry::Location{200, 200};
 
-  dh.writeBox(subject, predicate, box);
+  dh.writeBoostGeometryWkt(subject, predicate, box);
   output.flush();
   output.close();
 

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -56,7 +56,7 @@ TEST(OSM_FactHandler, areaFromWay) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
 
   osm2rdf::util::Output output{config, config.output};
@@ -106,7 +106,7 @@ TEST(OSM_FactHandler, areaFromRelation) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
 
   osm2rdf::util::Output output{config, config.output};
@@ -156,7 +156,7 @@ TEST(OSM_FactHandler, areaAddConvexHull) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addAreaConvexHull = true;
   config.addSortMetadata = false;
 
@@ -211,7 +211,7 @@ TEST(OSM_FactHandler, areaAddEnvelope) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addAreaEnvelope = true;
   config.addSortMetadata = false;
 
@@ -266,7 +266,7 @@ TEST(OSM_FactHandler, areaAddOrientedBoundingBox) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addAreaOrientedBoundingBox = true;
   config.addSortMetadata = false;
 
@@ -320,7 +320,7 @@ TEST(OSM_FactHandler, areaAddSortMetadata) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -372,7 +372,7 @@ TEST(OSM_FactHandler, areaAddAreaEnvelopeRatioRectangle) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addAreaEnvelopeRatio = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -425,7 +425,7 @@ TEST(OSM_FactHandler, areaAddAreaEnvelopeRatioDiamond) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addAreaEnvelopeRatio = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -478,7 +478,7 @@ TEST(OSM_FactHandler, node) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -524,7 +524,7 @@ TEST(OSM_FactHandler, nodeAddConvexHull) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addNodeConvexHull = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -574,7 +574,7 @@ TEST(OSM_FactHandler, nodeAddEnvelope) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addNodeEnvelope = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -624,7 +624,7 @@ TEST(OSM_FactHandler, nodeAddOrientedBoundingBox) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addNodeOrientedBoundingBox = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -673,7 +673,7 @@ TEST(OSM_FactHandler, relation) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -733,7 +733,7 @@ TEST(OSM_FactHandler, relationAddConvexHull) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addRelationConvexHull = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -794,7 +794,7 @@ TEST(OSM_FactHandler, relationAddEnvelop) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addRelationEnvelope = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -855,7 +855,7 @@ TEST(OSM_FactHandler, relationAddOrientedBoundingBox) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addRelationOrientedBoundingBox = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -917,7 +917,7 @@ TEST(OSM_FactHandler, relationWithGeometry) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -1006,7 +1006,7 @@ TEST(OSM_FactHandler, relationWithGeometryAddConvexHull) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addRelationConvexHull = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1099,7 +1099,7 @@ TEST(OSM_FactHandler, relationWithGeometryAddEnvelope) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addRelationEnvelope = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1192,7 +1192,7 @@ TEST(OSM_FactHandler, relationWithGeometryAddOrientedBoundingBox) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addRelationOrientedBoundingBox = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1285,7 +1285,7 @@ TEST(OSM_FactHandler, way) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1335,7 +1335,7 @@ TEST(OSM_FactHandler, wayAddSortMetadata) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = true;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1387,7 +1387,7 @@ TEST(OSM_FactHandler, wayAddWayConvexHull) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
   config.addWayConvexHull = true;
 
@@ -1440,7 +1440,7 @@ TEST(OSM_FactHandler, wayAddWayEnvelope) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
   config.addWayEnvelope = true;
 
@@ -1494,7 +1494,7 @@ TEST(OSM_FactHandler, wayAddWayOrientedBoundingBox) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
   config.addWayOrientedBoundingBox = true;
 
@@ -1547,7 +1547,7 @@ TEST(OSM_FactHandler, wayAddWayNodeGeoemtry) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
   config.addWayNodeGeometry = true;
   config.addWayNodeOrder = true;
@@ -1609,7 +1609,7 @@ TEST(OSM_FactHandler, wayAddWayNodeOrder) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
   config.addWayNodeOrder = true;
 
@@ -1666,7 +1666,7 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataShortWay) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
   config.addWayNodeOrder = true;
   config.addWayNodeSpatialMetadata = true;
@@ -1726,7 +1726,7 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataLongerWay) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
   config.addWayNodeOrder = true;
   config.addWayNodeSpatialMetadata = true;
@@ -1798,7 +1798,7 @@ TEST(OSM_FactHandler, wayAddWayMetaData) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
   config.addSortMetadata = false;
   config.addWayMetadata = true;
 
@@ -1852,7 +1852,7 @@ TEST(OSM_FactHandler, writeBoostGeometryWay) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -1891,10 +1891,10 @@ TEST(OSM_FactHandler, writeBoostGeometryWaySimplify1) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
-  config.simplifyWKT = 2;
+  config.geometriesDumpPrecision = 1;
+  config.geometriesDumpMinNumPointsForSimplification = 2;
   // Simplify all nodes with distance <= 5% of small side (100 * 0.05 = 5)
-  config.wktDeviation = 5;
+  config.geometriesDumpDeviation = 5;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -1937,10 +1937,10 @@ TEST(OSM_FactHandler, writeBoostGeometryWaySimplify2) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
-  config.simplifyWKT = 2;
+  config.geometriesDumpPrecision = 1;
+  config.geometriesDumpMinNumPointsForSimplification = 2;
   // Simplify all nodes with distance <= 5% of small side (100 * 0.05 = 5)
-  config.wktDeviation = 5;
+  config.geometriesDumpDeviation = 5;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -1979,10 +1979,10 @@ TEST(OSM_FactHandler, writeBoostGeometryWaySimplify3) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
-  config.simplifyWKT = 2;
+  config.geometriesDumpPrecision = 1;
+  config.geometriesDumpMinNumPointsForSimplification = 2;
   // Simplify all nodes with distance <= 80% of small side (100 * 0.8 = 80)
-  config.wktDeviation = 80;
+  config.geometriesDumpDeviation = 80;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -2022,7 +2022,7 @@ TEST(OSM_FactHandler, writeBoxPrecision1) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
+  config.geometriesDumpPrecision = 1;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -2062,7 +2062,7 @@ TEST(OSM_FactHandler, writeBoxPrecision2) {
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 2;
+  config.geometriesDumpPrecision = 2;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();


### PR DESCRIPTION
This PR adds basic GeoJSON output to osm2rdf for the `hasGeometry` predicate. Other predicates still return only WKT.