### PR TITLE
Improve OHM support

### DIFF
--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -36,6 +36,11 @@ enum GeoTriplesMode {
   full = 2
 };
 
+enum SourceDataset {
+  OSM = 0,
+  OHM = 1
+};
+
 struct Config {
   // Select what to do
   std::string storeLocationsOnDisk;
@@ -52,6 +57,8 @@ struct Config {
   bool noRelationGeometricRelations = false;
   bool noWayGeometricRelations = false;
   double simplifyGeometries = 0;
+
+  SourceDataset sourceDataset = OSM;
 
   // the epsilon for the inner/outer douglas-peucker is based on the
   // circumference of a hypothetical circle. By dividing by ~pi, we base the

--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -67,6 +67,7 @@ struct Config {
   // "collapsed away" by the inner simplification, or added by the outer
   // simplification
   double simplifyGeometriesInnerOuter = 1 / (3.14 * 20);
+  double approxContainsSlack = 0.05;
   bool dontUseInnerOuterGeoms = false;
   bool approximateSpatialRels = false;
 

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -94,6 +94,14 @@ const static inline std::string NO_FACTS_OPTION_SHORT = "";
 const static inline std::string NO_FACTS_OPTION_LONG = "no-facts";
 const static inline std::string NO_FACTS_OPTION_HELP = "Do not dump facts";
 
+const static inline std::string SOURCE_DATASET_INFO =
+    "Source dataset";
+const static inline std::string SOURCE_DATASET_OPTION_SHORT = "";
+const static inline std::string SOURCE_DATASET_OPTION_LONG =
+    "source-dataset";
+const static inline std::string SOURCE_DATASET_OPTION_HELP =
+    "Source dataset, either 'OSM', or 'OHM'";
+
 const static inline std::string OSM2RDF_GEO_TRIPLES_INFO =
     "Writing mode of osm2rdf-style geometric triples";
 const static inline std::string OSM2RDF_GEO_TRIPLES_OPTION_SHORT = "";

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -270,8 +270,16 @@ const static inline std::string APPROX_SPATIAL_REL_OPTION_SHORT =
 const static inline std::string APPROX_SPATIAL_REL_OPTION_LONG =
     "approximate-spatial-relations";
 const static inline std::string APPROX_SPATIAL_REL_OPTION_HELP = "Use "
-  "simplified inner/outer geometries for approximate calcuation of spatial "
-  "relations";
+    "simplified inner/outer geometries for approximate calculation of spatial "
+    "relations";
+
+const static inline std::string APPROX_CONTAINS_SLACK_INFO =
+    "Slack for approximate contains";
+const static inline std::string APPROX_CONTAINS_SLACK_OPTION_SHORT =
+    "";
+const static inline std::string APPROX_CONTAINS_SLACK_OPTION_LONG =
+    "approximate-contains-slack";
+const static inline std::string APPROX_CONTAINS_SLACK_OPTION_HELP = "";
 
 const static inline std::string SIMPLIFY_WKT_INFO = "Simplifying WKT";
 const static inline std::string SIMPLIFY_WKT_OPTION_SHORT = "s";

--- a/include/osm2rdf/osm/FactHandler.h
+++ b/include/osm2rdf/osm/FactHandler.h
@@ -28,6 +28,14 @@
 
 namespace osm2rdf::osm {
 
+enum DateTimeType {
+  invalid = 0,
+  date_yyyy = 1,
+  date_yyyy_mm = 2,
+  date_yyyy_mm_dd = 3,
+  date_time = 4
+};
+
 template <typename W>
 class FactHandler {
  public:
@@ -75,6 +83,21 @@ class FactHandler {
   FRIEND_TEST(OSM_FactHandler, writeTagListWikipediaWithLang);
   FRIEND_TEST(OSM_FactHandler, writeTagListWikipediaWithoutLang);
   FRIEND_TEST(OSM_FactHandler, writeTagListSkipWikiLinks);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateInvalid);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateInvalid2);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateInvalid3);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYear1);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYear2);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYear3);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYear4);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonth1);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonth2);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonth3);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonth4);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay1);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay2);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay3);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay4);
 
   void writeSecondsAsISO(const std::string& s, const std::string& p,
                          const std::time_t& t);

--- a/include/osm2rdf/osm/FactHandler.h
+++ b/include/osm2rdf/osm/FactHandler.h
@@ -48,7 +48,6 @@ class FactHandler {
   FRIEND_TEST(OSM_FactHandler, writeBoostGeometryWaySimplify3);
 
  protected:
-
   void writeBox(const std::string& s, const std::string& p,
                 const osm2rdf::geometry::Box& box);
   FRIEND_TEST(OSM_FactHandler, writeBoxPrecision1);
@@ -76,6 +75,9 @@ class FactHandler {
   FRIEND_TEST(OSM_FactHandler, writeTagListWikipediaWithLang);
   FRIEND_TEST(OSM_FactHandler, writeTagListWikipediaWithoutLang);
   FRIEND_TEST(OSM_FactHandler, writeTagListSkipWikiLinks);
+
+  void writeSecondsAsISO(const std::string& s, const std::string& p,
+                         const std::time_t& t);
 
   bool hasSuffix(const std::string& s, const std::string& suffix) const;
 

--- a/include/osm2rdf/osm/GeometryHandler.h
+++ b/include/osm2rdf/osm/GeometryHandler.h
@@ -47,8 +47,6 @@ const static int NUM_GRID_CELLS = 5000;
 const static double GRID_W = 360.0 / NUM_GRID_CELLS;
 const static double GRID_H = 180.0 / NUM_GRID_CELLS;
 
-const double APPROX_CONTAINS_SLACK = 0.05;
-
 struct GeomRelationStats {
   size_t _totalChecks = 0;
   size_t _fullChecks = 0;

--- a/include/osm2rdf/osm/Node.h
+++ b/include/osm2rdf/osm/Node.h
@@ -19,6 +19,7 @@
 #ifndef OSM2RDF_OSM_NODE_H_
 #define OSM2RDF_OSM_NODE_H_
 
+#include "Generic.h"
 #include "boost/serialization/nvp.hpp"
 #include "osm2rdf/geometry/Box.h"
 #include "osm2rdf/geometry/Location.h"
@@ -36,6 +37,7 @@ class Node {
   explicit Node(const osmium::Node& node);
   explicit Node(const osmium::NodeRef& nodeRef);
   [[nodiscard]] id_t id() const noexcept;
+  [[nodiscard]] std::time_t timestamp() const noexcept;
   [[nodiscard]] osm2rdf::geometry::Box envelope() const noexcept;
   [[nodiscard]] const osm2rdf::geometry::Location& geom() const noexcept;
   [[nodiscard]] const osm2rdf::osm::TagList& tags() const noexcept;
@@ -47,6 +49,7 @@ class Node {
 
  protected:
   id_t _id;
+  std::time_t _timestamp;
   osm2rdf::geometry::Location _geom;
   osm2rdf::osm::TagList _tags;
 
@@ -54,6 +57,7 @@ class Node {
   template <class Archive>
   void serialize(Archive& ar, [[maybe_unused]] const unsigned int version) {
     ar& boost::serialization::make_nvp("_id", _id);
+    ar& boost::serialization::make_nvp("_timestamp", _timestamp);
     ar& boost::serialization::make_nvp("_geom", _geom);
     ar& boost::serialization::make_nvp("_tags", _tags);
   }

--- a/include/osm2rdf/osm/Relation.h
+++ b/include/osm2rdf/osm/Relation.h
@@ -41,6 +41,7 @@ class Relation {
   Relation();
   explicit Relation(const osmium::Relation& relation);
   [[nodiscard]] id_t id() const noexcept;
+  [[nodiscard]] std::time_t timestamp() const noexcept;
   [[nodiscard]] const std::vector<osm2rdf::osm::RelationMember>& members()
       const noexcept;
   [[nodiscard]] const osm2rdf::osm::TagList& tags() const noexcept;
@@ -60,6 +61,7 @@ class Relation {
 
  protected:
   id_t _id;
+  std::time_t _timestamp;
   std::vector<osm2rdf::osm::RelationMember> _members;
   osm2rdf::osm::TagList _tags;
 #if BOOST_VERSION >= 107800
@@ -74,6 +76,7 @@ class Relation {
   template <class Archive>
   void serialize(Archive& ar, [[maybe_unused]] const unsigned int version) {
     ar& boost::serialization::make_nvp("_id", _id);
+    ar& boost::serialization::make_nvp("_timestamp", _timestamp);
     ar& boost::serialization::make_nvp("_members", _members);
     ar& boost::serialization::make_nvp("_tags", _tags);
 #if BOOST_VERSION >= 107800

--- a/include/osm2rdf/osm/Way.h
+++ b/include/osm2rdf/osm/Way.h
@@ -44,6 +44,7 @@ class Way {
   Way();
   explicit Way(const osmium::Way& way);
   [[nodiscard]] id_t id() const noexcept;
+  [[nodiscard]] std::time_t timestamp() const noexcept;
   [[nodiscard]] bool closed() const noexcept;
   [[nodiscard]] bool isArea() const noexcept;
   [[nodiscard]] const osm2rdf::geometry::Box& envelope() const noexcept;
@@ -60,6 +61,7 @@ class Way {
 
  protected:
   id_t _id;
+  std::time_t _timestamp;
   std::vector<osm2rdf::osm::Node> _nodes;
   osm2rdf::geometry::Way _geom;
   osm2rdf::geometry::Box _envelope;
@@ -71,6 +73,7 @@ class Way {
   template <class Archive>
   void serialize(Archive& ar, [[maybe_unused]] const unsigned int version) {
     ar& boost::serialization::make_nvp("_id", _id);
+    ar& boost::serialization::make_nvp("_timestamp", _timestamp);
     ar& boost::serialization::make_nvp("_nodes", _nodes);
     ar& boost::serialization::make_nvp("_geom", _geom);
     ar& boost::serialization::make_nvp("_envelope", _envelope);

--- a/include/osm2rdf/ttl/Constants.h
+++ b/include/osm2rdf/ttl/Constants.h
@@ -25,11 +25,16 @@ namespace osm2rdf::ttl::constants {
 
 // Real constants
 const static inline std::string NAMESPACE__GEOSPARQL = "geo";
+const static inline std::string NAMESPACE__OHM_NODE = "ohmnode";
+const static inline std::string NAMESPACE__OHM_RELATION = "ohmrel";
+const static inline std::string NAMESPACE__OHM_WAY = "ohmway";
+const static inline std::string NAMESPACE__OHM = "ohm";
 const static inline std::string NAMESPACE__OPENGIS = "ogc";
 const static inline std::string NAMESPACE__OSM_NODE = "osmnode";
 const static inline std::string NAMESPACE__OSM_RELATION = "osmrel";
 const static inline std::string NAMESPACE__OSM_TAG = "osmkey";
 const static inline std::string NAMESPACE__OSM_WAY = "osmway";
+const static inline std::string NAMESPACE__OSM_META = "osmmeta";
 const static inline std::string NAMESPACE__OSM = "osm";
 const static inline std::string NAMESPACE__OSM2RDF = "osm2rdf";
 const static inline std::string NAMESPACE__OSM2RDF_GEOM = "osm2rdfgeom";
@@ -57,6 +62,7 @@ inline std::string IRI__OSM2RDF_GEOM__CONVEX_HULL;
 inline std::string IRI__OSM2RDF_GEOM__ENVELOPE;
 inline std::string IRI__OSM2RDF_GEOM__OBB;
 inline std::string IRI__OSM2RDF__POS;
+inline std::string IRI__OSMMETA_TIMESTAMP;
 inline std::string IRI__OSMWAY_IS_CLOSED;
 inline std::string IRI__OSMWAY_NEXT_NODE;
 inline std::string IRI__OSMWAY_NEXT_NODE_DISTANCE;
@@ -71,6 +77,7 @@ inline std::string IRI__OSM_WAY;
 inline std::string IRI__RDF_TYPE;
 
 inline std::string IRI__XSD_DATE;
+inline std::string IRI__XSD_DATE_TIME;
 inline std::string IRI__XSD_DECIMAL;
 inline std::string IRI__XSD_DOUBLE;
 inline std::string IRI__XSD_FLOAT;
@@ -80,6 +87,13 @@ inline std::string IRI__XSD_YEAR_MONTH;
 
 inline std::string LITERAL__NO;
 inline std::string LITERAL__YES;
+
+// Arrays holding values depending on the used dataset
+inline std::string DATASET_ID[2] = {"osm", "ohm"};
+inline std::string DATASET_NAMESPACE[2] = {NAMESPACE__OSM, NAMESPACE__OHM};
+inline std::string NODE_NAMESPACE[2] = {NAMESPACE__OSM_NODE, NAMESPACE__OHM_NODE};
+inline std::string RELATION_NAMESPACE[2] = {NAMESPACE__OSM_RELATION, NAMESPACE__OHM_RELATION};
+inline std::string WAY_NAMESPACE[2] = {NAMESPACE__OSM_WAY, NAMESPACE__OHM_WAY};
 
 }  // namespace osm2rdf::ttl::constants
 

--- a/include/osm2rdf/ttl/Constants.h
+++ b/include/osm2rdf/ttl/Constants.h
@@ -55,9 +55,6 @@ inline std::string IRI__OPENGIS_INTERSECTS;
 inline std::string IRI__OSM2RDF_INTERSECTS_NON_AREA;
 inline std::string IRI__OSM2RDF_INTERSECTS_AREA;
 
-inline std::string IRI__OSM2RDF_CONTAINS;
-inline std::string IRI__OSM2RDF_INTERSECTS;
-
 inline std::string IRI__OSM2RDF_GEOM__CONVEX_HULL;
 inline std::string IRI__OSM2RDF_GEOM__ENVELOPE;
 inline std::string IRI__OSM2RDF_GEOM__OBB;

--- a/include/osm2rdf/ttl/Constants.h
+++ b/include/osm2rdf/ttl/Constants.h
@@ -70,10 +70,13 @@ inline std::string IRI__OSM_WAY;
 
 inline std::string IRI__RDF_TYPE;
 
+inline std::string IRI__XSD_DATE;
 inline std::string IRI__XSD_DECIMAL;
 inline std::string IRI__XSD_DOUBLE;
 inline std::string IRI__XSD_FLOAT;
 inline std::string IRI__XSD_INTEGER;
+inline std::string IRI__XSD_YEAR;
+inline std::string IRI__XSD_YEAR_MONTH;
 
 inline std::string LITERAL__NO;
 inline std::string LITERAL__YES;

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -461,9 +461,9 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
 
     // Dataset selection
     if (sourceDatasetOp->is_set()) {
-      if (osm2rdfGeoTriplesModeOp->value() == "OSM") {
+      if (sourceDatasetOp->value() == "OSM") {
         sourceDataset = OSM;
-      } else if (osm2rdfGeoTriplesModeOp->value() == "OHM") {
+      } else if (sourceDatasetOp->value() == "OHM") {
         sourceDataset = OHM;
       } else {
         throw popl::invalid_option(

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -126,6 +126,10 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       << prefix << osm2rdf::config::constants::OGC_GEO_TRIPLES_INFO << ": "
       << (modeStrings[ogcGeoTriplesMode]);
 
+  oss << "\n"
+      << prefix << osm2rdf::config::constants::APPROX_CONTAINS_SLACK_INFO
+      << ": " << approxContainsSlack;
+
   if (ogcGeoTriplesMode || osm2rdfGeoTriplesMode) {
      if (noAreaGeometricRelations) {
       oss << "\n"
@@ -376,6 +380,13 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
       osm2rdf::config::constants::CACHE_OPTION_LONG,
       osm2rdf::config::constants::CACHE_OPTION_HELP, cache);
 
+  auto approxContainsSlackOp =
+      parser.add<popl::Value<double>, popl::Attribute::expert>(
+          osm2rdf::config::constants::APPROX_CONTAINS_SLACK_OPTION_SHORT,
+          osm2rdf::config::constants::APPROX_CONTAINS_SLACK_OPTION_LONG,
+          osm2rdf::config::constants::APPROX_CONTAINS_SLACK_OPTION_HELP,
+          approxContainsSlack);
+
   try {
     parser.parse(argc, argv);
 
@@ -463,13 +474,19 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
     if (sourceDatasetOp->is_set()) {
       if (sourceDatasetOp->value() == "OSM") {
         sourceDataset = OSM;
+        approxContainsSlack = 0.05;
       } else if (sourceDatasetOp->value() == "OHM") {
         sourceDataset = OHM;
+        approxContainsSlack = 0;
       } else {
         throw popl::invalid_option(
-            sourceDatasetOp.get(), popl::invalid_option::Error::invalid_argument,
+            sourceDatasetOp.get(),
+            popl::invalid_option::Error::invalid_argument,
             popl::OptionName::long_name, sourceDatasetOp->value(), "");
       }
+    }
+    if (approxContainsSlackOp->is_set()) {
+      approxContainsSlack = approxContainsSlackOp->value();
     }
 
     // Select amount to dump

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -52,9 +52,12 @@ using osm2rdf::ttl::constants::IRI__OSMWAY_NODE;
 using osm2rdf::ttl::constants::IRI__OSMWAY_NODE_COUNT;
 using osm2rdf::ttl::constants::IRI__OSMWAY_UNIQUE_NODE_COUNT;
 using osm2rdf::ttl::constants::IRI__RDF_TYPE;
+using osm2rdf::ttl::constants::IRI__XSD_DATE;
 using osm2rdf::ttl::constants::IRI__XSD_DECIMAL;
 using osm2rdf::ttl::constants::IRI__XSD_DOUBLE;
 using osm2rdf::ttl::constants::IRI__XSD_INTEGER;
+using osm2rdf::ttl::constants::IRI__XSD_YEAR;
+using osm2rdf::ttl::constants::IRI__XSD_YEAR_MONTH;
 using osm2rdf::ttl::constants::LITERAL__NO;
 using osm2rdf::ttl::constants::LITERAL__YES;
 using osm2rdf::ttl::constants::NAMESPACE__OSM;
@@ -431,7 +434,7 @@ void osm2rdf::osm::FactHandler<W>::writeTagList(
         (key == "wikidata" || hasSuffix(key, ":wikidata"))) {
       // Only take first wikidata entry if ; is found
       std::string valueTmp = value;
-      auto end = valueTmp.find(';');
+      const auto end = valueTmp.find(';');
       if (end != std::string::npos) {
         valueTmp = valueTmp.erase(end);
       }
@@ -448,7 +451,7 @@ void osm2rdf::osm::FactHandler<W>::writeTagList(
     }
     if (!_config.skipWikiLinks &&
         (key == "wikipedia" || hasSuffix(key, ":wikipedia"))) {
-      auto pos = value.find(':');
+      const auto pos = value.find(':');
       if (pos != std::string::npos) {
         const std::string& lang = value.substr(0, pos);
         const std::string& entry = value.substr(pos + 1);
@@ -462,6 +465,26 @@ void osm2rdf::osm::FactHandler<W>::writeTagList(
             subj, _writer->generateIRI(NAMESPACE__OSM, key),
             _writer->generateIRI("https://www.wikipedia.org/wiki/", value));
         tagTripleCount++;
+      }
+    }
+    if (key == "start_date" || key == "end_date") {
+      const auto dashCount = std::count(value.begin(), value.end(), '-');
+      switch (dashCount) {
+        case 2:
+          _writer->writeTriple(
+              subj, _writer->generateIRIUnsafe(NAMESPACE__OSM, key),
+              _writer->generateLiteralUnsafe(value, "^^" + IRI__XSD_DATE));
+          break;
+        case 1:
+          _writer->writeTriple(
+              subj, _writer->generateIRIUnsafe(NAMESPACE__OSM, key),
+              _writer->generateLiteralUnsafe(value, "^^" + IRI__XSD_YEAR_MONTH));
+          break;
+        case 0:
+          _writer->writeTriple(
+              subj, _writer->generateIRIUnsafe(NAMESPACE__OSM, key),
+              _writer->generateLiteralUnsafe(value, "^^" + IRI__XSD_YEAR));
+          break;
       }
     }
   }

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -507,31 +507,27 @@ void osm2rdf::osm::FactHandler<W>::writeTagList(
         continue;
       }
 
-      std::vector<std::string> parts;
-      parts.reserve(minusCount + 1);
-      size_t last = 0;
-      size_t next;
-      for (size_t i = 0; i < (minusCount + 1); ++i) {
-        next = value.find('-', last);
-        parts.emplace_back(value.substr(last, next - last));
-        last = next + 1;
-      }
-
-      auto resultType = 0;
       std::string newValue;
       newValue.reserve(value.size());
       std::ostringstream tmp;
       tmp << std::setfill('0');
+
+      size_t last = 0;
+      size_t next;
+      auto resultType = 0;
       for (size_t i = 0; i < (minusCount + 1); ++i) {
-        if (i == 0 && parts[i].empty()) {
+        next = value.find('-', last);
+        if (i == 0 && next == 0) {
           newValue += '-';
+          last = next + 1;
           continue;
         }
         tmp << std::setw(resultType == 0 ? 4 : 2) << std::dec
-            << std::atoi(parts[i].c_str());
+            << std::atoi(value.substr(last, next - last).c_str());
         newValue += tmp.str().substr(0, resultType == 0 ? 4 : 2) + '-';
         tmp.seekp(0);
         resultType++;
+        last = next + 1;
       }
       if (resultType > 3) {
         // Invalid length

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -613,7 +613,7 @@ void GeometryHandler<W>::prepareDAG() {
         }
 
         // skip equal geometries
-        if (APPROX_CONTAINS_SLACK == 0) {
+        if (_config.approxContainsSlack == 0) {
           if (fabs(areaArea - entryArea) < 0.0001 * 0.0001) {
             continue;
           }
@@ -625,7 +625,7 @@ void GeometryHandler<W>::prepareDAG() {
         }
 
         GeomRelationInfo geomRelInf;
-        if (APPROX_CONTAINS_SLACK == 0) {
+        if (_config.approxContainsSlack == 0) {
           if (!areaInArea(entry, area, &geomRelInf, &stats)) {
             continue;
           }
@@ -650,9 +650,9 @@ void GeometryHandler<W>::prepareDAG() {
           }
         }
 
-        if (APPROX_CONTAINS_SLACK > 0 &&
+        if (_config.approxContainsSlack > 0 &&
             fabs(1.0 - areaArea / geomRelInf.intersectArea) <
-                APPROX_CONTAINS_SLACK) {
+                _config.approxContainsSlack) {
           continue;
         }
 
@@ -2184,7 +2184,7 @@ bool GeometryHandler<W>::areaInAreaApprox(const SpatialAreaValue& a,
   const auto& areaGeom = std::get<2>(b);
   const auto& areaConvexHull = std::get<10>(b);
 
-  if (areaArea / entryArea <= 1.0 - APPROX_CONTAINS_SLACK) {
+  if (areaArea / entryArea <= 1.0 - _config.approxContainsSlack) {
     stats->skippedByAreaSize();
     return false;
   }
@@ -2221,7 +2221,7 @@ bool GeometryHandler<W>::areaInAreaApprox(const SpatialAreaValue& a,
     geomRelInf->intersectArea = boost::geometry::area(intersect);
     stats->skippedByBoxIdIntersectCutout();
     return fabs(1.0 - entryArea / geomRelInf->intersectArea) <
-           APPROX_CONTAINS_SLACK;
+           _config.approxContainsSlack;
   } else {
     if (!boost::geometry::is_empty(entryConvexHull) &&
         !boost::geometry::is_empty(areaConvexHull) &&
@@ -2251,7 +2251,7 @@ bool GeometryHandler<W>::areaInAreaApprox(const SpatialAreaValue& a,
     geomRelInf->intersectArea = boost::geometry::area(intersect);
     stats->fullCheck();
     return fabs(1.0 - entryArea / geomRelInf->intersectArea) <
-           APPROX_CONTAINS_SLACK;
+           _config.approxContainsSlack;
   }
 }
 

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -60,8 +60,6 @@ using osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_AREA;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA;
-using osm2rdf::ttl::constants::NAMESPACE__OSM_NODE;
-using osm2rdf::ttl::constants::NAMESPACE__OSM_WAY;
 using osm2rdf::util::currentTimeFormatted;
 using osm2rdf::util::DirectedGraph;
 
@@ -755,19 +753,15 @@ void GeometryHandler<W>::dumpNamedAreaRelations() {
 
   std::vector<DirectedGraph<uint32_t>::entry_t> vertices =
       _directedAreaGraph.getVertices();
-#pragma omp parallel for shared(                                         \
-        vertices, osm2rdf::ttl::constants::NAMESPACE__OSM_WAY,           \
-            osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION,            \
-            osm2rdf::ttl::constants::IRI__OPENGIS_CONTAINS,              \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_AREA,         \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,     \
-            osm2rdf::ttl::constants::IRI__OPENGIS_INTERSECTS,            \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA,       \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,   \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS,            \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS, progressBar, \
-            entryCount) reduction(+ : intersectStats) default(none)      \
-    schedule(static)
+#pragma omp parallel for shared(                                       \
+        vertices, osm2rdf::ttl::constants::IRI__OPENGIS_CONTAINS,      \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_AREA,       \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,   \
+            osm2rdf::ttl::constants::IRI__OPENGIS_INTERSECTS,          \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA,     \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA, \
+            progressBar, entryCount)                                   \
+    reduction(+ : intersectStats) default(none) schedule(static)
   for (size_t i = 0; i < vertices.size(); i++) {
     const auto id = vertices[i];
     const auto& entry = _spatialStorageArea[id];
@@ -924,10 +918,10 @@ void GeometryHandler<W>::dumpUnnamedAreaRelations() {
               << std::endl;
   } else if (_numUnnamedAreas == 0) {
     std::cerr << std::endl;
-    std::cerr
-        << currentTimeFormatted() << " "
-        << "Skipping contains relation for unnamed areas ... no unnamed area"
-        << std::endl;
+    std::cerr << currentTimeFormatted() << " "
+              << "Skipping contains relation for unnamed areas ... "
+                 "no unnamed area"
+              << std::endl;
   } else {
     std::cerr << std::endl;
     std::cerr << currentTimeFormatted() << " "
@@ -944,17 +938,13 @@ void GeometryHandler<W>::dumpUnnamedAreaRelations() {
     GeomRelationStats intersectStats, containsStats;
     size_t entryCount = 0;
     progressBar.update(entryCount);
-#pragma omp parallel for shared(                                         \
-        osm2rdf::ttl::constants::NAMESPACE__OSM_WAY,                     \
-            osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION,            \
-            osm2rdf::ttl::constants::IRI__OPENGIS_INTERSECTS,            \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,   \
-            osm2rdf::ttl::constants::IRI__OPENGIS_CONTAINS,              \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,     \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS,            \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS, progressBar, \
-            entryCount, ia)                                              \
-    reduction(+ : intersectStats, containsStats) default(none)           \
+#pragma omp parallel for shared(                                       \
+        osm2rdf::ttl::constants::IRI__OPENGIS_INTERSECTS,              \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA, \
+            osm2rdf::ttl::constants::IRI__OPENGIS_CONTAINS,            \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,   \
+            progressBar, entryCount, ia)                               \
+    reduction(+ : intersectStats, containsStats) default(none)         \
     schedule(dynamic)
     for (size_t i = 0; i < _numUnnamedAreas; i++) {
       SpatialAreaValue entry;
@@ -1168,15 +1158,11 @@ void GeometryHandler<W>::dumpNodeRelations() {
     progressBar.update(entryCount);
 
 #pragma omp parallel for shared(                                            \
-        std::cout, osm2rdf::ttl::constants::NAMESPACE__OSM_NODE,            \
-            osm2rdf::ttl::constants::NAMESPACE__OSM_WAY,                    \
-            osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION,               \
+        std::cout, osm2rdf::ttl::constants::NODE_NAMESPACE,                 \
             osm2rdf::ttl::constants::IRI__OPENGIS_CONTAINS,                 \
             osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,        \
             osm2rdf::ttl::constants::IRI__OPENGIS_INTERSECTS,               \
             osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,      \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS,               \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS,                 \
             osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA,          \
             progressBar, ia, entryCount) reduction(+ : stats) default(none) \
     schedule(dynamic)
@@ -1186,7 +1172,9 @@ void GeometryHandler<W>::dumpNodeRelations() {
       ia >> node;
 
       const auto& nodeId = std::get<0>(node);
-      std::string nodeIRI = _writer->generateIRI(NAMESPACE__OSM_NODE, nodeId);
+      std::string nodeIRI = _writer->generateIRI(
+          osm2rdf::ttl::constants::NODE_NAMESPACE[_config.sourceDataset],
+          nodeId);
 
       // Set containing all areas we are inside of
       SkipSet skip;
@@ -1224,9 +1212,9 @@ void GeometryHandler<W>::dumpNodeRelations() {
           if (relations != _areaBorderWaysIndex.end()) {
             for (auto r : relations->second) {
               if (r.second) {
-                // way is inner geometry of this area relation, so if we
-                // encounter the enclosing area again for this way, we can
-                // be sure that we are not contained in it!
+                // way is inner geometry of this area relation, so if
+                // we encounter the enclosing area again for this way,
+                // we can be sure that we are not contained in it!
                 skipByContainedInInner.insert(r.first);
               }
             }
@@ -1349,18 +1337,15 @@ void GeometryHandler<W>::dumpWayRelations() {
     GeomRelationStats intersectStats, containsStats;
 
     progressBar.update(entryCount);
-#pragma omp parallel for shared(                                           \
-        std::cout, std::cerr, osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, \
-            osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION,              \
-            osm2rdf::ttl::constants::IRI__OPENGIS_INTERSECTS,              \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA,     \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA,         \
-            osm2rdf::ttl::constants::IRI__OPENGIS_CONTAINS,                \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,       \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS,              \
-            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS, progressBar,   \
-            entryCount, ia)                                                \
-    reduction(+ : intersectStats, containsStats) default(none)             \
+#pragma omp parallel for shared(                                       \
+        std::cout, std::cerr, osm2rdf::ttl::constants::WAY_NAMESPACE,  \
+            osm2rdf::ttl::constants::IRI__OPENGIS_INTERSECTS,          \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA, \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA,     \
+            osm2rdf::ttl::constants::IRI__OPENGIS_CONTAINS,            \
+            osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA,   \
+            progressBar, entryCount, ia)                               \
+    reduction(+ : intersectStats, containsStats) default(none)         \
     schedule(dynamic)
 
     for (size_t i = 0; i < _numWays; i++) {
@@ -1371,14 +1356,15 @@ void GeometryHandler<W>::dumpWayRelations() {
 
       const auto& wayId = std::get<1>(way);
 
-      // Check if an area computed from this way exists if yes we don't need to
-      // calculate any relation again.
+      // Check if an area computed from this way exists if yes we
+      // don't need to calculate any relation again.
       auto it = _spatialStorageAreaIndex.find(wayId * 2);
       if (it != _spatialStorageAreaIndex.end()) {
         continue;
       }
 
-      std::string wayIRI = _writer->generateIRI(NAMESPACE__OSM_WAY, wayId);
+      std::string wayIRI = _writer->generateIRI(
+          osm2rdf::ttl::constants::WAY_NAMESPACE[_config.sourceDataset], wayId);
 
       // Set containing all areas we are inside of
       SkipSet skipIntersects;
@@ -1507,9 +1493,10 @@ void GeometryHandler<W>::dumpWayRelations() {
             if (relations != _areaBorderWaysIndex.end()) {
               for (auto r : relations->second) {
                 if (r.second) {
-                  // way is inner geometry of this area relation, so if we
-                  // encounter the enclosing area again for this way, we can
-                  // be sure that we are not contained in it!
+                  // way is inner geometry of this area relation, so
+                  // if we encounter the enclosing area again for this
+                  // way, we can be sure that we are not contained in
+                  // it!
                   skipByContainedInInner.insert(r.first);
                 }
               }
@@ -1716,7 +1703,8 @@ bool GeometryHandler<W>::nodeInArea(const SpatialNodeValue& a,
   }
 
   if (!boost::geometry::covered_by(geomA, outerGeomB)) {
-    // if NOT covered by simplified out, we are definitely not contained
+    // if NOT covered by simplified out, we are definitely not
+    // contained
     stats->skippedByOuter();
     return false;
   }
@@ -1770,8 +1758,8 @@ bool GeometryHandler<W>::areaIntersectsArea(const SpatialAreaValue& a,
     return true;
   }
 
-  // if there is no full contained box, and no potentially contained, we
-  // surely do not intersect
+  // if there is no full contained box, and no potentially contained,
+  // we surely do not intersect
   if (geomRelInf->toCheck.empty()) {
     geomRelInf->intersects = RelInfoValue::NO;
     stats->skippedByBoxIdIntersect();
@@ -1884,16 +1872,16 @@ bool GeometryHandler<W>::wayIntersectsArea(const SpatialWayValue& a,
   if (geomRelInf->fullContained < 0)
     boxIdIsect(wayBoxIds, areaBoxIds, geomRelInf);
 
-  // if we have at least one of A's boxes fully contained in B, we surely
-  // intersect
+  // if we have at least one of A's boxes fully contained in B, we
+  // surely intersect
   if (geomRelInf->fullContained > 0) {
     geomRelInf->intersects = RelInfoValue::YES;
     stats->skippedByBoxIdIntersect();
     return true;
   }
 
-  // if not, and if we also have no potential intersection box, we are not
-  // contained
+  // if not, and if we also have no potential intersection box, we are
+  // not contained
   if (geomRelInf->toCheck.empty()) {
     geomRelInf->intersects = RelInfoValue::NO;
     stats->skippedByBoxIdIntersect();
@@ -1963,7 +1951,8 @@ bool GeometryHandler<W>::wayIntersectsArea(const SpatialWayValue& a,
   }
 
   if (!intersects) {
-    // if does not intersect with envelope, we definitely don't intersect
+    // if does not intersect with envelope, we definitely don't
+    // intersect
     geomRelInf->intersects = RelInfoValue::NO;
     stats->skippedByBox();
     return false;
@@ -2055,8 +2044,8 @@ bool GeometryHandler<W>::wayInArea(const SpatialWayValue& a,
     return true;
   }
 
-  // the combined number of potential contains and sure contains is not
-  // equal to the number of A's boxes, so we cannot be contained
+  // the combined number of potential contains and sure contains is
+  // not equal to the number of A's boxes, so we cannot be contained
   if ((static_cast<int32_t>(geomRelInf->toCheck.size()) +
        geomRelInf->fullContained) != wayBoxIds[0].first) {
     geomRelInf->contained = RelInfoValue::NO;
@@ -2064,8 +2053,8 @@ bool GeometryHandler<W>::wayInArea(const SpatialWayValue& a,
     return false;
   }
 
-  // if the way is only in one box, and area cutouts are available, we can
-  // check against the corresponding cutout
+  // if the way is only in one box, and area cutouts are available, we
+  // can check against the corresponding cutout
   if (wayBoxIds[0].first == 1 && !areaCutouts.empty()) {
     const auto& cutout = areaCutouts.find(abs(wayBoxIds[1].first));
 
@@ -2309,7 +2298,8 @@ bool GeometryHandler<W>::areaInArea(const SpatialAreaValue& a,
   }
 
   // else, if the number of surely contained and potentially contained
-  // boxes is unequal the number of A's boxes, we are surely not contained
+  // boxes is unequal the number of A's boxes, we are surely not
+  // contained
   if ((static_cast<int32_t>(geomRelInf->toCheck.size()) +
        geomRelInf->fullContained) != boxIdsA[0].first) {
     geomRelInf->contained = RelInfoValue::NO;
@@ -2317,8 +2307,8 @@ bool GeometryHandler<W>::areaInArea(const SpatialAreaValue& a,
     return false;
   }
 
-  // if A is in only one box, we can check it against the corresponding
-  // cutout of B, if available
+  // if A is in only one box, we can check it against the
+  // corresponding cutout of B, if available
   if (boxIdsA[0].first == 1 && !cutoutsB.empty()) {
     const auto& cutout = cutoutsB.find(abs(boxIdsA[1].first));
 
@@ -2586,11 +2576,11 @@ template <typename W>
 std::string GeometryHandler<W>::areaNS(AreaFromType type) const {
   switch (type) {
     case AreaFromType::RELATION:
-      return osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION;
+      return osm2rdf::ttl::constants::RELATION_NAMESPACE[_config.sourceDataset];
     case AreaFromType::WAY:
-      return osm2rdf::ttl::constants::NAMESPACE__OSM_WAY;
+      return osm2rdf::ttl::constants::WAY_NAMESPACE[_config.sourceDataset];
     default:
-      return osm2rdf::ttl::constants::NAMESPACE__OSM_WAY;
+      return osm2rdf::ttl::constants::WAY_NAMESPACE[_config.sourceDataset];
   }
 }
 
@@ -2621,8 +2611,8 @@ void GeometryHandler<W>::boxIdIsect(const BoxIdList& idsA,
       if (idsB[j].first > 0) {
         geomRelInf->fullContained++;
 
-        // we now know that we surely intersect. If we know already that
-        // we cannot be contained, return here
+        // we now know that we surely intersect. If we know already
+        // that we cannot be contained, return here
         if (noContained) {
           return;
         }
@@ -2641,8 +2631,8 @@ void GeometryHandler<W>::boxIdIsect(const BoxIdList& idsA,
       }
     } else if (abs(idsA[i].first) + ii < abs(idsB[j].first) + jj) {
       // if we already know that we intersect, we are now sure that we
-      // cannot be contained - it is irrelevant by how "much" we cannot be
-      // contained, so just return
+      // cannot be contained - it is irrelevant by how "much" we
+      // cannot be contained, so just return
       if (geomRelInf->fullContained > 0) {
         return;
       }
@@ -2794,8 +2784,8 @@ std::vector<SpatialAreaRefValue> GeometryHandler<W>::indexQryIntersect(
 // ____________________________________________________________________________
 template <typename W>
 void GeometryHandler<W>::unique(std::vector<SpatialAreaRefValue>& refs) const {
-  // remove duplicates, may occur since we used multiple envelope queries
-  // to build the result!
+  // remove duplicates, may occur since we used multiple envelope
+  // queries to build the result!
   std::sort(refs.begin(), refs.end(),
             [](const auto& a, const auto& b) { return a.second < b.second; });
   auto last = std::unique(
@@ -2837,8 +2827,9 @@ uint8_t GeometryHandler<W>::borderContained(Way::id_t wayId,
 // ____________________________________________________________________________
 template <typename W>
 void GeometryHandler<W>::writeTransitiveClosure(
-    const std::vector<uint32_t>& successors, const SkipSet& skipSet, const std::string& entryIRI,
-    const std::string& rel, const std::string& symmRel) {
+    const std::vector<uint32_t>& successors, const SkipSet& skipSet,
+    const std::string& entryIRI, const std::string& rel,
+    const std::string& symmRel) {
   // transitive closure
   for (const auto& succIdx : successors) {
     if (skipSet.find(succIdx) != skipSet.end()) {
@@ -2857,8 +2848,8 @@ void GeometryHandler<W>::writeTransitiveClosure(
 // ____________________________________________________________________________
 template <typename W>
 void GeometryHandler<W>::writeTransitiveClosure(
-    const std::vector<uint32_t>& successors, const SkipSet& skipSet, const std::string& entryIRI,
-    const std::string& rel) {
+    const std::vector<uint32_t>& successors, const SkipSet& skipSet,
+    const std::string& entryIRI, const std::string& rel) {
   // transitive closure
   for (const auto& succIdx : successors) {
     if (skipSet.find(succIdx) != skipSet.end()) {

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -578,7 +578,6 @@ void GeometryHandler<W>::prepareDAG() {
 #pragma omp parallel for shared(                                               \
         tmpDirectedAreaGraph, std::cout, std::cerr,                            \
             osm2rdf::ttl::constants::IRI__GEOSPARQL__HAS_GEOMETRY, entryCount, \
-            APPROX_CONTAINS_SLACK, \
             progressBar) reduction(+ : stats) default(none) schedule(dynamic)
 
     for (uint32_t i = 0; i < _spatialStorageArea.size(); i++) {

--- a/src/osm/Node.cpp
+++ b/src/osm/Node.cpp
@@ -16,12 +16,13 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "osm2rdf/osm/Node.h"
+
 #include "boost/geometry.hpp"
 #include "boost/geometry/algorithms/envelope.hpp"
 #include "osm2rdf/geometry/Box.h"
 #include "osm2rdf/geometry/Global.h"
 #include "osm2rdf/geometry/Polygon.h"
-#include "osm2rdf/osm/Node.h"
 #include "osm2rdf/osm/Generic.h"
 #include "osm2rdf/osm/TagList.h"
 #include "osmium/osm/node.hpp"
@@ -35,6 +36,7 @@ osm2rdf::osm::Node::Node() {
 // ____________________________________________________________________________
 osm2rdf::osm::Node::Node(const osmium::Node& node) {
   _id = node.positive_id();
+  _timestamp = node.timestamp().seconds_since_epoch();
   const auto& loc = node.location();
   _geom = osm2rdf::geometry::Location(loc.lon(), loc.lat());
   _tags = osm2rdf::osm::convertTagList(node.tags());
@@ -51,15 +53,20 @@ osm2rdf::osm::Node::Node(const osmium::NodeRef& nodeRef) {
 osm2rdf::osm::Node::id_t osm2rdf::osm::Node::id() const noexcept { return _id; }
 
 // ____________________________________________________________________________
+std::time_t osm2rdf::osm::Node::timestamp() const noexcept {
+  return _timestamp;
+}
+
+// ____________________________________________________________________________
 const osm2rdf::geometry::Location& osm2rdf::osm::Node::geom() const noexcept {
   return _geom;
 }
 
 // ____________________________________________________________________________
 osm2rdf::geometry::Box osm2rdf::osm::Node::envelope() const noexcept {
- osm2rdf::geometry::Box envelope;
- boost::geometry::envelope(geom(), envelope);
- return envelope;
+  osm2rdf::geometry::Box envelope;
+  boost::geometry::envelope(geom(), envelope);
+  return envelope;
 }
 
 // ____________________________________________________________________________
@@ -68,7 +75,8 @@ osm2rdf::geometry::Polygon osm2rdf::osm::Node::convexHull() const noexcept {
 }
 
 // ____________________________________________________________________________
-osm2rdf::geometry::Polygon osm2rdf::osm::Node::orientedBoundingBox() const noexcept {
+osm2rdf::geometry::Polygon osm2rdf::osm::Node::orientedBoundingBox()
+    const noexcept {
   return convexHull();
 }
 

--- a/src/osm/Relation.cpp
+++ b/src/osm/Relation.cpp
@@ -38,6 +38,7 @@ osm2rdf::osm::Relation::Relation() {
 // ____________________________________________________________________________
 osm2rdf::osm::Relation::Relation(const osmium::Relation& relation) {
   _id = relation.positive_id();
+  _timestamp = relation.timestamp().seconds_since_epoch();
   _tags = osm2rdf::osm::convertTagList(relation.tags());
   _members.reserve(relation.cmembers().size());
   for (const auto& member : relation.cmembers()) {
@@ -49,6 +50,11 @@ osm2rdf::osm::Relation::Relation(const osmium::Relation& relation) {
 // ____________________________________________________________________________
 osm2rdf::osm::Relation::id_t osm2rdf::osm::Relation::id() const noexcept {
   return _id;
+}
+
+// ____________________________________________________________________________
+std::time_t osm2rdf::osm::Relation::timestamp() const noexcept {
+  return _timestamp;
 }
 
 // ____________________________________________________________________________
@@ -78,22 +84,26 @@ bool osm2rdf::osm::Relation::hasGeometry() const noexcept {
 }
 
 // ____________________________________________________________________________
-const osm2rdf::geometry::Relation& osm2rdf::osm::Relation::geom() const noexcept {
+const osm2rdf::geometry::Relation& osm2rdf::osm::Relation::geom()
+    const noexcept {
   return _geom;
 }
 
 // ____________________________________________________________________________
-const osm2rdf::geometry::Box& osm2rdf::osm::Relation::envelope() const noexcept {
+const osm2rdf::geometry::Box& osm2rdf::osm::Relation::envelope()
+    const noexcept {
   return _envelope;
 }
 
 // ____________________________________________________________________________
-const osm2rdf::geometry::Polygon& osm2rdf::osm::Relation::convexHull() const noexcept {
+const osm2rdf::geometry::Polygon& osm2rdf::osm::Relation::convexHull()
+    const noexcept {
   return _convexHull;
 }
 
 // ____________________________________________________________________________
-const osm2rdf::geometry::Polygon& osm2rdf::osm::Relation::orientedBoundingBox() const noexcept {
+const osm2rdf::geometry::Polygon& osm2rdf::osm::Relation::orientedBoundingBox()
+    const noexcept {
   return _obb;
 }
 
@@ -144,7 +154,8 @@ void osm2rdf::osm::Relation::buildGeometry(
   if (!_geom.empty()) {
     boost::geometry::envelope(_geom, _envelope);
     boost::geometry::convex_hull(_geom, _convexHull);
-    _obb = osm2rdf::osm::generic::orientedBoundingBoxFromConvexHull(_convexHull);
+    _obb =
+        osm2rdf::osm::generic::orientedBoundingBoxFromConvexHull(_convexHull);
   } else {
     _envelope.min_corner() = geometry::Location{0, 0};
     _envelope.max_corner() = geometry::Location{0, 0};

--- a/src/osm/Way.cpp
+++ b/src/osm/Way.cpp
@@ -17,15 +17,16 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "osm2rdf/geometry/Way.h"
+
 #include <vector>
 
 #include "boost/geometry.hpp"
 #include "osm2rdf/geometry/Box.h"
 #include "osm2rdf/geometry/Polygon.h"
-#include "osm2rdf/geometry/Way.h"
 #include "osm2rdf/osm/Box.h"
-#include "osm2rdf/osm/Node.h"
 #include "osm2rdf/osm/Generic.h"
+#include "osm2rdf/osm/Node.h"
 #include "osm2rdf/osm/TagList.h"
 #include "osm2rdf/osm/Way.h"
 #include "osmium/osm/way.hpp"
@@ -40,6 +41,7 @@ osm2rdf::osm::Way::Way() {
 // ____________________________________________________________________________
 osm2rdf::osm::Way::Way(const osmium::Way& way) {
   _id = way.positive_id();
+  _timestamp = way.timestamp().seconds_since_epoch();
   _tags = osm2rdf::osm::convertTagList(way.tags());
   _nodes.reserve(way.nodes().size());
   _geom.reserve(way.nodes().size());
@@ -50,10 +52,18 @@ osm2rdf::osm::Way::Way(const osmium::Way& way) {
   double latMax = -std::numeric_limits<double>::infinity();
 
   for (const auto& nodeRef : way.nodes()) {
-    if (nodeRef.lon() < lonMin) { lonMin = nodeRef.lon(); }
-    if (nodeRef.lat() < latMin) { latMin = nodeRef.lat(); }
-    if (nodeRef.lon() > lonMax) { lonMax = nodeRef.lon(); }
-    if (nodeRef.lat() > latMax) { latMax = nodeRef.lat(); }
+    if (nodeRef.lon() < lonMin) {
+      lonMin = nodeRef.lon();
+    }
+    if (nodeRef.lat() < latMin) {
+      latMin = nodeRef.lat();
+    }
+    if (nodeRef.lon() > lonMax) {
+      lonMax = nodeRef.lon();
+    }
+    if (nodeRef.lat() > latMax) {
+      latMax = nodeRef.lat();
+    }
 
     _nodes.emplace_back(nodeRef);
 
@@ -70,6 +80,9 @@ osm2rdf::osm::Way::Way(const osmium::Way& way) {
 
 // ____________________________________________________________________________
 osm2rdf::osm::Way::id_t osm2rdf::osm::Way::id() const noexcept { return _id; }
+
+// ____________________________________________________________________________
+std::time_t osm2rdf::osm::Way::timestamp() const noexcept { return _timestamp; }
 
 // ____________________________________________________________________________
 const osm2rdf::osm::TagList& osm2rdf::osm::Way::tags() const noexcept {
@@ -93,12 +106,14 @@ const osm2rdf::geometry::Box& osm2rdf::osm::Way::envelope() const noexcept {
 }
 
 // ____________________________________________________________________________
-const osm2rdf::geometry::Polygon& osm2rdf::osm::Way::convexHull() const noexcept {
+const osm2rdf::geometry::Polygon& osm2rdf::osm::Way::convexHull()
+    const noexcept {
   return _convexHull;
 }
 
 // ____________________________________________________________________________
-const osm2rdf::geometry::Polygon& osm2rdf::osm::Way::orientedBoundingBox() const noexcept {
+const osm2rdf::geometry::Polygon& osm2rdf::osm::Way::orientedBoundingBox()
+    const noexcept {
   return _obb;
 }
 

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -59,27 +59,23 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
       // osm prefixes
       {osm2rdf::ttl::constants::NAMESPACE__OSM,
        "https://www.openstreetmap.org/"},
+      {osm2rdf::ttl::constants::NAMESPACE__OSM_META,
+       "https://www.openstreetmap.org/meta/"},
       {osm2rdf::ttl::constants::NAMESPACE__OSM_TAG,
-       "https://www.openstreetmap.org/wiki/Key:"}};
-
-  // Dataset specific prefixes
-  switch (_config.sourceDataset) {
-    case config::OHM:
-      _prefixes[osm2rdf::ttl::constants::NAMESPACE__OSM_NODE] =
-          "https://www.openhistoricalmap.org/node/";
-      _prefixes[osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION] =
-          "https://www.openhistoricalmap.org/relation/";
-      _prefixes[osm2rdf::ttl::constants::NAMESPACE__OSM_WAY] =
-          "https://www.openhistoricalmap.org/way/";
-      break;
-    default:
-      _prefixes[osm2rdf::ttl::constants::NAMESPACE__OSM_NODE] =
-          "https://www.openstreetmap.org/node/";
-      _prefixes[osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION] =
-          "https://www.openstreetmap.org/relation/";
-      _prefixes[osm2rdf::ttl::constants::NAMESPACE__OSM_WAY] =
-          "https://www.openstreetmap.org/way/";
-  }
+       "https://www.openstreetmap.org/wiki/Key:"},
+      {osm2rdf::ttl::constants::NAMESPACE__OSM_NODE,
+       "https://www.openstreetmap.org/node/"},
+      {osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION,
+       "https://www.openstreetmap.org/relation/"},
+      {osm2rdf::ttl::constants::NAMESPACE__OSM_WAY,
+       "https://www.openstreetmap.org/way/"},
+      // ohm prefixes
+      {osm2rdf::ttl::constants::NAMESPACE__OHM_NODE,
+       "https://www.openhistoricalmap.org/node/"},
+      {osm2rdf::ttl::constants::NAMESPACE__OHM_RELATION,
+       "https://www.openhistoricalmap.org/relation/"},
+      {osm2rdf::ttl::constants::NAMESPACE__OHM_WAY,
+       "https://www.openhistoricalmap.org/way/"}};
 
   // Generate constants
   osm2rdf::ttl::constants::IRI__GEOSPARQL__HAS_GEOMETRY =
@@ -110,6 +106,8 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF_GEOM, "obb");
   osm2rdf::ttl::constants::IRI__OSM2RDF__POS =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF, "pos");
+  osm2rdf::ttl::constants::IRI__OSMMETA_TIMESTAMP =
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_META, "timestamp");
   osm2rdf::ttl::constants::IRI__OSMWAY_IS_CLOSED =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_WAY, "is_closed");
   osm2rdf::ttl::constants::IRI__OSMWAY_NEXT_NODE =
@@ -135,6 +133,8 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
 
   osm2rdf::ttl::constants::IRI__XSD_DATE =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "date");
+  osm2rdf::ttl::constants::IRI__XSD_DATE_TIME =
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "dateTime");
   osm2rdf::ttl::constants::IRI__XSD_DECIMAL =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "decimal");
   osm2rdf::ttl::constants::IRI__XSD_DOUBLE =

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -36,6 +36,7 @@ template <typename T>
 osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
                                 osm2rdf::util::Output* output)
     : _config(config), _out(output) {
+  // Static prefixes
   _prefixes = {
       // well-known prefixes
       {osm2rdf::ttl::constants::NAMESPACE__GEOSPARQL,
@@ -53,19 +54,32 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
        "https://osm2rdf.cs.uni-freiburg.de/rdf#"},
       {osm2rdf::ttl::constants::NAMESPACE__OSM2RDF_GEOM,
        "https://osm2rdf.cs.uni-freiburg.de/rdf/geom#"},
+      // https://wiki.openstreetmap.org/wiki/Sophox#How_OSM_data_is_stored
+      // https://github.com/Sophox/sophox/blob/master/osm2rdf/osmutils.py#L35-L39
       // osm prefixes
       {osm2rdf::ttl::constants::NAMESPACE__OSM,
        "https://www.openstreetmap.org/"},
-      // https://wiki.openstreetmap.org/wiki/Sophox#How_OSM_data_is_stored
-      // https://github.com/Sophox/sophox/blob/master/osm2rdf/osmutils.py#L35-L39
-      {osm2rdf::ttl::constants::NAMESPACE__OSM_NODE,
-       "https://www.openstreetmap.org/node/"},
-      {osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION,
-       "https://www.openstreetmap.org/relation/"},
       {osm2rdf::ttl::constants::NAMESPACE__OSM_TAG,
-       "https://www.openstreetmap.org/wiki/Key:"},
-      {osm2rdf::ttl::constants::NAMESPACE__OSM_WAY,
-       "https://www.openstreetmap.org/way/"}};
+       "https://www.openstreetmap.org/wiki/Key:"}};
+
+  // Dataset specific prefixes
+  switch (_config.sourceDataset) {
+    case config::OHM:
+      _prefixes[osm2rdf::ttl::constants::NAMESPACE__OSM_NODE] =
+          "https://www.openhistoricalmap.org/node/";
+      _prefixes[osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION] =
+          "https://www.openhistoricalmap.org/relation/";
+      _prefixes[osm2rdf::ttl::constants::NAMESPACE__OSM_WAY] =
+          "https://www.openhistoricalmap.org/way/";
+      break;
+    default:
+      _prefixes[osm2rdf::ttl::constants::NAMESPACE__OSM_NODE] =
+          "https://www.openstreetmap.org/node/";
+      _prefixes[osm2rdf::ttl::constants::NAMESPACE__OSM_RELATION] =
+          "https://www.openstreetmap.org/relation/";
+      _prefixes[osm2rdf::ttl::constants::NAMESPACE__OSM_WAY] =
+          "https://www.openstreetmap.org/way/";
+  }
 
   // Generate constants
   osm2rdf::ttl::constants::IRI__GEOSPARQL__HAS_GEOMETRY =
@@ -76,14 +90,14 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__GEOSPARQL, "asWKT");
   osm2rdf::ttl::constants::IRI__GEOSPARQL__WKT_LITERAL =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__GEOSPARQL, "wktLiteral");
-  osm2rdf::ttl::constants::IRI__OPENGIS_CONTAINS = generateIRI(
-      osm2rdf::ttl::constants::NAMESPACE__OPENGIS, "sfContains");
-  osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_AREA = generateIRI(
-      osm2rdf::ttl::constants::NAMESPACE__OSM2RDF, "contains_area");
+  osm2rdf::ttl::constants::IRI__OPENGIS_CONTAINS =
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS, "sfContains");
+  osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_AREA =
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF, "contains_area");
   osm2rdf::ttl::constants::IRI__OSM2RDF_CONTAINS_NON_AREA = generateIRI(
       osm2rdf::ttl::constants::NAMESPACE__OSM2RDF, "contains_nonarea");
-  osm2rdf::ttl::constants::IRI__OPENGIS_INTERSECTS = generateIRI(
-      osm2rdf::ttl::constants::NAMESPACE__OPENGIS, "sfIntersects");
+  osm2rdf::ttl::constants::IRI__OPENGIS_INTERSECTS =
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__OPENGIS, "sfIntersects");
   osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_AREA = generateIRI(
       osm2rdf::ttl::constants::NAMESPACE__OSM2RDF, "intersects_area");
   osm2rdf::ttl::constants::IRI__OSM2RDF_INTERSECTS_NON_AREA = generateIRI(

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -133,6 +133,8 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
   osm2rdf::ttl::constants::IRI__RDF_TYPE =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__RDF, "type");
 
+  osm2rdf::ttl::constants::IRI__XSD_DATE =
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "date");
   osm2rdf::ttl::constants::IRI__XSD_DECIMAL =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "decimal");
   osm2rdf::ttl::constants::IRI__XSD_DOUBLE =
@@ -141,6 +143,10 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "float");
   osm2rdf::ttl::constants::IRI__XSD_INTEGER =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "integer");
+  osm2rdf::ttl::constants::IRI__XSD_YEAR =
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "gYear");
+  osm2rdf::ttl::constants::IRI__XSD_YEAR_MONTH =
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "gYearMont");
 
   osm2rdf::ttl::constants::LITERAL__NO = generateLiteral("no", "");
   osm2rdf::ttl::constants::LITERAL__YES = generateLiteral("yes", "");

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -146,7 +146,7 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
   osm2rdf::ttl::constants::IRI__XSD_YEAR =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "gYear");
   osm2rdf::ttl::constants::IRI__XSD_YEAR_MONTH =
-      generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "gYearMont");
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "gYearMonth");
 
   osm2rdf::ttl::constants::LITERAL__NO = generateLiteral("no", "");
   osm2rdf::ttl::constants::LITERAL__YES = generateLiteral("yes", "");

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -70,6 +70,8 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
       {osm2rdf::ttl::constants::NAMESPACE__OSM_WAY,
        "https://www.openstreetmap.org/way/"},
       // ohm prefixes
+      {osm2rdf::ttl::constants::NAMESPACE__OHM,
+       "https://www.openhistoricalmap.org/"},
       {osm2rdf::ttl::constants::NAMESPACE__OHM_NODE,
        "https://www.openhistoricalmap.org/node/"},
       {osm2rdf::ttl::constants::NAMESPACE__OHM_RELATION,

--- a/tests/issues/Issue24.cpp
+++ b/tests/issues/Issue24.cpp
@@ -115,8 +115,8 @@ TEST(Issue24, areaFromWayHasGeometryAsGeoSPARQL) {
   output.close();
 
   ASSERT_EQ(
-      "osmway:21 geo:hasGeometry osm2rdfgeom:wayarea_21 .\n"
-      "osm2rdfgeom:wayarea_21 geo:asWKT \"MULTIPOLYGON(((48.0 7.5,48.0 "
+      "osmway:21 geo:hasGeometry osm2rdfgeom:osm_wayarea_21 .\n"
+      "osm2rdfgeom:osm_wayarea_21 geo:asWKT \"MULTIPOLYGON(((48.0 7.5,48.0 "
       "7.6,48.1 7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral .\n"
       "osmway:21 osm2rdfgeom:convex_hull \"POLYGON(())\"^^geo:wktLiteral .\n"
       "osmway:21 osm2rdfgeom:envelope \"POLYGON((48.0 7.5,48.0 7.6,48.1 "
@@ -223,8 +223,8 @@ TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
   output.close();
 
   ASSERT_EQ(
-      "osmrel:10 geo:hasGeometry osm2rdfgeom:relarea_10 .\n"
-      "osm2rdfgeom:relarea_10 geo:asWKT \"MULTIPOLYGON(((48.0 7.5,48.0 "
+      "osmrel:10 geo:hasGeometry osm2rdfgeom:osm_relarea_10 .\n"
+      "osm2rdfgeom:osm_relarea_10 geo:asWKT \"MULTIPOLYGON(((48.0 7.5,48.0 "
       "7.6,48.1 7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral .\n"
       "osmrel:10 osm2rdfgeom:convex_hull \"POLYGON((48.0 7.5,48.0 7.6,48.1 7.6,48.1 7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
       "osmrel:10 osm2rdfgeom:envelope \"POLYGON((48.0 7.5,48.0 7.6,48.1 "
@@ -273,8 +273,9 @@ TEST(Issue24, nodeHasGeometryAsWkt) {
 
   ASSERT_EQ(
       "osmnode:42 rdf:type osm:node .\n"
-      "osmnode:42 geo:hasGeometry \"POINT(7.5 48.0)\"^^geo:wktLiteral .\n"
+      "osmnode:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmnode:42 osm2rdf:facts \"0\"^^xsd:integer .\n"
+      "osmnode:42 geo:hasGeometry \"POINT(7.5 48.0)\"^^geo:wktLiteral .\n"
       "osmnode:42 osm2rdfgeom:convex_hull \"POLYGON((7.5 48.0,7.5 48.0,7.5 "
       "48.0,7.5 48.0,7.5 48.0))\"^^geo:wktLiteral .\n"
       "osmnode:42 osm2rdfgeom:envelope \"POLYGON((7.5 48.0,7.5 48.0,7.5 "
@@ -323,9 +324,10 @@ TEST(Issue24, nodeHasGeometryAsGeoSPARQL) {
 
   ASSERT_EQ(
       "osmnode:42 rdf:type osm:node .\n"
-      "osmnode:42 geo:hasGeometry osm2rdfgeom:node_42 .\n"
-      "osm2rdfgeom:node_42 geo:asWKT \"POINT(7.5 48.0)\"^^geo:wktLiteral .\n"
+      "osmnode:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmnode:42 osm2rdf:facts \"0\"^^xsd:integer .\n"
+      "osmnode:42 geo:hasGeometry osm2rdfgeom:osm_node_42 .\n"
+      "osm2rdfgeom:osm_node_42 geo:asWKT \"POINT(7.5 48.0)\"^^geo:wktLiteral .\n"
       "osmnode:42 osm2rdfgeom:convex_hull \"POLYGON((7.5 48.0,7.5 48.0,7.5 "
       "48.0,7.5 48.0,7.5 48.0))\"^^geo:wktLiteral .\n"
       "osmnode:42 osm2rdfgeom:envelope \"POLYGON((7.5 48.0,7.5 48.0,7.5 "
@@ -411,6 +413,7 @@ TEST(Issue24, relationWithGeometryHasGeometryAsWkt) {
 
   ASSERT_EQ(
       "osmrel:42 rdf:type osm:relation .\n"
+      "osmrel:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmrel:42 osm2rdf:facts \"0\"^^xsd:integer .\n"
       "osmrel:42 osmrel:member _:0_0 .\n"
       "_:0_0 osm:id osmnode:23 .\n"
@@ -507,6 +510,7 @@ TEST(Issue24, relationWithGeometryHasGeometryAsGeoSPARQL) {
 
   ASSERT_EQ(
       "osmrel:42 rdf:type osm:relation .\n"
+      "osmrel:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmrel:42 osm2rdf:facts \"0\"^^xsd:integer .\n"
       "osmrel:42 osmrel:member _:0_0 .\n"
       "_:0_0 osm:id osmnode:23 .\n"
@@ -516,8 +520,8 @@ TEST(Issue24, relationWithGeometryHasGeometryAsGeoSPARQL) {
       "_:0_1 osm:id osmway:55 .\n"
       "_:0_1 osm:role \"outer\" .\n"
       "_:0_1 osm2rdf:pos \"1\"^^xsd:integer .\n"
-      "osmrel:42 geo:hasGeometry osm2rdfgeom:relation_42 .\n"
-      "osm2rdfgeom:relation_42 geo:asWKT \"GEOMETRYCOLLECTION(POINT(7.5 "
+      "osmrel:42 geo:hasGeometry osm2rdfgeom:osm_relation_42 .\n"
+      "osm2rdfgeom:osm_relation_42 geo:asWKT \"GEOMETRYCOLLECTION(POINT(7.5 "
       "48.0),LINESTRING(7.5 48.0,7.6 48.0))\"^^geo:wktLiteral .\n"
       "osmrel:42 osm2rdfgeom:convex_hull \"POLYGON((7.5 48.0,7.6 48.0,7.5 "
       "48.0,7.5 48.0))\"^^geo:wktLiteral .\n"
@@ -571,6 +575,7 @@ TEST(Issue24, wayHasGeometryAsWkt) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
+      "osmway:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmway:42 osm2rdf:facts \"0\"^^xsd:integer .\n"
       "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
       "7.6)\"^^geo:wktLiteral .\n"
@@ -625,6 +630,7 @@ TEST(Issue24, wayHasGeometryAsGeoSPARQL) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
+      "osmway:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmway:42 osm2rdf:facts \"0\"^^xsd:integer .\n"
       "osmway:42 geo:hasGeometry osm2rdf:way_42 .\n"
       "osm2rdf:way_42 geo:asWKT \"LINESTRING(48.0 7.5,48.1 "

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -196,9 +196,10 @@ TEST(OSM_FactHandler, node) {
 
   ASSERT_EQ(
       "osmnode:42 rdf:type osm:node .\n"
-      "osmnode:42 geo:hasGeometry \"POINT(7.5 48.0)\"^^geo:wktLiteral .\n"
+      "osmnode:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmnode:42 osmkey:city \"Freiburg\" .\n"
       "osmnode:42 osm2rdf:facts \"1\"^^xsd:integer .\n"
+      "osmnode:42 geo:hasGeometry \"POINT(7.5 48.0)\"^^geo:wktLiteral .\n"
       "osmnode:42 osm2rdfgeom:convex_hull \"POLYGON((7.5 48.0,7.5 48.0,7.5 "
       "48.0,7.5 48.0,7.5 48.0))\"^^geo:wktLiteral .\n"
       "osmnode:42 osm2rdfgeom:envelope \"POLYGON((7.5 48.0,7.5 48.0,7.5 "
@@ -251,6 +252,7 @@ TEST(OSM_FactHandler, relation) {
 
   ASSERT_EQ(
       "osmrel:42 rdf:type osm:relation .\n"
+      "osmrel:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmrel:42 osmkey:city \"Freiburg\" .\n"
       "osmrel:42 osm2rdf:facts \"1\"^^xsd:integer .\n"
       "osmrel:42 osmrel:member _:0_0 .\n"
@@ -350,6 +352,7 @@ TEST(OSM_FactHandler, relationWithGeometry) {
 
   ASSERT_EQ(
       "osmrel:42 rdf:type osm:relation .\n"
+      "osmrel:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmrel:42 osmkey:city \"Freiburg\" .\n"
       "osmrel:42 osm2rdf:facts \"1\"^^xsd:integer .\n"
       "osmrel:42 osmrel:member _:0_0 .\n"
@@ -415,6 +418,7 @@ TEST(OSM_FactHandler, way) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
+      "osmway:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmway:42 osmkey:city \"Freiburg\" .\n"
       "osmway:42 osm2rdf:facts \"1\"^^xsd:integer .\n"
       "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
@@ -473,6 +477,7 @@ TEST(OSM_FactHandler, wayAddWayNodeGeoemtry) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
+      "osmway:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmway:42 osmkey:city \"Freiburg\" .\n"
       "osmway:42 osm2rdf:facts \"1\"^^xsd:integer .\n"
       "osmway:42 osmway:node _:0_0 .\n"
@@ -540,6 +545,7 @@ TEST(OSM_FactHandler, wayAddWayNodeOrder) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
+      "osmway:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmway:42 osmkey:city \"Freiburg\" .\n"
       "osmway:42 osm2rdf:facts \"1\"^^xsd:integer .\n"
       "osmway:42 osmway:node _:0_0 .\n"
@@ -604,6 +610,7 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataShortWay) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
+      "osmway:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmway:42 osmkey:city \"Freiburg\" .\n"
       "osmway:42 osm2rdf:facts \"1\"^^xsd:integer .\n"
       "osmway:42 osmway:node _:0_0 .\n"
@@ -673,6 +680,7 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataLongerWay) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
+      "osmway:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmway:42 osmkey:city \"Freiburg\" .\n"
       "osmway:42 osm2rdf:facts \"1\"^^xsd:integer .\n"
       "osmway:42 osmway:node _:0_0 .\n"
@@ -748,6 +756,7 @@ TEST(OSM_FactHandler, wayAddWayMetaData) {
 
   ASSERT_EQ(
       "osmway:42 rdf:type osm:way .\n"
+      "osmway:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmway:42 osmkey:city \"Freiburg\" .\n"
       "osmway:42 osm2rdf:facts \"1\"^^xsd:integer .\n"
       "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -1811,4 +1811,694 @@ TEST(OSM_FactHandler, writeTagListSkipWikiLinks) {
   // Cleanup
   std::cout.rdbuf(sbuf);
 }
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateInvalid) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "lorem";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::Not(::testing::HasSubstr("ear")));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateInvalid2) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "-lo-r-em-";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::Not(::testing::HasSubstr("ear")));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateInvalid3) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "-1111-22-33-44";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::Not(::testing::HasSubstr("ear")));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateYear1) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "11";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+  const std::string predicate2 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, tagKey);
+  const std::string object2 = writer.generateLiteral(
+      "0011", "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR);
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate2 +
+                                                " " + object2 + " .\n"));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateYear2) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "-11";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+  const std::string predicate2 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, tagKey);
+  const std::string object2 = writer.generateLiteral(
+      "-0011", "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR);
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate2 +
+                                                " " + object2 + " .\n"));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateYear3) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "1111";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+  const std::string predicate2 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, tagKey);
+  const std::string object2 = writer.generateLiteral(
+      tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR);
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate2 +
+                                                " " + object2 + " .\n"));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateYear4) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "-1111";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+  const std::string predicate2 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, tagKey);
+  const std::string object2 = writer.generateLiteral(
+      tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR);
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate2 +
+                                                " " + object2 + " .\n"));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateYearMonth1) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "11-1";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+  const std::string predicate2 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, tagKey);
+  const std::string object2 = writer.generateLiteral(
+      "0011-01", "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR_MONTH);
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate2 +
+                                                " " + object2 + " .\n"));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateYearMonth2) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "-11-1";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+  const std::string predicate2 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, tagKey);
+  const std::string object2 = writer.generateLiteral(
+      "-0011-01", "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR_MONTH);
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate2 +
+                                                " " + object2 + " .\n"));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateYearMonth3) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "1111-11";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+  const std::string predicate2 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, tagKey);
+  const std::string object2 = writer.generateLiteral(
+      tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR_MONTH);
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate2 +
+                                                " " + object2 + " .\n"));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateYearMonth4) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "-1111-11";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+  const std::string predicate2 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, tagKey);
+  const std::string object2 = writer.generateLiteral(
+      tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR_MONTH);
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate2 +
+                                                " " + object2 + " .\n"));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay1) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "11-1-1";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+  const std::string predicate2 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, tagKey);
+  const std::string object2 = writer.generateLiteral(
+      "0011-01-01", "^^" + osm2rdf::ttl::constants::IRI__XSD_DATE);
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate2 +
+                                                " " + object2 + " .\n"));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay2) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "-11-1-1";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+  const std::string predicate2 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, tagKey);
+  const std::string object2 = writer.generateLiteral(
+      "-0011-01-01", "^^" + osm2rdf::ttl::constants::IRI__XSD_DATE);
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate2 +
+                                                " " + object2 + " .\n"));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay3) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "1111-11-11";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+  const std::string predicate2 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, tagKey);
+  const std::string object2 = writer.generateLiteral(
+      tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_DATE);
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate2 +
+                                                " " + object2 + " .\n"));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
+
+// ____________________________________________________________________________
+TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay4) {
+  // Capture std::cout
+  std::stringstream buffer;
+  std::streambuf* sbuf = std::cout.rdbuf();
+  std::cout.rdbuf(buffer.rdbuf());
+
+  osm2rdf::config::Config config;
+  config.output = "";
+  config.hasGeometryAsWkt = true;
+  config.outputCompress = false;
+  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
+
+  osm2rdf::util::Output output{config, config.output};
+  output.open();
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::osm::FactHandler dh{config, &writer};
+
+  const std::string tagKey = "start_date";
+  const std::string tagValue = "-1111-11-11";
+
+  const std::string subject = "subject";
+  const std::string predicate1 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_TAG, tagKey);
+  const std::string object1 = writer.generateLiteral(tagValue, "");
+  const std::string predicate2 =
+      writer.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, tagKey);
+  const std::string object2 = writer.generateLiteral(
+      tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_DATE);
+
+  osm2rdf::osm::TagList tagList;
+  tagList[tagKey] = tagValue;
+
+  dh.writeTagList(subject, tagList);
+  output.flush();
+  output.close();
+
+  const std::string printedData = buffer.str();
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate1 +
+                                                " " + object1 + " .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(subject + " " + predicate2 +
+                                                " " + object2 + " .\n"));
+
+  // Cleanup
+  std::cout.rdbuf(sbuf);
+}
 }  // namespace osm2rdf::osm

--- a/tests/ttl/Writer.cpp
+++ b/tests/ttl/Writer.cpp
@@ -707,8 +707,8 @@ TEST(TTL_WriterTTL, writeStatisticJson) {
   statsBuffer << statsIFStream.rdbuf();
 
   ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"blankNodes\": 3"));
-  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"header\": 16"));
-  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"lines\": 21"));
+  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"header\": 17"));
+  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"lines\": 22"));
   ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"triples\": 5"));
 
   // Cleanup
@@ -770,8 +770,8 @@ TEST(TTL_WriterQLEVER, writeStatisticJson) {
   statsBuffer << statsIFStream.rdbuf();
 
   ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"blankNodes\": 3"));
-  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"header\": 16"));
-  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"lines\": 21"));
+  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"header\": 17"));
+  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"lines\": 22"));
   ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"triples\": 5"));
 
   // Cleanup

--- a/tests/ttl/Writer.cpp
+++ b/tests/ttl/Writer.cpp
@@ -674,6 +674,7 @@ TEST(TTL_WriterTTL, writeStatisticJson) {
   // Setup temp dir and stats file
   std::filesystem::path tmpDir =
       config.getTempPath("TEST_TTL_WriterTTL", "writeStatisticJson");
+  std::filesystem::remove_all(tmpDir);
   ASSERT_FALSE(std::filesystem::exists(tmpDir));
   std::filesystem::create_directories(tmpDir);
   ASSERT_TRUE(std::filesystem::exists(tmpDir));
@@ -706,8 +707,8 @@ TEST(TTL_WriterTTL, writeStatisticJson) {
   statsBuffer << statsIFStream.rdbuf();
 
   ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"blankNodes\": 3"));
-  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"header\": 12"));
-  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"lines\": 17"));
+  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"header\": 16"));
+  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"lines\": 21"));
   ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"triples\": 5"));
 
   // Cleanup
@@ -736,6 +737,7 @@ TEST(TTL_WriterQLEVER, writeStatisticJson) {
   // Setup temp dir and stats file
   std::filesystem::path tmpDir =
       config.getTempPath("TEST_TTL_WriterQLEVER", "writeStatisticJson");
+  std::filesystem::remove_all(tmpDir);
   ASSERT_FALSE(std::filesystem::exists(tmpDir));
   std::filesystem::create_directories(tmpDir);
   ASSERT_TRUE(std::filesystem::exists(tmpDir));
@@ -768,8 +770,8 @@ TEST(TTL_WriterQLEVER, writeStatisticJson) {
   statsBuffer << statsIFStream.rdbuf();
 
   ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"blankNodes\": 3"));
-  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"header\": 12"));
-  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"lines\": 17"));
+  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"header\": 16"));
+  ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"lines\": 21"));
   ASSERT_THAT(statsBuffer.str(), ::testing::HasSubstr("\"triples\": 5"));
 
   // Cleanup


### PR DESCRIPTION
This PR improves the support for OHM. It addresses among other things:
* Configurable `approx_contains_slack` with different default values for OHM (`0`) and OSM (`0.05`)
* #69 
* prefix names mentioned in ad-freiburg/qlever#1220
* basic support for `start_date` and `end_date` mentioned in ad-freiburg/qlever#1220