### PR TITLE
Area linestring remove

### DIFF
--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -66,6 +66,7 @@ struct Config {
   bool addAreaConvexHull = false;
   bool addAreaEnvelope = false;
   bool addAreaOrientedBoundingBox = false;
+  bool addAreaWayLinestrings = false;
   bool addNodeConvexHull = false;
   bool addNodeEnvelope = false;
   bool addNodeOrientedBoundingBox = false;

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -201,6 +201,14 @@ const static inline std::string ADD_AREA_ORIENTED_BOUNDING_BOX_OPTION_LONG =
 const static inline std::string ADD_AREA_ORIENTED_BOUNDING_BOX_OPTION_HELP =
     "Add oriented-bounding-box to areas";
 
+const static inline std::string ADD_AREA_WAY_LINESTRINGS_INFO =
+    "Adding linestrings for ways which form areas";
+const static inline std::string ADD_AREA_WAY_LINESTRINGS_OPTION_SHORT = "";
+const static inline std::string ADD_AREA_WAY_LINESTRINGS_OPTION_LONG =
+    "add-area-way-linestrings";
+const static inline std::string ADD_AREA_WAY_LINESTRINGS_OPTION_HELP =
+    "Add linestrings for ways which form areas";
+
 const static inline std::string HASGEOMETRY_AS_WKT_INFO =
     "Letting geo:hasGeometry point directly to WKT serialization literal";
 const static inline std::string HASGEOMETRY_AS_WKT_OPTION_SHORT = "";

--- a/include/osm2rdf/osm/Way.h
+++ b/include/osm2rdf/osm/Way.h
@@ -45,6 +45,7 @@ class Way {
   explicit Way(const osmium::Way& way);
   [[nodiscard]] id_t id() const noexcept;
   [[nodiscard]] bool closed() const noexcept;
+  [[nodiscard]] bool isArea() const noexcept;
   [[nodiscard]] const osm2rdf::geometry::Box& envelope() const noexcept;
   [[nodiscard]] const osm2rdf::geometry::Way& geom() const noexcept;
   // Return the convex hull.

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -17,13 +17,14 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "osm2rdf/config/Config.h"
+
 #include <filesystem>
 #include <iostream>
 #include <string>
 
 #include "boost/version.hpp"
 #include "omp.h"
-#include "osm2rdf/config/Config.h"
 #include "osm2rdf/config/Constants.h"
 #include "osm2rdf/config/ExitCode.h"
 #include "popl.hpp"
@@ -66,7 +67,8 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       }
       if (addAreaOrientedBoundingBox) {
         oss << "\n"
-            << prefix << osm2rdf::config::constants::ADD_AREA_ORIENTED_BOUNDING_BOX_INFO;
+            << prefix
+            << osm2rdf::config::constants::ADD_AREA_ORIENTED_BOUNDING_BOX_INFO;
       }
       if (addAreaEnvelopeRatio) {
         oss << "\n"
@@ -87,7 +89,8 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       }
       if (addNodeOrientedBoundingBox) {
         oss << "\n"
-            << prefix << osm2rdf::config::constants::ADD_NODE_ORIENTED_BOUNDING_BOX_INFO;
+            << prefix
+            << osm2rdf::config::constants::ADD_NODE_ORIENTED_BOUNDING_BOX_INFO;
       }
     }
     if (noRelationFacts) {
@@ -101,7 +104,8 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       }
       if (addRelationConvexHull) {
         oss << "\n"
-            << prefix << osm2rdf::config::constants::ADD_RELATION_CONVEX_HULL_INFO;
+            << prefix
+            << osm2rdf::config::constants::ADD_RELATION_CONVEX_HULL_INFO;
       }
       if (addRelationEnvelope) {
         oss << "\n"
@@ -109,7 +113,9 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       }
       if (addRelationOrientedBoundingBox) {
         oss << "\n"
-            << prefix << osm2rdf::config::constants::ADD_RELATION_ORIENTED_BOUNDING_BOX_INFO;
+            << prefix
+            << osm2rdf::config::constants::
+                   ADD_RELATION_ORIENTED_BOUNDING_BOX_INFO;
       }
     }
     if (noWayFacts) {
@@ -125,7 +131,8 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       }
       if (addWayOrientedBoundingBox) {
         oss << "\n"
-            << prefix << osm2rdf::config::constants::ADD_WAY_ORIENTED_BOUNDING_BOX_INFO;
+            << prefix
+            << osm2rdf::config::constants::ADD_WAY_ORIENTED_BOUNDING_BOX_INFO;
       }
       if (addWayMetadata) {
         oss << "\n"

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -66,8 +66,7 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       }
       if (addAreaOrientedBoundingBox) {
         oss << "\n"
-            << prefix
-            << osm2rdf::config::constants::ADD_AREA_ORIENTED_BOUNDING_BOX_INFO;
+            << prefix << osm2rdf::config::constants::ADD_AREA_ORIENTED_BOUNDING_BOX_INFO;
       }
       if (addAreaEnvelopeRatio) {
         oss << "\n"
@@ -88,8 +87,7 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       }
       if (addNodeOrientedBoundingBox) {
         oss << "\n"
-            << prefix
-            << osm2rdf::config::constants::ADD_NODE_ORIENTED_BOUNDING_BOX_INFO;
+            << prefix << osm2rdf::config::constants::ADD_NODE_ORIENTED_BOUNDING_BOX_INFO;
       }
     }
     if (noRelationFacts) {
@@ -103,8 +101,7 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       }
       if (addRelationConvexHull) {
         oss << "\n"
-            << prefix
-            << osm2rdf::config::constants::ADD_RELATION_CONVEX_HULL_INFO;
+            << prefix << osm2rdf::config::constants::ADD_RELATION_CONVEX_HULL_INFO;
       }
       if (addRelationEnvelope) {
         oss << "\n"
@@ -112,9 +109,7 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       }
       if (addRelationOrientedBoundingBox) {
         oss << "\n"
-            << prefix
-            << osm2rdf::config::constants::
-                   ADD_RELATION_ORIENTED_BOUNDING_BOX_INFO;
+            << prefix << osm2rdf::config::constants::ADD_RELATION_ORIENTED_BOUNDING_BOX_INFO;
       }
     }
     if (noWayFacts) {
@@ -130,8 +125,7 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       }
       if (addWayOrientedBoundingBox) {
         oss << "\n"
-            << prefix
-            << osm2rdf::config::constants::ADD_WAY_ORIENTED_BOUNDING_BOX_INFO;
+            << prefix << osm2rdf::config::constants::ADD_WAY_ORIENTED_BOUNDING_BOX_INFO;
       }
       if (addWayMetadata) {
         oss << "\n"
@@ -149,6 +143,11 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
         oss << "\n"
             << prefix
             << osm2rdf::config::constants::ADD_WAY_NODE_SPATIAL_METADATA_INFO;
+      }
+      if (addAreaWayLinestrings) {
+        oss << "\n"
+            << prefix
+            << osm2rdf::config::constants::ADD_AREA_WAY_LINESTRINGS_INFO;
       }
     }
     if (simplifyWKT > 0) {
@@ -335,6 +334,11 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
           osm2rdf::config::constants::ADD_AREA_ENVELOPE_RATIO_OPTION_SHORT,
           osm2rdf::config::constants::ADD_AREA_ENVELOPE_RATIO_OPTION_LONG,
           osm2rdf::config::constants::ADD_AREA_ENVELOPE_RATIO_OPTION_HELP);
+  auto addAreaWayLinestringsOp =
+      parser.add<popl::Switch, popl::Attribute::expert>(
+          osm2rdf::config::constants::ADD_AREA_WAY_LINESTRINGS_OPTION_SHORT,
+          osm2rdf::config::constants::ADD_AREA_WAY_LINESTRINGS_OPTION_LONG,
+          osm2rdf::config::constants::ADD_AREA_WAY_LINESTRINGS_OPTION_HELP);
   auto addRelationBorderMembersOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::ADD_RELATION_BORDER_MEMBERS_OPTION_SHORT,
       osm2rdf::config::constants::ADD_RELATION_BORDER_MEMBERS_OPTION_LONG,
@@ -571,6 +575,7 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
     addAreaEnvelope = addAreaEnvelopeOp->is_set();
     addAreaEnvelopeRatio = addAreaEnvelopeRatioOp->is_set();
     addAreaOrientedBoundingBox = addAreaOrientedBoundingBoxOp->is_set();
+    addAreaWayLinestrings = addAreaWayLinestringsOp->is_set();
     addRelationBorderMembers = addRelationBorderMembersOp->is_set();
 #if BOOST_VERSION >= 107800
     addRelationConvexHull = addRelationConvexHullOp->is_set();

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -308,7 +308,7 @@ void osm2rdf::osm::FactHandler<W>::way(const osm2rdf::osm::Way& way) {
   osm2rdf::geometry::Linestring locations{way.geom()};
   size_t numUniquePoints = locations.size();
 
-  if (!way.isArea()) {
+  if (_config.addAreaWayLinestrings || !way.isArea()) {
     if (!_config.hasGeometryAsWkt) {
       const std::string& geomObj = _writer->generateIRI(
           NAMESPACE__OSM2RDF, "way_" + std::to_string(way.id()));

--- a/src/osm/Way.cpp
+++ b/src/osm/Way.cpp
@@ -108,6 +108,23 @@ bool osm2rdf::osm::Way::closed() const noexcept {
 }
 
 // ____________________________________________________________________________
+bool osm2rdf::osm::Way::isArea() const noexcept {
+  if (_nodes.size() < 4) {
+    return false;
+  }
+  if (!closed()) {
+    return false;
+  }
+  const auto& areaTag = _tags.find("area");
+  if (areaTag != _tags.end()) {
+    if (areaTag->second == "no") {
+      return false;
+    }
+  }
+  return true;
+}
+
+// ____________________________________________________________________________
 bool osm2rdf::osm::Way::operator==(
     const osm2rdf::osm::Way& other) const noexcept {
   return _id == other._id && _envelope == other._envelope &&

--- a/src/osm/Way.cpp
+++ b/src/osm/Way.cpp
@@ -109,6 +109,7 @@ bool osm2rdf::osm::Way::closed() const noexcept {
 
 // ____________________________________________________________________________
 bool osm2rdf::osm::Way::isArea() const noexcept {
+  // See libosmium/include/osmium/area/multipolygon_manager.hpp:154
   if (_nodes.size() < 4) {
     return false;
   }

--- a/tests/E2E.cpp
+++ b/tests/E2E.cpp
@@ -437,6 +437,7 @@ TEST(E2E, building51NT) {
   config.output = "";
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
+  config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -606,6 +607,7 @@ TEST(E2E, building51TTL) {
   config.output = "";
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
+  config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -744,6 +746,7 @@ TEST(E2E, building51QLEVER) {
   config.output = "";
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
+  config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -882,6 +885,7 @@ TEST(E2E, tf) {
   config.output = "";
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
+  config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -977,6 +981,7 @@ TEST(E2E, building51inTF) {
   config.output = "";
   config.hasGeometryAsWkt = true;
   config.outputCompress = false;
+  config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file

--- a/tests/config/Config.cpp
+++ b/tests/config/Config.cpp
@@ -46,6 +46,7 @@ void assertDefaultConfig(const osm2rdf::config::Config& config) {
   ASSERT_FALSE(config.addAreaEnvelope);
   ASSERT_FALSE(config.addAreaEnvelopeRatio);
   ASSERT_FALSE(config.addAreaOrientedBoundingBox);
+  ASSERT_FALSE(config.addAreaWayLinestrings);
   ASSERT_FALSE(config.addNodeConvexHull);
   ASSERT_FALSE(config.addNodeEnvelope);
   ASSERT_FALSE(config.addNodeOrientedBoundingBox);
@@ -646,6 +647,22 @@ TEST(CONFIG_Config, fromArgsAddAreaOrientedBoundingBoxLong) {
 }
 
 // ____________________________________________________________________________
+TEST(CONFIG_Config, fromArgsAddAreaWayLinestringsLong) {
+  osm2rdf::config::Config config;
+  assertDefaultConfig(config);
+  osm2rdf::util::CacheFile cf("/tmp/dummyInput");
+
+  const auto arg =
+      "--" + osm2rdf::config::constants::ADD_AREA_WAY_LINESTRINGS_OPTION_LONG;
+  const int argc = 3;
+  char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
+                      const_cast<char*>("/tmp/dummyInput")};
+  config.fromArgs(argc, argv);
+  ASSERT_EQ("", config.output.string());
+  ASSERT_TRUE(config.addAreaWayLinestrings);
+}
+
+// ____________________________________________________________________________
 TEST(CONFIG_Config, fromArgsAddNodeConvexHullLong) {
   osm2rdf::config::Config config;
   assertDefaultConfig(config);
@@ -719,8 +736,7 @@ TEST(CONFIG_Config, fromArgsAddRelationConvexHullLong) {
   osm2rdf::util::CacheFile cf("/tmp/dummyInput");
 
   const auto arg =
-      "--" +
-      osm2rdf::config::constants::ADD_RELATION_CONVEX_HULL_OPTION_LONG;
+      "--" + osm2rdf::config::constants::ADD_RELATION_CONVEX_HULL_OPTION_LONG;
   const int argc = 3;
   char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
                       const_cast<char*>("/tmp/dummyInput")};
@@ -736,8 +752,7 @@ TEST(CONFIG_Config, fromArgsAddRelationEnvelopeLong) {
   osm2rdf::util::CacheFile cf("/tmp/dummyInput");
 
   const auto arg =
-      "--" +
-      osm2rdf::config::constants::ADD_RELATION_ENVELOPE_OPTION_LONG;
+      "--" + osm2rdf::config::constants::ADD_RELATION_ENVELOPE_OPTION_LONG;
   const int argc = 3;
   char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
                       const_cast<char*>("/tmp/dummyInput")};
@@ -752,9 +767,8 @@ TEST(CONFIG_Config, fromArgsAddRelationOrientedBoundingBoxLong) {
   assertDefaultConfig(config);
   osm2rdf::util::CacheFile cf("/tmp/dummyInput");
 
-  const auto arg =
-      "--" +
-      osm2rdf::config::constants::ADD_RELATION_ORIENTED_BOUNDING_BOX_OPTION_LONG;
+  const auto arg = "--" + osm2rdf::config::constants::
+                              ADD_RELATION_ORIENTED_BOUNDING_BOX_OPTION_LONG;
   const int argc = 3;
   char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
                       const_cast<char*>("/tmp/dummyInput")};
@@ -803,7 +817,8 @@ TEST(CONFIG_Config, fromArgsAddWayOrientedBoundingBOxLong) {
   osm2rdf::util::CacheFile cf("/tmp/dummyInput");
 
   const auto arg =
-      "--" + osm2rdf::config::constants::ADD_WAY_ORIENTED_BOUNDING_BOX_OPTION_LONG;
+      "--" +
+      osm2rdf::config::constants::ADD_WAY_ORIENTED_BOUNDING_BOX_OPTION_LONG;
   const int argc = 3;
   char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
                       const_cast<char*>("/tmp/dummyInput")};
@@ -1166,6 +1181,18 @@ TEST(CONFIG_Config, getInfoAddAreaOrientedBoundingBox) {
       res,
       ::testing::HasSubstr(
           osm2rdf::config::constants::ADD_AREA_ORIENTED_BOUNDING_BOX_INFO));
+}
+
+// ____________________________________________________________________________
+TEST(CONFIG_Config, getInfoAddAreaWayLinestrings) {
+  osm2rdf::config::Config config;
+  assertDefaultConfig(config);
+  config.addAreaWayLinestrings = true;
+
+  const std::string res = config.getInfo("");
+  ASSERT_THAT(res,
+              ::testing::HasSubstr(
+                  osm2rdf::config::constants::ADD_AREA_WAY_LINESTRINGS_INFO));
 }
 
 // ____________________________________________________________________________

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -1730,6 +1730,7 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataLongerWay) {
   config.addSortMetadata = false;
   config.addWayNodeOrder = true;
   config.addWayNodeSpatialMetadata = true;
+  config.addAreaWayLinestrings = true;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();

--- a/tests/osm/Way.cpp
+++ b/tests/osm/Way.cpp
@@ -186,6 +186,90 @@ TEST(OSM_Way, FromClosedWayWithDuplicateNodes) {
 }
 
 // ____________________________________________________________________________
+TEST(OSM_Way, isAreaFalseForClosedWayWithoutArea) {
+    // Create osmium object
+    const size_t initial_buffer_size = 10000;
+    osmium::memory::Buffer buffer{initial_buffer_size,
+                                  osmium::memory::Buffer::auto_grow::yes};
+    osmium::builder::add_way(buffer, osmium::builder::attr::_id(42),
+                             osmium::builder::attr::_nodes({
+                                 {1, {48.0, 7.51}},
+                                 {2, {48.1, 7.61}},
+                                 {1, {48.0, 7.51}},
+                             }));
+
+    // Create osm2rdf object from osmium object
+    const osm2rdf::osm::Way w{buffer.get<osmium::Way>(0)};
+    ASSERT_TRUE(w.closed());
+
+    ASSERT_FALSE(w.isArea());
+}
+
+// ____________________________________________________________________________
+TEST(OSM_Way, isAreaFalseForOpenWay) {
+  // Create osmium object
+  const size_t initial_buffer_size = 10000;
+  osmium::memory::Buffer buffer{initial_buffer_size,
+                                osmium::memory::Buffer::auto_grow::yes};
+  osmium::builder::add_way(buffer, osmium::builder::attr::_id(42),
+                           osmium::builder::attr::_nodes({
+                               {1, {48.0, 7.51}},
+                               {2, {48.0, 7.61}},
+                               {1, {48.1, 7.61}},
+                               {1, {48.1, 7.51}},
+                           }));
+
+  // Create osm2rdf object from osmium object
+  const osm2rdf::osm::Way w{buffer.get<osmium::Way>(0)};
+  ASSERT_FALSE(w.closed());
+
+  ASSERT_FALSE(w.isArea());
+}
+
+// ____________________________________________________________________________
+TEST(OSM_Way, isAreaTrueForTriangle) {
+  // Create osmium object
+  const size_t initial_buffer_size = 10000;
+  osmium::memory::Buffer buffer{initial_buffer_size,
+                                osmium::memory::Buffer::auto_grow::yes};
+  osmium::builder::add_way(buffer, osmium::builder::attr::_id(42),
+                           osmium::builder::attr::_nodes({
+                               {1, {48.0, 7.51}},
+                               {2, {48.0, 7.61}},
+                               {1, {48.1, 7.61}},
+                               {1, {48.0, 7.51}},
+                           }));
+
+  // Create osm2rdf object from osmium object
+  const osm2rdf::osm::Way w{buffer.get<osmium::Way>(0)};
+  ASSERT_TRUE(w.closed());
+
+  ASSERT_TRUE(w.isArea());
+}
+
+// ____________________________________________________________________________
+TEST(OSM_Way, isAreaFalseForTriangleMarkedAsNoArea) {
+  // Create osmium object
+  const size_t initial_buffer_size = 10000;
+  osmium::memory::Buffer buffer{initial_buffer_size,
+                                osmium::memory::Buffer::auto_grow::yes};
+  osmium::builder::add_way(buffer, osmium::builder::attr::_id(42),
+                           osmium::builder::attr::_nodes({
+                               {1, {48.0, 7.51}},
+                               {2, {48.0, 7.61}},
+                               {1, {48.1, 7.61}},
+                               {1, {48.0, 7.51}},
+                           }),
+                           osmium::builder::attr::_tag("area", "no"));
+
+  // Create osm2rdf object from osmium object
+  const osm2rdf::osm::Way w{buffer.get<osmium::Way>(0)};
+  ASSERT_TRUE(w.closed());
+
+  ASSERT_FALSE(w.isArea());
+}
+
+// ____________________________________________________________________________
 TEST(OSM_Way, equalsOperator) {
   // Create osmium object
   const size_t initial_buffer_size = 10000;


### PR DESCRIPTION
Dump ways which represent areas only as MULTIPOLYGON.
Add option to restore the old behavior by adding LINESTRING representations explicitly.