### PR TITLE
Improve progress bar for second pass

### DIFF
--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -49,6 +49,7 @@ struct Config {
   bool noGeometricRelations = false;
   bool noAreaGeometricRelations = false;
   bool noNodeGeometricRelations = false;
+  bool noRelationGeometricRelations = false;
   bool noWayGeometricRelations = false;
   double simplifyGeometries = 0;
 

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -152,6 +152,13 @@ const static inline std::string NO_RELATION_FACTS_OPTION_LONG =
     "no-relation-facts";
 const static inline std::string NO_RELATION_FACTS_OPTION_HELP =
     "Do not dump relation facts";
+const static inline std::string NO_RELATION_GEOM_RELATIONS_INFO =
+    "Ignoring relation geometric relations";
+const static inline std::string NO_RELATION_GEOM_RELATIONS_OPTION_SHORT = "";
+const static inline std::string NO_RELATION_GEOM_RELATIONS_OPTION_LONG =
+    "no-relation-geometric-relations";
+const static inline std::string NO_RELATION_GEOM_RELATIONS_OPTION_HELP =
+    "Do not dump relation geometric relations";
 
 const static inline std::string NO_WAY_OPTION_SHORT = "";
 const static inline std::string NO_WAY_OPTION_LONG = "no-ways";

--- a/include/osm2rdf/osm/CountHandler.h
+++ b/include/osm2rdf/osm/CountHandler.h
@@ -1,0 +1,46 @@
+// Copyright 2024, University of Freiburg
+// Authors: Axel Lehmann <lehmann@cs.uni-freiburg.de>.
+
+// This file is part of osm2rdf.
+//
+// osm2rdf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// osm2rdf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef OSM2RDF_OSM_COUNTHANDLER_H
+#define OSM2RDF_OSM_COUNTHANDLER_H
+
+#include "osm2rdf/config/Config.h"
+#include "osm2rdf/osm/LocationHandler.h"
+
+namespace osm2rdf::osm {
+
+class CountHandler : public osmium::handler::Handler {
+ public:
+  void node(const osmium::Node& node);
+  void relation(const osmium::Relation& relation);
+  void way(const osmium::Way& way);
+  void prepare_for_lookup();
+
+  size_t numNodes() const;
+  size_t numRelations() const;
+  size_t numWays() const;
+
+ protected:
+  size_t _numNodes = 0;
+  size_t _numRelations = 0;
+  size_t _numWays = 0;
+  bool _firstPassDone = false;
+};
+}
+
+#endif  // OSM2RDF_OSM_RELATIONHANDLER_H

--- a/include/osm2rdf/osm/OsmiumHandler.h
+++ b/include/osm2rdf/osm/OsmiumHandler.h
@@ -24,6 +24,7 @@
 #include "osm2rdf/osm/FactHandler.h"
 #include "osm2rdf/osm/GeometryHandler.h"
 #include "osm2rdf/ttl/Writer.h"
+#include "osm2rdf/util/ProgressBar.h"
 #include "osmium/handler.hpp"
 #include "osmium/osm/area.hpp"
 #include "osmium/osm/node.hpp"
@@ -61,6 +62,7 @@ class OsmiumHandler : public osmium::handler::Handler {
   osm2rdf::osm::FactHandler<W> _factHandler;
   osm2rdf::osm::GeometryHandler<W> _geometryHandler;
   osm2rdf::osm::RelationHandler _relationHandler;
+  osm2rdf::util::ProgressBar _progressBar;
   size_t _areasSeen = 0;
   size_t _areasDumped = 0;
   size_t _areaGeometriesHandled = 0;
@@ -73,6 +75,8 @@ class OsmiumHandler : public osmium::handler::Handler {
   size_t _waysSeen = 0;
   size_t _waysDumped = 0;
   size_t _wayGeometriesHandled = 0;
+
+  size_t _numTasksDone = 0;
 };
 }  // namespace osm2rdf::osm
 

--- a/include/osm2rdf/util/ProgressBar.h
+++ b/include/osm2rdf/util/ProgressBar.h
@@ -31,6 +31,7 @@ class ProgressBar {
   // Initializes a ProgressBar with given maxValue. If show equals false nothing
   // will be printed to std::cerr when update is called.
   ProgressBar(std::size_t maxValue, bool show);
+  ProgressBar() = default;
   // Updates the progress bar.
   void update(std::size_t count);
   // Marks progress bar as done (calling update with _maxValue).

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -206,6 +206,11 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       oss << "\n"
           << prefix << osm2rdf::config::constants::NO_NODE_GEOM_RELATIONS_INFO;
     }
+    if (noRelationGeometricRelations) {
+      oss << "\n"
+          << prefix
+          << osm2rdf::config::constants::NO_RELATION_GEOM_RELATIONS_INFO;
+    }
     if (noWayGeometricRelations) {
       oss << "\n"
           << prefix << osm2rdf::config::constants::NO_WAY_GEOM_RELATIONS_INFO;
@@ -306,6 +311,11 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
           osm2rdf::config::constants::NO_NODE_GEOM_RELATIONS_OPTION_SHORT,
           osm2rdf::config::constants::NO_NODE_GEOM_RELATIONS_OPTION_LONG,
           osm2rdf::config::constants::NO_NODE_GEOM_RELATIONS_OPTION_HELP);
+  auto noRelationGeometricRelationsOp =
+      parser.add<popl::Switch, popl::Attribute::expert>(
+          osm2rdf::config::constants::NO_RELATION_GEOM_RELATIONS_OPTION_SHORT,
+          osm2rdf::config::constants::NO_RELATION_GEOM_RELATIONS_OPTION_LONG,
+          osm2rdf::config::constants::NO_RELATION_GEOM_RELATIONS_OPTION_HELP);
   auto noWayGeometricRelationsOp =
       parser.add<popl::Switch, popl::Attribute::expert>(
           osm2rdf::config::constants::NO_WAY_GEOM_RELATIONS_OPTION_SHORT,
@@ -537,6 +547,7 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
 
     noAreaGeometricRelations = noAreaGeometricRelationsOp->is_set();
     noNodeGeometricRelations = noNodeGeometricRelationsOp->is_set();
+    noRelationGeometricRelations = noRelationGeometricRelationsOp->is_set();
     noWayGeometricRelations = noWayGeometricRelationsOp->is_set();
 
     if (ogcGeoTriplesModeOp->is_set()) {
@@ -569,11 +580,15 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
       }
     }
 
+    noGeometricRelations =
+        ogcGeoTriplesMode == none && osm2rdfGeoTriplesMode == none;
+
     noAreaFacts |= noAreasOp->is_set();
     noAreaGeometricRelations |= noAreasOp->is_set();
     noNodeFacts |= noNodesOp->is_set();
     noNodeGeometricRelations |= noNodesOp->is_set();
     noRelationFacts |= noRelationsOp->is_set();
+    noRelationGeometricRelations |= noWaysOp->is_set();
     noWayFacts |= noWaysOp->is_set();
     noWayGeometricRelations |= noWaysOp->is_set();
 

--- a/src/osm/CountHandler.cpp
+++ b/src/osm/CountHandler.cpp
@@ -1,0 +1,65 @@
+// Copyright 2024, University of Freiburg
+// Authors: Axel Lehmann <lehmann@cs.uni-freiburg.de>.
+
+// This file is part of osm2rdf.
+//
+// osm2rdf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// osm2rdf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "osm2rdf/osm/CountHandler.h"
+
+#include <iostream>
+
+// ____________________________________________________________________________
+void osm2rdf::osm::CountHandler::prepare_for_lookup() {
+  _firstPassDone = true;
+}
+
+// ____________________________________________________________________________
+void osm2rdf::osm::CountHandler::node(const osmium::Node& /*unused*/){
+  if (_firstPassDone) {
+    return;
+  }
+  _numNodes++;
+}
+
+// ____________________________________________________________________________
+void osm2rdf::osm::CountHandler::relation(const osmium::Relation& /*unused*/) {
+  if (_firstPassDone) {
+    return;
+  }
+  _numRelations++;
+}
+
+// ____________________________________________________________________________
+void osm2rdf::osm::CountHandler::way(const osmium::Way& /*unused*/) {
+  if (_firstPassDone) {
+    return;
+  }
+  _numWays++;
+}
+
+// ____________________________________________________________________________
+size_t osm2rdf::osm::CountHandler::numNodes() const {
+  return _numNodes;
+}
+
+// ____________________________________________________________________________
+size_t osm2rdf::osm::CountHandler::numRelations() const {
+  return _numRelations;
+}
+
+// ____________________________________________________________________________
+size_t osm2rdf::osm::CountHandler::numWays() const {
+  return _numWays;
+}

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -17,12 +17,15 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "osm2rdf/osm/OsmiumHandler.h"
+
 #include "boost/version.hpp"
+#include "osm2rdf/osm/CountHandler.h"
 #include "osm2rdf/osm/FactHandler.h"
 #include "osm2rdf/osm/GeometryHandler.h"
 #include "osm2rdf/osm/LocationHandler.h"
-#include "osm2rdf/osm/OsmiumHandler.h"
 #include "osm2rdf/osm/RelationHandler.h"
+#include "osm2rdf/util/ProgressBar.h"
 #include "osm2rdf/util/Time.h"
 #include "osmium/area/assembler.hpp"
 #include "osmium/area/multipolygon_manager.hpp"
@@ -49,24 +52,33 @@ void osm2rdf::osm::OsmiumHandler<W>::handle() {
     assembler_config.create_empty_areas = false;
     osmium::area::MultipolygonManager<osmium::area::Assembler> mp_manager{
         assembler_config};
+    osm2rdf::osm::CountHandler countHandler;
 
     // read relations for areas
     {
       std::cerr << std::endl;
-      osmium::io::Reader reader{input_file};
-      osmium::ProgressBar progress{reader.file_size(), osmium::isatty(2)};
       std::cerr << osm2rdf::util::currentTimeFormatted()
-                << "OSM Pass 1 ... (Relations for areas"
+                << "OSM Pass 1 ... (Count objects, Relations for areas"
 #if BOOST_VERSION >= 107800
                 << ", Relation members"
 #endif  // BOOST_VERSION >= 107800
-                << ")"
-                << std::endl;
-      osmium::relations::read_relations(progress, input_file, mp_manager
+                << ")" << std::endl;
+      osmium::io::ReaderWithProgressBar reader{true, input_file,
+                                               osmium::osm_entity_bits::object};
+      {
+        while (auto buf = reader.read()) {
+          osmium::apply(buf, mp_manager,
 #if BOOST_VERSION >= 107800
-                                        , _relationHandler
+                        _relationHandler,
 #endif  // BOOST_VERSION >= 107800
-      );
+                        countHandler);
+        }
+      }
+      reader.close();
+      mp_manager.prepare_for_lookup();
+#if BOOST_VERSION >= 107800
+      _relationHandler.prepare_for_lookup();
+#endif  // BOOST_VERSION >= 107800
       std::cerr << osm2rdf::util::currentTimeFormatted() << "... done"
                 << std::endl;
     }
@@ -76,11 +88,34 @@ void osm2rdf::osm::OsmiumHandler<W>::handle() {
       std::cerr << std::endl;
       std::cerr << osm2rdf::util::currentTimeFormatted()
                 << "OSM Pass 2 ... (dump)" << std::endl;
-      osmium::io::ReaderWithProgressBar reader{true, input_file,
-                                               osmium::osm_entity_bits::object};
+      osmium::io::Reader reader{input_file, osmium::osm_entity_bits::object};
       osm2rdf::osm::LocationHandler* locationHandler =
           osm2rdf::osm::LocationHandler::create(_config);
       _relationHandler.setLocationHandler(locationHandler);
+
+      size_t numTasks = 0;
+      if (!_config.noFacts && !_config.noNodeFacts) {
+        numTasks += countHandler.numNodes();
+      }
+      if (!_config.noGeometricRelations && !_config.noNodeGeometricRelations) {
+        numTasks += countHandler.numNodes();
+      }
+      if (!_config.noFacts && !_config.noRelationFacts) {
+        numTasks += countHandler.numRelations();
+      }
+      if (!_config.noGeometricRelations &&
+          !_config.noRelationGeometricRelations) {
+        numTasks += countHandler.numRelations();
+      }
+      if (!_config.noFacts && !_config.noWayFacts) {
+        numTasks += countHandler.numWays();
+      }
+      if (!_config.noGeometricRelations && !_config.noWayGeometricRelations) {
+        numTasks += countHandler.numWays();
+      }
+
+      _progressBar = osm2rdf::util::ProgressBar{numTasks, true};
+      _progressBar.update(_numTasksDone);
 
 #pragma omp parallel
       {
@@ -101,9 +136,10 @@ void osm2rdf::osm::OsmiumHandler<W>::handle() {
       }
       reader.close();
       delete locationHandler;
+      _progressBar.done();
+
       std::cerr << osm2rdf::util::currentTimeFormatted()
-                << "... done reading (libosmium) and converting (libosmium -> "
-                   "osm2rdf)"
+                << "... done"
                 << std::endl;
 
       std::cerr << osm2rdf::util::currentTimeFormatted()
@@ -151,12 +187,12 @@ void osm2rdf::osm::OsmiumHandler<W>::area(const osmium::Area& area) {
       if (!_config.noFacts && !_config.noAreaFacts) {
         _areasDumped++;
 #pragma omp task
-        _factHandler.area(osmArea);
+        { _factHandler.area(osmArea); };
       }
       if (!_config.noGeometricRelations && !_config.noAreaGeometricRelations) {
         _areaGeometriesHandled++;
 #pragma omp task
-        _geometryHandler.area(osmArea);
+        { _geometryHandler.area(osmArea); };
       }
     }
   } catch (const osmium::invalid_location& e) {
@@ -179,12 +215,18 @@ void osm2rdf::osm::OsmiumHandler<W>::node(const osmium::Node& node) {
     if (!_config.noFacts && !_config.noNodeFacts) {
       _nodesDumped++;
 #pragma omp task
-      _factHandler.node(osmNode);
+      {
+        _factHandler.node(osmNode);
+#pragma omp critical(progress)
+        _progressBar.update(_numTasksDone++);
+      };
     }
     if (!_config.noGeometricRelations && !_config.noNodeGeometricRelations) {
       _nodeGeometriesHandled++;
 #pragma omp task
       _geometryHandler.node(osmNode);
+#pragma omp critical(progress)
+      _progressBar.update(_numTasksDone++);
     }
   } catch (const osmium::invalid_location& e) {
     return;
@@ -217,11 +259,17 @@ void osm2rdf::osm::OsmiumHandler<W>::relation(
         _relationsDumped++;
 #pragma omp task
         _factHandler.relation(osmRelation);
+#pragma omp critical(progress)
+        _progressBar.update(_numTasksDone++);
       }
 
+    if (!_config.noGeometricRelations &&
+        !_config.noRelationGeometricRelations) {
 #pragma omp task
-      _geometryHandler.relation(osmRelation);
-
+        _geometryHandler.relation(osmRelation);
+#pragma omp critical(progress)
+        _progressBar.update(_numTasksDone++);
+      }
 #if BOOST_VERSION >= 107800
     }
 #endif
@@ -246,12 +294,20 @@ void osm2rdf::osm::OsmiumHandler<W>::way(const osmium::Way& way) {
     if (!_config.noFacts && !_config.noWayFacts) {
       _waysDumped++;
 #pragma omp task
-      _factHandler.way(osmWay);
+      {
+        _factHandler.way(osmWay);
+#pragma omp critical(progress)
+        _progressBar.update(_numTasksDone++);
+      };
     }
     if (!_config.noGeometricRelations && !_config.noWayGeometricRelations) {
       _wayGeometriesHandled++;
 #pragma omp task
-      _geometryHandler.way(osmWay);
+      {
+        _geometryHandler.way(osmWay);
+#pragma omp critical(progress)
+        _progressBar.update(_numTasksDone++);
+      };
     }
   } catch (const osmium::invalid_location& e) {
     return;

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -138,8 +138,7 @@ void osm2rdf::osm::OsmiumHandler<W>::handle() {
       delete locationHandler;
       _progressBar.done();
 
-      std::cerr << osm2rdf::util::currentTimeFormatted()
-                << "... done"
+      std::cerr << osm2rdf::util::currentTimeFormatted() << "... done"
                 << std::endl;
 
       std::cerr << osm2rdf::util::currentTimeFormatted()
@@ -224,9 +223,11 @@ void osm2rdf::osm::OsmiumHandler<W>::node(const osmium::Node& node) {
     if (!_config.noGeometricRelations && !_config.noNodeGeometricRelations) {
       _nodeGeometriesHandled++;
 #pragma omp task
-      _geometryHandler.node(osmNode);
+      {
+        _geometryHandler.node(osmNode);
 #pragma omp critical(progress)
-      _progressBar.update(_numTasksDone++);
+        _progressBar.update(_numTasksDone++);
+      };
     }
   } catch (const osmium::invalid_location& e) {
     return;
@@ -258,17 +259,21 @@ void osm2rdf::osm::OsmiumHandler<W>::relation(
       if (!_config.noFacts && !_config.noRelationFacts) {
         _relationsDumped++;
 #pragma omp task
-        _factHandler.relation(osmRelation);
+        {
+          _factHandler.relation(osmRelation);
 #pragma omp critical(progress)
-        _progressBar.update(_numTasksDone++);
+          _progressBar.update(_numTasksDone++);
+        };
       }
 
-    if (!_config.noGeometricRelations &&
-        !_config.noRelationGeometricRelations) {
+      if (!_config.noGeometricRelations &&
+          !_config.noRelationGeometricRelations) {
 #pragma omp task
-        _geometryHandler.relation(osmRelation);
+        {
+          _geometryHandler.relation(osmRelation);
 #pragma omp critical(progress)
-        _progressBar.update(_numTasksDone++);
+          _progressBar.update(_numTasksDone++);
+        };
       }
 #if BOOST_VERSION >= 107800
     }


### PR DESCRIPTION
* Extend first pass to count number of osm objects
* Calculate number of tasks to handle these objects - areas are not known at this point in time and not added to the task count!
* Use finished tasks as progress indicator for second pass instead of read bytes