### PR TITLE
Do not output GEOMETRYCOLLECTION geometry for relations which are areas

### DIFF
--- a/include/osm2rdf/osm/Relation.h
+++ b/include/osm2rdf/osm/Relation.h
@@ -45,6 +45,7 @@ class Relation {
       const noexcept;
   [[nodiscard]] const osm2rdf::osm::TagList& tags() const noexcept;
   [[nodiscard]] bool hasCompleteGeometry() const noexcept;
+  [[nodiscard]] bool isArea() const noexcept;
 #if BOOST_VERSION >= 107800
   [[nodiscard]] bool hasGeometry() const noexcept;
   [[nodiscard]] const osm2rdf::geometry::Box& envelope() const noexcept;

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -203,7 +203,7 @@ void osm2rdf::osm::FactHandler<W>::relation(
   }
 
 #if BOOST_VERSION >= 107800
-  if (relation.hasGeometry()) {
+  if (relation.hasGeometry() && !relation.isArea()) {
     if (!_config.hasGeometryAsWkt) {
       const std::string& geomObj = _writer->generateIRI(
           NAMESPACE__OSM2RDF_GEOM, "relation_" + std::to_string(relation.id()));

--- a/src/osm/Relation.cpp
+++ b/src/osm/Relation.cpp
@@ -57,6 +57,15 @@ const osm2rdf::osm::TagList& osm2rdf::osm::Relation::tags() const noexcept {
 }
 
 // ____________________________________________________________________________
+bool osm2rdf::osm::Relation::isArea() const noexcept {
+  const auto& typeTag = _tags.find("type");
+  if (typeTag != _tags.end()) {
+    return typeTag->second == "multipolygon" || typeTag->second == "boundary";
+  }
+  return false;
+}
+
+// ____________________________________________________________________________
 const std::vector<osm2rdf::osm::RelationMember>&
 osm2rdf::osm::Relation::members() const noexcept {
   return _members;


### PR DESCRIPTION
In https://github.com/ad-freiburg/osm2rdf/commit/efc743168ccd9aad62a926666bd87261e63f9e37, we fixed the issue of areas always having two geometries (the area POLYGON, and the original way linestring).

This PR introduceds this behavior for relations also. Here, a simply check whether the polygon has `type=boundary` or `type=multipolygon` suffices.

This should fix this issue, again raised in https://github.com/ad-freiburg/qlever/issues/1217