### PR TITLE
Reduce memory usage during DAG build

### DIFF
--- a/include/osm2rdf/osm/GeometryHandler.h
+++ b/include/osm2rdf/osm/GeometryHandler.h
@@ -208,7 +208,7 @@ typedef std::tuple<std::vector<osm2rdf::geometry::Box>,
                    osm2rdf::geometry::Polygon, osm2rdf::geometry::Polygon>
     SpatialAreaValue;
 
-typedef std::pair<osm2rdf::geometry::Box, size_t> SpatialAreaRefValue;
+typedef std::pair<osm2rdf::geometry::Box, uint32_t> SpatialAreaRefValue;
 
 typedef std::vector<SpatialAreaValue> SpatialAreaVector;
 
@@ -412,7 +412,7 @@ class GeometryHandler {
   // Store areas as r-tree
   SpatialIndex _spatialIndex;
   // Store dag
-  osm2rdf::util::DirectedGraph<osm2rdf::osm::Area::id_t> _directedAreaGraph;
+  osm2rdf::util::DirectedGraph<uint32_t> _directedAreaGraph;
   // Spatial Data
   SpatialAreaVector _spatialStorageArea;
   std::unordered_map<osm2rdf::osm::Area::id_t, uint64_t>

--- a/include/osm2rdf/util/DirectedAcyclicGraph.h
+++ b/include/osm2rdf/util/DirectedAcyclicGraph.h
@@ -41,10 +41,10 @@ osm2rdf::util::DirectedGraph<T> reduceDAG(
                                 entryCount) default(none)
   for (size_t i = 0; i < vertices.size(); i++) {
     const auto& src = vertices[i];
-    std::vector<T> possibleEdges(sourceDAG.getEdgesFast(src));
+    std::vector<T> possibleEdges(sourceDAG.findSuccessors(src));
     std::vector<T> edges;
-    for (const auto& dst : sourceDAG.getEdgesFast(src)) {
-      const auto& dstEdges = sourceDAG.findSuccessorsFast(dst);
+    for (const auto& dst : sourceDAG.findSuccessors(src)) {
+      const auto& dstEdges = sourceDAG.findSuccessors(dst);
       std::set_difference(possibleEdges.begin(), possibleEdges.end(),
                           dstEdges.begin(), dstEdges.end(),
                           std::back_inserter(edges));

--- a/include/osm2rdf/util/DirectedGraph.h
+++ b/include/osm2rdf/util/DirectedGraph.h
@@ -57,8 +57,6 @@ class DirectedGraph {
   [[nodiscard]] std::vector<T> getVertices() const;
   // getEdges returns the stored edges for the given vertex.
   [[nodiscard]] std::vector<T> getEdges(T src) const;
-  // getEdges returns the stored edges but uses "fast" storage for lookup.
-  [[nodiscard]] std::vector<T> getEdgesFast(T src) const;
 
  protected:
   void findSuccessorsHelper(T src, std::vector<T>* tmp) const;

--- a/include/osm2rdf/util/DirectedGraph.h
+++ b/include/osm2rdf/util/DirectedGraph.h
@@ -22,7 +22,7 @@
 #include <stdint.h>
 
 #include <filesystem>
-#include <unordered_map>
+#include <map>
 #include <vector>
 
 namespace osm2rdf::util {
@@ -62,8 +62,8 @@ class DirectedGraph {
 
  protected:
   void findSuccessorsHelper(T src, std::vector<T>* tmp) const;
-  std::unordered_map<T, std::vector<T>> _adjacency;
-  std::unordered_map<T, std::vector<T>> _successors;
+  std::map<T, std::vector<T>> _adjacency;
+  std::map<T, std::vector<T>> _successors;
   size_t _numEdges = 0;
   bool _preparedFast = false;
 };

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -58,6 +58,8 @@ using osm2rdf::ttl::constants::IRI__OPENGIS_INTERSECTS;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_AREA;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA;
+
+
 using osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA;
 using osm2rdf::ttl::constants::NAMESPACE__OSM_NODE;
 using osm2rdf::ttl::constants::NAMESPACE__OSM_WAY;
@@ -563,12 +565,6 @@ void GeometryHandler<W>::prepareDAG() {
   // Store dag
   {
     DirectedGraph<Area::id_t> tmpDirectedAreaGraph;
-    // Prepare id based lookup table for later usage...
-    _spatialStorageAreaIndex.reserve(_spatialStorageArea.size());
-    for (size_t i = 0; i < _spatialStorageArea.size(); ++i) {
-      const auto& area = _spatialStorageArea[i];
-      _spatialStorageAreaIndex[std::get<1>(area)] = i;
-    }
 
     std::cerr << currentTimeFormatted() << " Generating non-reduced DAG from "
               << _spatialStorageArea.size() << " areas ... " << std::endl;
@@ -702,9 +698,9 @@ void GeometryHandler<W>::prepareDAG() {
                 << std::endl;
 
       // Prepare non-reduced DAG for cleanup
-      tmpDirectedAreaGraph.prepareFindSuccessorsFast();
-      std::cerr << currentTimeFormatted() << " ... fast lookup prepared ... "
-                << std::endl;
+      // tmpDirectedAreaGraph.prepareFindSuccessorsFast();
+      // std::cerr << currentTimeFormatted() << " ... fast lookup prepared ... "
+                // << std::endl;
 
       _directedAreaGraph = osm2rdf::util::reduceDAG(tmpDirectedAreaGraph, true);
 
@@ -729,6 +725,13 @@ void GeometryHandler<W>::prepareDAG() {
               << " Preparing fast above lookup in DAG ..." << std::endl;
     _directedAreaGraph.prepareFindSuccessorsFast();
     std::cerr << currentTimeFormatted() << " ... done" << std::endl;
+  }
+
+  // Prepare id based lookup table for later usage...
+  _spatialStorageAreaIndex.reserve(_spatialStorageArea.size());
+  for (size_t i = 0; i < _spatialStorageArea.size(); ++i) {
+    const auto& area = _spatialStorageArea[i];
+    _spatialStorageAreaIndex[std::get<1>(area)] = i;
   }
 }
 

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -58,7 +58,6 @@ using osm2rdf::ttl::constants::IRI__OPENGIS_INTERSECTS;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_AREA;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA;
-
 using osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA;
 using osm2rdf::ttl::constants::NAMESPACE__OSM_NODE;
 using osm2rdf::ttl::constants::NAMESPACE__OSM_WAY;

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -561,8 +561,8 @@ void GeometryHandler<W>::prepareRTree() {
 template <typename W>
 void GeometryHandler<W>::prepareDAG() {
   // Store dag
-  DirectedGraph<Area::id_t> tmpDirectedAreaGraph;
   {
+    DirectedGraph<Area::id_t> tmpDirectedAreaGraph;
     // Prepare id based lookup table for later usage...
     _spatialStorageAreaIndex.reserve(_spatialStorageArea.size());
     for (size_t i = 0; i < _spatialStorageArea.size(); ++i) {
@@ -685,34 +685,36 @@ void GeometryHandler<W>::prepareDAG() {
               << stats.printFullChecks() << " by full geometric check"
 
               << std::endl;
-  }
-  if (_config.writeDAGDotFiles) {
-    std::cerr << currentTimeFormatted() << " Dumping non-reduced DAG as "
-              << _config.output << ".non-reduced.dot ..." << std::endl;
-    std::filesystem::path p{_config.output};
-    p += ".non-reduced.dot";
-    tmpDirectedAreaGraph.dump(p);
-    std::cerr << currentTimeFormatted() << " done" << std::endl;
-  }
-  {
-    std::cerr << std::endl;
-    std::cerr << currentTimeFormatted() << " Reducing DAG with "
-              << tmpDirectedAreaGraph.getNumEdges() << " edges and "
-              << tmpDirectedAreaGraph.getNumVertices() << " vertices ... "
-              << std::endl;
 
-    // Prepare non-reduced DAG for cleanup
-    tmpDirectedAreaGraph.prepareFindSuccessorsFast();
-    std::cerr << currentTimeFormatted() << " ... fast lookup prepared ... "
-              << std::endl;
+    if (_config.writeDAGDotFiles) {
+      std::cerr << currentTimeFormatted() << " Dumping non-reduced DAG as "
+                << _config.output << ".non-reduced.dot ..." << std::endl;
+      std::filesystem::path p{_config.output};
+      p += ".non-reduced.dot";
+      tmpDirectedAreaGraph.dump(p);
+      std::cerr << currentTimeFormatted() << " done" << std::endl;
+    }
+    {
+      std::cerr << std::endl;
+      std::cerr << currentTimeFormatted() << " Reducing DAG with "
+                << tmpDirectedAreaGraph.getNumEdges() << " edges and "
+                << tmpDirectedAreaGraph.getNumVertices() << " vertices ... "
+                << std::endl;
 
-    _directedAreaGraph = osm2rdf::util::reduceDAG(tmpDirectedAreaGraph, true);
+      // Prepare non-reduced DAG for cleanup
+      tmpDirectedAreaGraph.prepareFindSuccessorsFast();
+      std::cerr << currentTimeFormatted() << " ... fast lookup prepared ... "
+                << std::endl;
 
-    std::cerr << currentTimeFormatted() << " ... done, resulting in DAG with "
-              << _directedAreaGraph.getNumEdges() << " edges and "
-              << _directedAreaGraph.getNumVertices() << " vertices"
-              << std::endl;
+      _directedAreaGraph = osm2rdf::util::reduceDAG(tmpDirectedAreaGraph, true);
+
+      std::cerr << currentTimeFormatted() << " ... done, resulting in DAG with "
+                << _directedAreaGraph.getNumEdges() << " edges and "
+                << _directedAreaGraph.getNumVertices() << " vertices"
+                << std::endl;
+    }
   }
+
   if (_config.writeDAGDotFiles) {
     std::cerr << currentTimeFormatted() << " Dumping DAG as " << _config.output
               << ".dot ..." << std::endl;

--- a/src/util/DirectedGraph.cpp
+++ b/src/util/DirectedGraph.cpp
@@ -45,7 +45,7 @@ std::vector<T> osm2rdf::util::DirectedGraph<T>::findSuccessors(T src) const {
   q.push(src);
 
   while (!q.empty()) {
-    const auto& cur = q.front();
+    auto cur = q.front();
     visited.insert(cur);
     q.pop();
 

--- a/src/util/DirectedGraph.cpp
+++ b/src/util/DirectedGraph.cpp
@@ -133,8 +133,8 @@ void osm2rdf::util::DirectedGraph<T>::dumpOsm(
 template <typename T>
 void osm2rdf::util::DirectedGraph<T>::prepareFindSuccessorsFast() {
   const auto& vertices = getVertices();
-  for (size_t i = 0; i < vertices.size(); i++) {
-    _successors[vertices[i]] = findSuccessors(vertices[i]);
+  for (const auto& [key, _] : _adjacency) {
+    _successors[key] = findSuccessors(key);
   }
   _preparedFast = true;
 }

--- a/src/util/DirectedGraph.cpp
+++ b/src/util/DirectedGraph.cpp
@@ -16,14 +16,16 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "osm2rdf/util/DirectedGraph.h"
-
 #include <stdint.h>
 
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <set>
+#include <queue>
+
+#include "osm2rdf/util/DirectedGraph.h"
 
 // ____________________________________________________________________________
 template <typename T>
@@ -38,31 +40,33 @@ void osm2rdf::util::DirectedGraph<T>::addEdge(T src, T dst) {
 // ____________________________________________________________________________
 template <typename T>
 std::vector<T> osm2rdf::util::DirectedGraph<T>::findSuccessors(T src) const {
+  std::queue<T> q;
+  std::set<T> visited;
+  q.push(src);
+
+  while (!q.empty()) {
+    const auto& cur = q.front();
+    visited.insert(cur);
+    q.pop();
+
+    const auto& entry = _adjacency.find(cur);
+    if (entry == _adjacency.end()) {
+      continue;
+    }
+
+    for (const auto& nd : entry->second) {
+      if (visited.find(nd) == visited.end()) q.push(nd);
+    }
+  }
+
+  visited.erase(src);
+
   std::vector<T> tmp;
-  // Collect parents
-  findSuccessorsHelper(src, &tmp);
-  // Make unique
-  std::sort(tmp.begin(), tmp.end());
-  const auto it2 = std::unique(tmp.begin(), tmp.end());
-  tmp.resize(std::distance(tmp.begin(), it2));
+  tmp.reserve(visited.size());
+  tmp.insert(tmp.end(), visited.begin(), visited.end());
+
+  // guaranteed to be sorted
   return tmp;
-}
-
-// ____________________________________________________________________________
-template <typename T>
-void osm2rdf::util::DirectedGraph<T>::findSuccessorsHelper(
-    T src, std::vector<T>* tmp) const {
-  const auto& entry = _adjacency.find(src);
-  if (entry == _adjacency.end()) {
-    return;
-  }
-
-  // Copy direct successors.
-  tmp->insert(tmp->end(), entry->second.begin(), entry->second.end());
-  // Recursively add all successors.
-  for (const auto& dst : entry->second) {
-    findSuccessorsHelper(dst, tmp);
-  }
 }
 
 // ____________________________________________________________________________
@@ -165,15 +169,6 @@ std::vector<T> osm2rdf::util::DirectedGraph<T>::getVertices() const {
 template <typename T>
 std::vector<T> osm2rdf::util::DirectedGraph<T>::getEdges(T src) const {
   return _adjacency.at(src);
-}
-
-// ____________________________________________________________________________
-template <typename T>
-std::vector<T> osm2rdf::util::DirectedGraph<T>::getEdgesFast(T src) const {
-  if (!_preparedFast) {
-    throw std::runtime_error("findSuccessorsFast not prepared");
-  }
-  return _successors.at(src);
 }
 
 // ____________________________________________________________________________

--- a/tests/osm/GeometryHandler.cpp
+++ b/tests/osm/GeometryHandler.cpp
@@ -828,10 +828,10 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimple) {
   ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{28},
             gh._directedAreaGraph.getEdges(24));
 
-  ASSERT_EQ(2, gh._directedAreaGraph.findSuccessors(22).size());
-  ASSERT_EQ(1, gh._directedAreaGraph.findSuccessors(24).size());
-  ASSERT_EQ(2, gh._directedAreaGraph.findSuccessors(26).size());
-  ASSERT_EQ(0, gh._directedAreaGraph.findSuccessors(28).size());
+  ASSERT_EQ(2, gh._directedAreaGraph.findSuccesorsFast(22).size());
+  ASSERT_EQ(1, gh._directedAreaGraph.findSuccesorsFast(24).size());
+  ASSERT_EQ(2, gh._directedAreaGraph.findSuccesorsFast(26).size());
+  ASSERT_EQ(0, gh._directedAreaGraph.findSuccesorsFast(28).size());
 
   gh.dumpNamedAreaRelations();
 

--- a/tests/osm/GeometryHandler.cpp
+++ b/tests/osm/GeometryHandler.cpp
@@ -828,10 +828,10 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimple) {
   ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{28},
             gh._directedAreaGraph.getEdges(24));
 
-  ASSERT_EQ(2, gh._directedAreaGraph.getEdgesFast(22).size());
-  ASSERT_EQ(1, gh._directedAreaGraph.getEdgesFast(24).size());
-  ASSERT_EQ(2, gh._directedAreaGraph.getEdgesFast(26).size());
-  ASSERT_EQ(0, gh._directedAreaGraph.getEdgesFast(28).size());
+  ASSERT_EQ(2, gh._directedAreaGraph.findSuccessors(22).size());
+  ASSERT_EQ(1, gh._directedAreaGraph.findSuccessors(24).size());
+  ASSERT_EQ(2, gh._directedAreaGraph.findSuccessors(26).size());
+  ASSERT_EQ(0, gh._directedAreaGraph.findSuccessors(28).size());
 
   gh.dumpNamedAreaRelations();
 

--- a/tests/osm/GeometryHandler.cpp
+++ b/tests/osm/GeometryHandler.cpp
@@ -622,8 +622,8 @@ TEST(OSM_GeometryHandler, prepareDAGSimple) {
                             osmium::builder::attr::_outer_ring({
                                 {1, {40.0, 7.51}},
                                 {2, {40.0, 7.61}},
-                                {3, {40.1, 7.61}},
-                                {4, {40.1, 7.51}},
+                                {3, {40.2, 7.61}},
+                                {4, {40.2, 7.51}},
                                 {1, {40.0, 7.51}},
                             }));
   osmium::builder::add_area(osmiumBuffer4, osmium::builder::attr::_id(28),
@@ -663,12 +663,12 @@ TEST(OSM_GeometryHandler, prepareDAGSimple) {
   ASSERT_EQ(4, gh._directedAreaGraph.getNumVertices());
   ASSERT_EQ(3, gh._directedAreaGraph.getNumEdges());
 
-  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{24},
-            gh._directedAreaGraph.getEdges(22));
-  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{24},
-            gh._directedAreaGraph.getEdges(26));
-  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{28},
-            gh._directedAreaGraph.getEdges(24));
+  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{1},
+            gh._directedAreaGraph.getEdges(3));
+  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{1},
+            gh._directedAreaGraph.getEdges(2));
+  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{0},
+            gh._directedAreaGraph.getEdges(1));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -776,8 +776,8 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimple) {
                             osmium::builder::attr::_outer_ring({
                                 {1, {40.0, 7.51}},
                                 {2, {40.0, 7.61}},
-                                {3, {40.1, 7.61}},
-                                {4, {40.1, 7.51}},
+                                {3, {40.2, 7.61}},
+                                {4, {40.2, 7.51}},
                                 {1, {40.0, 7.51}},
                             }));
   osmium::builder::add_area(osmiumBuffer4, osmium::builder::attr::_id(28),
@@ -793,8 +793,8 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimple) {
                             osmium::builder::attr::_tag("name", "30"),
                             osmium::builder::attr::_outer_ring({
                                 {1, {48.0, 7.51}},
-                                {2, {48.0, 7.71}},
-                                {3, {48.05, 7.71}},
+                                {2, {48.0, 7.81}},
+                                {3, {48.05, 7.81}},
                                 {4, {48.05, 7.51}},
                                 {1, {48.0, 7.51}},
                             }));
@@ -821,17 +821,18 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimple) {
   gh.prepareRTree();
   gh.prepareDAG();
 
-  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{24},
-            gh._directedAreaGraph.getEdges(22));
-  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{24},
-            gh._directedAreaGraph.getEdges(26));
-  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{28},
-            gh._directedAreaGraph.getEdges(24));
+  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{1},
+            gh._directedAreaGraph.getEdges(4));
+  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{1},
+            gh._directedAreaGraph.getEdges(2));
+  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{0},
+            gh._directedAreaGraph.getEdges(1));
 
-  ASSERT_EQ(2, gh._directedAreaGraph.findSuccesorsFast(22).size());
-  ASSERT_EQ(1, gh._directedAreaGraph.findSuccesorsFast(24).size());
-  ASSERT_EQ(2, gh._directedAreaGraph.findSuccesorsFast(26).size());
-  ASSERT_EQ(0, gh._directedAreaGraph.findSuccesorsFast(28).size());
+  ASSERT_EQ(2, gh._directedAreaGraph.findSuccessors(4).size());
+  ASSERT_EQ(2, gh._directedAreaGraph.findSuccessors(3).size());
+  ASSERT_EQ(2, gh._directedAreaGraph.findSuccessors(2).size());
+  ASSERT_EQ(1, gh._directedAreaGraph.findSuccessors(1).size());
+  ASSERT_EQ(0, gh._directedAreaGraph.findSuccessors(0).size());
 
   gh.dumpNamedAreaRelations();
 
@@ -972,8 +973,8 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimpleOpenMP) {
                             osmium::builder::attr::_outer_ring({
                                 {1, {40.0, 7.51}},
                                 {2, {40.0, 7.61}},
-                                {3, {40.1, 7.61}},
-                                {4, {40.1, 7.51}},
+                                {3, {40.2, 7.61}},
+                                {4, {40.2, 7.51}},
                                 {1, {40.0, 7.51}},
                             }));
   osmium::builder::add_area(osmiumBuffer4, osmium::builder::attr::_id(28),
@@ -1005,12 +1006,17 @@ TEST(OSM_GeometryHandler, dumpNamedAreaRelationsSimpleOpenMP) {
   gh.prepareRTree();
   gh.prepareDAG();
 
-  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{24},
-            gh._directedAreaGraph.getEdges(22));
-  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{24},
-            gh._directedAreaGraph.getEdges(26));
-  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{28},
-            gh._directedAreaGraph.getEdges(24));
+  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{1},
+            gh._directedAreaGraph.getEdges(3));
+  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{1},
+            gh._directedAreaGraph.getEdges(2));
+  ASSERT_EQ(std::vector<osm2rdf::osm::Area::id_t>{0},
+            gh._directedAreaGraph.getEdges(1));
+
+  ASSERT_EQ(2, gh._directedAreaGraph.findSuccessors(3).size());
+  ASSERT_EQ(2, gh._directedAreaGraph.findSuccessors(2).size());
+  ASSERT_EQ(1, gh._directedAreaGraph.findSuccessors(1).size());
+  ASSERT_EQ(0, gh._directedAreaGraph.findSuccessors(0).size());
 
   gh.dumpNamedAreaRelations();
 


### PR DESCRIPTION
 The latest `planet.osm` run for https://osm2rdf.cs.uni-freiburg.de failed because the OOM killer killed `osm2rdf` during the fast-lookup preparation of the reduced DAG.

I implemented the following things to (hopefully) reduce the memory usage during this stage. Until this PR is merged, **this branch is used for the weekly builds**.

1.  Use a `std::map` to hold both the adjacency lists and the fast lookup cache (a bit slower, but lower memory overhead than `std::unordered_map`)
2.   Better scoping during DAG build to destroy the temporary full DAG before the fast lookup processing is started on the new reduced graph. Previously, the complete *unreduced* temporary DAG together with its fast lookup cache was still in memory during the fast lookup preparation on the *reduced* DAG. Now, the destructor of the temporary graph is called before this stage, freeing memory.
3.   Don't use an intermediate vector of all node IDs in `prepareFindSuccessorsFast()`, iterate over the adjacency list directly