### PR TITLE
Add osm2rdf meta information triples

### DIFF
--- a/apps/osm2rdf.cpp
+++ b/apps/osm2rdf.cpp
@@ -41,6 +41,11 @@ void run(const osm2rdf::config::Config& config) {
   }
   osm2rdf::ttl::Writer<T> writer{config, &output};
   writer.writeHeader();
+  writer.writeTriple(
+      osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
+      writer.generateIRIUnsafe(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF,
+                               "git-info"),
+      osm2rdf::version::GIT_INFO);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
   osmiumHandler.handle();


### PR DESCRIPTION
It would be nice for the TTL dumps to contain some information on how they were created.

This PR so far add a single triple containing the `VERSION_GIT_FULL` string.

It would also be nice for the dump to contain information on the command line parameters / config the build was started with.