### PR TITLE
First step fixing duplicate ogc triples

### DIFF
--- a/include/osm2rdf/osm/GeometryHandler.h
+++ b/include/osm2rdf/osm/GeometryHandler.h
@@ -357,12 +357,12 @@ class GeometryHandler {
 
   void writeTransitiveClosure(
       const std::vector<osm2rdf::osm::Area::id_t>& successors,
-      const std::string& entryIRI, const std::string& rel,
+      const SkipSet& skip, const std::string& entryIRI, const std::string& rel,
       const std::string& symmRel);
 
   void writeTransitiveClosure(
       const std::vector<osm2rdf::osm::Area::id_t>& successors,
-      const std::string& entryIRI, const std::string& rel);
+      const SkipSet& skip, const std::string& entryIRI, const std::string& rel);
 
   void getBoxIds(
       const osm2rdf::geometry::Area& area, const osm2rdf::geometry::Area& inner,


### PR DESCRIPTION
This PR removes duplicate `ogc:` triples when `writeTransitiveClosure` is used. It does not fix duplicate triples which are generated in `dumpNamedAreaRelations`.