### PR TITLE
Remove obsolete nodedata

### DIFF
--- a/include/osm2rdf/osm/GeometryHandler.h
+++ b/include/osm2rdf/osm/GeometryHandler.h
@@ -57,7 +57,6 @@ struct GeomRelationStats {
   size_t _skippedByBoxIdIntersectCutout = 0;
   size_t _skippedByContainedInInnerRing = 0;
   size_t _skippedByBorderContained = 0;
-  size_t _skippedByNodeContained = 0;
   size_t _skippedByInner = 0;
   size_t _skippedByOuter = 0;
   size_t _skippedByBox = 0;
@@ -79,7 +78,6 @@ struct GeomRelationStats {
     _skippedByOrientedBox += lh._skippedByOrientedBox;
     _skippedByConvexHull += lh._skippedByConvexHull;
     _skippedByBorderContained += lh._skippedByBorderContained;
-    _skippedByNodeContained += lh._skippedByNodeContained;
     return *this;
   }
 
@@ -96,7 +94,6 @@ struct GeomRelationStats {
   void skippedByOrientedBox() { _skippedByOrientedBox++; }
   void skippedByConvexHull() { _skippedByConvexHull++; }
   void skippedByBorderContained() { _skippedByBorderContained++; }
-  void skippedByNodeContained() { _skippedByNodeContained++; }
   void fullCheck() { _fullChecks++; }
 
   [[nodiscard]] std::string printPercNum(size_t n) const {
@@ -145,9 +142,6 @@ struct GeomRelationStats {
   }
   [[nodiscard]] std::string printSkippedByOuter() const {
     return printPercNum(_skippedByOuter);
-  }
-  [[nodiscard]] std::string printSkippedByNodeContained() const {
-    return printPercNum(_skippedByNodeContained);
   }
   [[nodiscard]] std::string printFullChecks() const {
     return printPercNum(_fullChecks);

--- a/include/osm2rdf/osm/GeometryHandler.h
+++ b/include/osm2rdf/osm/GeometryHandler.h
@@ -299,7 +299,7 @@ class GeometryHandler {
   FRIEND_TEST(OSM_GeometryHandler, dumpUnnamedAreaRelationsSimpleContainsOnly);
 
   // Calculate relations for each node.
-  NodesContainedInAreasData dumpNodeRelations();
+  void dumpNodeRelations();
   FRIEND_TEST(OSM_GeometryHandler, noNodeGeometricRelations);
   FRIEND_TEST(OSM_GeometryHandler, dumpNodeRelationsEmpty1);
   FRIEND_TEST(OSM_GeometryHandler, dumpNodeRelationsEmpty2);
@@ -307,8 +307,7 @@ class GeometryHandler {
   FRIEND_TEST(OSM_GeometryHandler, dumpNodeRelationsSimpleContains);
 
   // Calculate relations for each way.
-  void dumpWayRelations(
-      const osm2rdf::osm::NodesContainedInAreasData& nodeData);
+  void dumpWayRelations();
   FRIEND_TEST(OSM_GeometryHandler, noWayGeometricRelations);
   FRIEND_TEST(OSM_GeometryHandler, dumpWayRelationsEmpty1);
   FRIEND_TEST(OSM_GeometryHandler, dumpWayRelationsEmpty2);

--- a/tests/osm/GeometryHandler.cpp
+++ b/tests/osm/GeometryHandler.cpp
@@ -1794,8 +1794,7 @@ TEST(OSM_GeometryHandler, dumpNodeRelationsSimpleIntersects) {
   gh.prepareRTree();
   gh.prepareDAG();
 
-  const auto nd = gh.dumpNodeRelations();
-  ASSERT_EQ(1, nd.size());
+  gh.dumpNodeRelations();
 
   output.flush();
   output.close();
@@ -1915,8 +1914,7 @@ TEST(OSM_GeometryHandler, dumpNodeRelationsSimpleContains) {
   gh.prepareRTree();
   gh.prepareDAG();
 
-  const auto nd = gh.dumpNodeRelations();
-  ASSERT_EQ(1, nd.size());
+  gh.dumpNodeRelations();
 
   output.flush();
   output.close();
@@ -1956,7 +1954,7 @@ TEST(OSM_GeometryHandler, noWayGeometricRelations) {
   gh.prepareRTree();
   gh.prepareDAG();
 
-  gh.dumpWayRelations(osm2rdf::osm::NodesContainedInAreasData{});
+  gh.dumpWayRelations();
 
   output.flush();
   output.close();
@@ -1992,7 +1990,7 @@ TEST(OSM_GeometryHandler, dumpWayRelationsEmpty1) {
   gh.prepareRTree();
   gh.prepareDAG();
 
-  gh.dumpWayRelations(osm2rdf::osm::NodesContainedInAreasData{});
+  gh.dumpWayRelations();
 
   output.flush();
   output.close();
@@ -2088,7 +2086,7 @@ TEST(OSM_GeometryHandler, dumpWayRelationsEmpty2) {
   gh.prepareRTree();
   gh.prepareDAG();
 
-  gh.dumpWayRelations(osm2rdf::osm::NodesContainedInAreasData{});
+  gh.dumpWayRelations();
 
   output.flush();
   output.close();
@@ -2207,7 +2205,7 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleIntersects) {
   gh.prepareRTree();
   gh.prepareDAG();
 
-  gh.dumpWayRelations(osm2rdf::osm::NodesContainedInAreasData{});
+  gh.dumpWayRelations();
 
   output.flush();
   output.close();
@@ -2331,7 +2329,7 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleContains) {
   gh.prepareRTree();
   gh.prepareDAG();
 
-  gh.dumpWayRelations(osm2rdf::osm::NodesContainedInAreasData{});
+  gh.dumpWayRelations();
 
   output.flush();
   output.close();
@@ -2465,9 +2463,8 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleIntersectsWithNodeInfo) {
   gh.prepareRTree();
   gh.prepareDAG();
 
-  const auto nd = gh.dumpNodeRelations();
-  ASSERT_EQ(2, nd.size());
-  gh.dumpWayRelations(nd);
+  gh.dumpNodeRelations();
+  gh.dumpWayRelations();
 
   output.flush();
   output.close();
@@ -2614,9 +2611,8 @@ TEST(OSM_GeometryHandler, dumpWayRelationsSimpleContainsWithNodeInfo) {
   gh.prepareRTree();
   gh.prepareDAG();
 
-  const auto nd = gh.dumpNodeRelations();
-  ASSERT_EQ(1, nd.size());
-  gh.dumpWayRelations(nd);
+  gh.dumpNodeRelations();
+  gh.dumpWayRelations();
 
   output.flush();
   output.close();


### PR DESCRIPTION
This reduces the memory footprint as better algorithmic solutions are now implemented and the (huge) lookup-table has now next to no benefit on speed but a huge memory penality.