### PR TITLE
Make approximate contains slack configurable

### DIFF
--- a/include/osm2rdf/osm/GeometryHandler.h
+++ b/include/osm2rdf/osm/GeometryHandler.h
@@ -47,6 +47,8 @@ const static int NUM_GRID_CELLS = 5000;
 const static double GRID_W = 360.0 / NUM_GRID_CELLS;
 const static double GRID_H = 180.0 / NUM_GRID_CELLS;
 
+const double APPROX_CONTAINS_SLACK = 0.05;
+
 struct GeomRelationStats {
   size_t _totalChecks = 0;
   size_t _fullChecks = 0;


### PR DESCRIPTION
For the named area contains relation, we use an approximate *contains* relation. Its slack has so far been hardcoded. It makes sense to makes this configurable. The first commit in this PR adds a variable `APPROX_CONTAINS_SLACK` in `GeometryHandler.h`.

This is particularly important as we currently cannot build the OpenHistoricalMap dataset (see https://github.com/ad-freiburg/qlever/issues/1220) with an approximate contains relation. Basically, the problem is that for some administrative areas, we have many versions which differ only **slightly**. If the difference is within the allowed slack, none of our existing speedup heuristics are effective (they notice that we are not contained, but do not abort as we *might* be approximately contained), and we must compute a full intersection of the polygons A, B to compute whether A is approximately contained in B. If `APPROX_CONTAINS_SLACK` is 0, then we can immediately decide that A is not in B in such cases by a simple floating point comparison (the geometric area of A vs. the geometric area of B).

As an example, see https://www.openhistoricalmap.org/relation/2704379 and https://www.openhistoricalmap.org/relation/2704296, which are two of the (dozens of) versions of the boundaries of San Jose. Because of cases like this, it took 24h hours on our standard build machine to process **3%** (sic!) of the named areas in the latest OHM planet file.

@lehmann-4178656ch, it would be nice if you could add a configuration parameter for this.