### PR TITLE
Remove --hasgeometry-as-wkt

### DIFF
--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -77,7 +77,6 @@ struct Config {
   bool addWayNodeGeometry = false;
   bool addWayNodeOrder = false;
   bool addWayNodeSpatialMetadata = false;
-  bool hasGeometryAsWkt = false;
   bool skipWikiLinks = false;
 
   // Default settings for data

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -192,14 +192,6 @@ const static inline std::string ADD_AREA_WAY_LINESTRINGS_OPTION_LONG =
 const static inline std::string ADD_AREA_WAY_LINESTRINGS_OPTION_HELP =
     "Add linestrings for ways which form areas";
 
-const static inline std::string HASGEOMETRY_AS_WKT_INFO =
-    "Letting geo:hasGeometry point directly to WKT serialization literal";
-const static inline std::string HASGEOMETRY_AS_WKT_OPTION_SHORT = "";
-const static inline std::string HASGEOMETRY_AS_WKT_OPTION_LONG =
-    "hasgeometry-as-wkt";
-const static inline std::string HASGEOMETRY_AS_WKT_OPTION_HELP =
-    "Let geo:hasGeometry point directly to a WKT literal";
-
 const static inline std::string ADD_WAY_METADATA_INFO = "Adding way metadata";
 const static inline std::string ADD_WAY_METADATA_OPTION_SHORT = "";
 const static inline std::string ADD_WAY_METADATA_OPTION_LONG =

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -296,10 +296,6 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
       osm2rdf::config::constants::ADD_WAY_NODE_SPATIAL_METADATA_OPTION_SHORT,
       osm2rdf::config::constants::ADD_WAY_NODE_SPATIAL_METADATA_OPTION_LONG,
       osm2rdf::config::constants::ADD_WAY_NODE_SPATIAL_METADATA_OPTION_HELP);
-  auto hasGeometryAsWktOp = parser.add<popl::Switch>(
-      osm2rdf::config::constants::HASGEOMETRY_AS_WKT_OPTION_SHORT,
-      osm2rdf::config::constants::HASGEOMETRY_AS_WKT_OPTION_LONG,
-      osm2rdf::config::constants::HASGEOMETRY_AS_WKT_OPTION_HELP);
   auto skipWikiLinksOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::SKIP_WIKI_LINKS_OPTION_SHORT,
       osm2rdf::config::constants::SKIP_WIKI_LINKS_OPTION_LONG,
@@ -497,7 +493,6 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
     addWayNodeGeometry = addWayNodeGeometryOp->is_set();
     addWayNodeOrder = addWayNodeOrderOp->is_set();
     addWayNodeSpatialMetadata = addWayNodeSpatialMetadataOp->is_set();
-    hasGeometryAsWkt = hasGeometryAsWktOp->is_set();
     skipWikiLinks = skipWikiLinksOp->is_set();
     simplifyGeometries = simplifyGeometriesOp->value();
     simplifyGeometriesInnerOuter = simplifyGeometriesInnerOuterOp->value();

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -42,8 +42,8 @@ using osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__CONVEX_HULL;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__ENVELOPE;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__OBB;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_MEMBER__ID;
-using osm2rdf::ttl::constants::IRI__OSM2RDF_MEMBER__ROLE;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_MEMBER__POS;
+using osm2rdf::ttl::constants::IRI__OSM2RDF_MEMBER__ROLE;
 using osm2rdf::ttl::constants::IRI__OSM_NODE;
 using osm2rdf::ttl::constants::IRI__OSM_RELATION;
 using osm2rdf::ttl::constants::IRI__OSM_TAG;
@@ -92,17 +92,13 @@ void osm2rdf::osm::FactHandler<W>::area(const osm2rdf::osm::Area& area) {
                      : RELATION_NAMESPACE[_config.sourceDataset],
       area.objId());
 
-  if (!_config.hasGeometryAsWkt) {
-    const std::string& geomObj = _writer->generateIRI(
-        NAMESPACE__OSM2RDF_GEOM, DATASET_ID[_config.sourceDataset] + "_" +
-                                     (area.fromWay() ? "way" : "rel") +
-                                     "area_" + std::to_string(area.objId()));
+  const std::string& geomObj = _writer->generateIRI(
+      NAMESPACE__OSM2RDF_GEOM, DATASET_ID[_config.sourceDataset] + "_" +
+                                   (area.fromWay() ? "way" : "rel") + "area_" +
+                                   std::to_string(area.objId()));
 
-    _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
-    writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, area.geom());
-  } else {
-    writeBoostGeometry(subj, IRI__GEOSPARQL__HAS_GEOMETRY, area.geom());
-  }
+  _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
+  writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, area.geom());
 
   writeBoostGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, area.convexHull());
   writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, area.envelope());
@@ -128,16 +124,12 @@ void osm2rdf::osm::FactHandler<W>::node(const osm2rdf::osm::Node& node) {
   writeSecondsAsISO(subj, IRI__OSMMETA_TIMESTAMP, node.timestamp());
   writeTagList(subj, node.tags());
 
-  if (!_config.hasGeometryAsWkt) {
-    const std::string& geomObj = _writer->generateIRI(
-        NAMESPACE__OSM2RDF_GEOM, DATASET_ID[_config.sourceDataset] + "_node_" +
-                                     std::to_string(node.id()));
+  const std::string& geomObj = _writer->generateIRI(
+      NAMESPACE__OSM2RDF_GEOM,
+      DATASET_ID[_config.sourceDataset] + "_node_" + std::to_string(node.id()));
 
-    _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
-    writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, node.geom());
-  } else {
-    writeBoostGeometry(subj, IRI__GEOSPARQL__HAS_GEOMETRY, node.geom());
-  }
+  _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
+  writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, node.geom());
 
   writeBoostGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, node.convexHull());
   writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, node.envelope());
@@ -179,11 +171,9 @@ void osm2rdf::osm::FactHandler<W>::relation(
         subj, _writer->generateIRIUnsafe(NAMESPACE__OSM_RELATION, "member"),
         blankNode);
 
-    _writer->writeTriple(blankNode,
-                         IRI__OSM2RDF_MEMBER__ID,
+    _writer->writeTriple(blankNode, IRI__OSM2RDF_MEMBER__ID,
                          _writer->generateIRI(type, member.id()));
-    _writer->writeTriple(blankNode,
-                         IRI__OSM2RDF_MEMBER__ROLE,
+    _writer->writeTriple(blankNode, IRI__OSM2RDF_MEMBER__ROLE,
                          _writer->generateLiteral(role, ""));
     _writer->writeTriple(
         blankNode, IRI__OSM2RDF_MEMBER__POS,
@@ -193,17 +183,13 @@ void osm2rdf::osm::FactHandler<W>::relation(
 
 #if BOOST_VERSION >= 107800
   if (relation.hasGeometry() && !relation.isArea()) {
-    if (!_config.hasGeometryAsWkt) {
-      const std::string& geomObj = _writer->generateIRI(
-          NAMESPACE__OSM2RDF_GEOM, DATASET_ID[_config.sourceDataset] +
-                                       "_relation_" +
-                                       std::to_string(relation.id()));
+    const std::string& geomObj =
+        _writer->generateIRI(NAMESPACE__OSM2RDF_GEOM,
+                             DATASET_ID[_config.sourceDataset] + "_relation_" +
+                                 std::to_string(relation.id()));
 
-      _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
-      writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, relation.geom());
-    } else {
-      writeBoostGeometry(subj, IRI__GEOSPARQL__HAS_GEOMETRY, relation.geom());
-    }
+    _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
+    writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, relation.geom());
 
     writeBoostGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL,
                        relation.convexHull());
@@ -255,17 +241,12 @@ void osm2rdf::osm::FactHandler<W>::way(const osm2rdf::osm::Way& way) {
 
         _writer->writeTriple(subj, IRI__RDF_TYPE, IRI__OSM_NODE);
 
-        if (!_config.hasGeometryAsWkt) {
-          const std::string& geomObj =
-              _writer->generateIRI(NAMESPACE__OSM2RDF_GEOM,
-                                   DATASET_ID[_config.sourceDataset] +
-                                       "_node_" + std::to_string(node.id()));
+        const std::string& geomObj = _writer->generateIRI(
+            NAMESPACE__OSM2RDF_GEOM, DATASET_ID[_config.sourceDataset] +
+                                         "_node_" + std::to_string(node.id()));
 
-          _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
-          writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, node.geom());
-        } else {
-          writeBoostGeometry(subj, IRI__GEOSPARQL__HAS_GEOMETRY, node.geom());
-        }
+        _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
+        writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, node.geom());
       }
 
       if (_config.addWayNodeSpatialMetadata && !lastBlankNode.empty()) {
@@ -300,15 +281,11 @@ void osm2rdf::osm::FactHandler<W>::way(const osm2rdf::osm::Way& way) {
   size_t numUniquePoints = locations.size();
 
   if (_config.addAreaWayLinestrings || !way.isArea()) {
-    if (!_config.hasGeometryAsWkt) {
-      const std::string& geomObj = _writer->generateIRI(
-          NAMESPACE__OSM2RDF, "way_" + std::to_string(way.id()));
+    const std::string& geomObj = _writer->generateIRI(
+        NAMESPACE__OSM2RDF, "way_" + std::to_string(way.id()));
 
-      _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
-      writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, locations);
-    } else {
-      writeBoostGeometry(subj, IRI__GEOSPARQL__HAS_GEOMETRY, locations);
-    }
+    _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
+    writeBoostGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, locations);
   }
 
   writeBoostGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, way.convexHull());
@@ -466,8 +443,7 @@ void osm2rdf::osm::FactHandler<W>::writeTagList(
           valueTmp.end());
 
       _writer->writeTriple(
-          subj,
-          _writer->generateIRI(NAMESPACE__OSM2RDF_TAG, key),
+          subj, _writer->generateIRI(NAMESPACE__OSM2RDF_TAG, key),
           _writer->generateIRI(NAMESPACE__WIKIDATA_ENTITY, valueTmp));
       tagTripleCount++;
     }
@@ -478,22 +454,21 @@ void osm2rdf::osm::FactHandler<W>::writeTagList(
         const std::string& lang = value.substr(0, pos);
         const std::string& entry = value.substr(pos + 1);
         _writer->writeTriple(
-            subj,
-            _writer->generateIRI(NAMESPACE__OSM2RDF_TAG, key),
+            subj, _writer->generateIRI(NAMESPACE__OSM2RDF_TAG, key),
             _writer->generateIRI("https://" + lang + ".wikipedia.org/wiki/",
                                  entry));
         tagTripleCount++;
       } else {
         _writer->writeTriple(
-            subj,
-            _writer->generateIRI(NAMESPACE__OSM2RDF_TAG, key),
+            subj, _writer->generateIRI(NAMESPACE__OSM2RDF_TAG, key),
             _writer->generateIRI("https://www.wikipedia.org/wiki/", value));
         tagTripleCount++;
       }
     }
     if (key == "start_date" || key == "end_date") {
       // Abort if non digit and not -
-      if(std::any_of(value.cbegin(), value.cend(), [](char c) { return isdigit(c) == 0 && c != '-'; })) {
+      if (std::any_of(value.cbegin(), value.cend(),
+                      [](char c) { return isdigit(c) == 0 && c != '-'; })) {
         continue;
       }
 
@@ -535,11 +510,11 @@ void osm2rdf::osm::FactHandler<W>::writeTagList(
       }
       std::string typeString[3] = {IRI__XSD_YEAR, IRI__XSD_YEAR_MONTH,
                                    IRI__XSD_DATE};
-      _writer->writeTriple(subj,
-                           _writer->generateIRIUnsafe(NAMESPACE__OSM2RDF_TAG, key),
-                           _writer->generateLiteralUnsafe(
-                               newValue.substr(0, newValue.size() - 1),
-                               "^^" + typeString[resultType - 1]));
+      _writer->writeTriple(
+          subj, _writer->generateIRIUnsafe(NAMESPACE__OSM2RDF_TAG, key),
+          _writer->generateLiteralUnsafe(
+              newValue.substr(0, newValue.size() - 1),
+              "^^" + typeString[resultType - 1]));
     }
   }
   _writer->writeTriple(

--- a/tests/E2E.cpp
+++ b/tests/E2E.cpp
@@ -54,7 +54,6 @@ TEST(E2E, singleNode) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -120,7 +119,6 @@ TEST(E2E, singleNodeWithTags) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -174,7 +172,7 @@ TEST(E2E, singleNodeWithTags) {
               ::testing::HasSubstr("osmnode:925950614 rdf:type osm:node .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
-                  "osmnode:240092010 geo:hasGeometry \"POINT(7.8494005 "
+                  "osm2rdfgeom:osm_node_240092010 geo:asWKT \"POINT(7.8494005 "
                   "47.9960901)\"^^geo:wktLiteral .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
@@ -237,7 +235,6 @@ TEST(E2E, singleWayWithTagsAndNodes) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -320,7 +317,7 @@ TEST(E2E, singleWayWithTagsAndNodes) {
                                    "\"maps4bw (LGL, www.lgl-bw.de)\" .\n"));
   // No nodes -> no real geometry
   ASSERT_THAT(printedData,
-              ::testing::HasSubstr("osmway:98284318 geo:hasGeometry "
+              ::testing::HasSubstr("osm2rdf:way_98284318 geo:asWKT "
                                    "\"LINESTRING()\"^^geo:wktLiteral .\n"));
 
   // Reset std::cerr and std::cout
@@ -341,7 +338,6 @@ TEST(E2E, osmWikiExample) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -411,9 +407,8 @@ TEST(E2E, osmWikiExample) {
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "osmway:26659127 osmkey:name \"Pastower Straße\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:26659127 geo:hasGeometry \"LINESTRING("));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(
+                               "osm2rdf:way_26659127 geo:asWKT \"LINESTRING("));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr("osmrel:56688 rdf:type osm:relation .\n"));
   ASSERT_THAT(printedData,
@@ -437,7 +432,6 @@ TEST(E2E, building51NT) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
@@ -544,16 +538,17 @@ TEST(E2E, building51NT) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "<https://www.openstreetmap.org/way/98284318> "
-          "<http://www.opengis.net/ont/geosparql#hasGeometry> \"LINESTRING(7"));
+          "<https://osm2rdf.cs.uni-freiburg.de/rdf#way_98284318> "
+          "<http://www.opengis.net/ont/geosparql#asWKT> \"LINESTRING(7"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
           "7)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral> .\n"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(
-                               "<https://www.openstreetmap.org/way/98284318> "
-                               "<http://www.opengis.net/ont/"
-                               "geosparql#hasGeometry> \"MULTIPOLYGON(((7"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "<https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_wayarea_98284318> "
+          "<http://www.opengis.net/ont/geosparql#asWKT> \"MULTIPOLYGON(((7"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
@@ -607,7 +602,6 @@ TEST(E2E, building51TTL) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
@@ -697,11 +691,12 @@ TEST(E2E, building51TTL) {
                                    "\"maps4bw (LGL, www.lgl-bw.de)\" .\n"));
   ASSERT_THAT(
       printedData,
-      ::testing::HasSubstr("osmway:98284318 geo:hasGeometry \"LINESTRING(7"));
+      ::testing::HasSubstr("osm2rdf:way_98284318 geo:asWKT \"LINESTRING(7"));
   ASSERT_THAT(printedData, ::testing::HasSubstr("7)\"^^geo:wktLiteral .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "smway:98284318 geo:hasGeometry \"MULTIPOLYGON(((7"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osm2rdfgeom:osm_wayarea_98284318 geo:asWKT \"MULTIPOLYGON(((7"));
   ASSERT_THAT(printedData, ::testing::HasSubstr("0)))\"^^geo:wktLiteral .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
@@ -740,7 +735,6 @@ TEST(E2E, building51QLEVER) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
@@ -830,11 +824,12 @@ TEST(E2E, building51QLEVER) {
                                    "\"maps4bw (LGL, www.lgl-bw.de)\" .\n"));
   ASSERT_THAT(
       printedData,
-      ::testing::HasSubstr("osmway:98284318 geo:hasGeometry \"LINESTRING(7"));
+      ::testing::HasSubstr("osm2rdf:way_98284318 geo:asWKT \"LINESTRING(7"));
   ASSERT_THAT(printedData, ::testing::HasSubstr("7)\"^^geo:wktLiteral .\n"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "smway:98284318 geo:hasGeometry \"MULTIPOLYGON(((7"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osm2rdfgeom:osm_wayarea_98284318 geo:asWKT \"MULTIPOLYGON(((7"));
   ASSERT_THAT(printedData, ::testing::HasSubstr("0)))\"^^geo:wktLiteral .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
@@ -873,7 +868,6 @@ TEST(E2E, tf) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
@@ -944,12 +938,12 @@ TEST(E2E, tf) {
                                "\"Albert-Ludwigs-Universität Freiburg\" .\n"));
   ASSERT_THAT(printedData, ::testing::HasSubstr(
                                "osmway:4498466 osmkey:wheelchair \"yes\" .\n"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr(
+                               "osm2rdf:way_4498466 geo:asWKT \"LINESTRING(7"));
   ASSERT_THAT(
       printedData,
-      ::testing::HasSubstr("osmway:4498466 geo:hasGeometry \"LINESTRING(7"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:4498466 geo:hasGeometry \"MULTIPOLYGON(((7"));
+      ::testing::HasSubstr(
+          "osm2rdfgeom:osm_wayarea_4498466 geo:asWKT \"MULTIPOLYGON(((7"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -969,7 +963,6 @@ TEST(E2E, building51inTF) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
@@ -1066,10 +1059,11 @@ TEST(E2E, building51inTF) {
                                    "\"maps4bw (LGL, www.lgl-bw.de)\" .\n"));
   ASSERT_THAT(
       printedData,
-      ::testing::HasSubstr("osmway:98284318 geo:hasGeometry \"LINESTRING(7"));
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "smway:98284318 geo:hasGeometry \"MULTIPOLYGON(((7"));
+      ::testing::HasSubstr("osm2rdf:way_98284318 geo:asWKT \"LINESTRING(7"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osm2rdfgeom:osm_wayarea_98284318 geo:asWKT \"MULTIPOLYGON(((7"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr("osmway:4498466 rdf:type osm:way .\n"));
   ASSERT_THAT(printedData,
@@ -1084,12 +1078,9 @@ TEST(E2E, building51inTF) {
                                "\"Albert-Ludwigs-Universität Freiburg\" .\n"));
   ASSERT_THAT(printedData, ::testing::HasSubstr(
                                "osmway:4498466 osmkey:wheelchair \"yes\" .\n"));
-  ASSERT_THAT(
-      printedData,
-      ::testing::HasSubstr("osmway:4498466 geo:hasGeometry \"LINESTRING(7"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
-                  "osmway:4498466 geo:hasGeometry \"MULTIPOLYGON(((7"));
+                  "osm2rdfgeom:osm_wayarea_4498466 geo:asWKT \"MULTIPOLYGON(((7"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "osmway:4498466 ogc:sfContains osmway:98284318 .\n"));

--- a/tests/issues/Issue15.cpp
+++ b/tests/issues/Issue15.cpp
@@ -39,7 +39,6 @@ TEST(Issue15, Relation_8291361_expected) {
   osm2rdf::config::Config config;
   config.noGeometricRelations = true;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.input = "../../tests/issues/issue15_osmrel_8291361.xml";
@@ -69,9 +68,10 @@ TEST(Issue15, Relation_8291361_expected) {
   ASSERT_THAT(printedState,
               ::testing::HasSubstr("ways seen:47 dumped: 1 geometry: 0\n"));
   const auto printedData = coutBuffer.str();
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmrel:8291361 geo:hasGeometry \"MULTIPOLYGON(((14"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osm2rdfgeom:osm_relarea_8291361 geo:asWKT \"MULTIPOLYGON(((14"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -91,7 +91,6 @@ TEST(Issue15, Relation_8291361_failed) {
   osm2rdf::config::Config config;
   config.noGeometricRelations = true;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.input = "../../tests/issues/issue15_osmrel_8291361.xml";
@@ -117,9 +116,10 @@ TEST(Issue15, Relation_8291361_failed) {
   ASSERT_THAT(printedState,
               ::testing::HasSubstr("ways seen:47 dumped: 1 geometry: 0\n"));
   const auto printedData = coutBuffer.str();
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmrel:8291361 geo:hasGeometry \"MULTIPOLYGON(((14"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osm2rdfgeom:osm_relarea_8291361 geo:asWKT \"MULTIPOLYGON(((14"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -139,7 +139,6 @@ TEST(Issue15, Way_201387026_expected) {
   osm2rdf::config::Config config;
   config.noGeometricRelations = true;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.input = "../../tests/issues/issue15_osmway_201387026.xml";
@@ -169,9 +168,10 @@ TEST(Issue15, Way_201387026_expected) {
   ASSERT_THAT(printedState,
               ::testing::HasSubstr("ways seen:1 dumped: 1 geometry: 0\n"));
   const auto printedData = coutBuffer.str();
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:201387026 geo:hasGeometry \"MULTIPOLYGON(((1"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osm2rdfgeom:osm_wayarea_201387026 geo:asWKT \"MULTIPOLYGON(((1"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -191,7 +191,6 @@ TEST(Issue15, Way_201387026_failed) {
   osm2rdf::config::Config config;
   config.noGeometricRelations = true;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.input = "../../tests/issues/issue15_osmway_201387026.xml";
@@ -217,9 +216,10 @@ TEST(Issue15, Way_201387026_failed) {
   ASSERT_THAT(printedState,
               ::testing::HasSubstr("ways seen:1 dumped: 1 geometry: 0\n"));
   const auto printedData = coutBuffer.str();
-  ASSERT_THAT(printedData,
-              ::testing::HasSubstr(
-                  "osmway:201387026 geo:hasGeometry \"MULTIPOLYGON(((1"));
+  ASSERT_THAT(
+      printedData,
+      ::testing::HasSubstr(
+          "osm2rdfgeom:osm_wayarea_201387026 geo:asWKT \"MULTIPOLYGON(((1"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);

--- a/tests/issues/Issue24.cpp
+++ b/tests/issues/Issue24.cpp
@@ -25,57 +25,6 @@
 namespace osm2rdf::util {
 
 // ____________________________________________________________________________
-TEST(Issue24, areaFromWayHasGeometryAsWkt) {
-  // Capture std::cout
-  std::stringstream buffer;
-  std::streambuf* sbuf = std::cout.rdbuf();
-  std::cout.rdbuf(buffer.rdbuf());
-
-  osm2rdf::config::Config config;
-  config.output = "";
-  config.hasGeometryAsWkt = true;
-  config.outputCompress = false;
-  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
-
-  osm2rdf::util::Output output{config, config.output};
-  output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
-  osm2rdf::osm::FactHandler dh{config, &writer};
-
-  // Create osmium object
-  const size_t initial_buffer_size = 10000;
-  osmium::memory::Buffer osmiumBuffer{initial_buffer_size,
-                                      osmium::memory::Buffer::auto_grow::yes};
-  osmium::builder::add_area(osmiumBuffer, osmium::builder::attr::_id(42),
-                            osmium::builder::attr::_outer_ring({
-                                {1, {48.0, 7.51}},
-                                {2, {48.0, 7.61}},
-                                {3, {48.1, 7.61}},
-                                {4, {48.1, 7.51}},
-                                {1, {48.0, 7.51}},
-                            }));
-
-  // Create osm2rdf object from osmium object
-  const osm2rdf::osm::Area a{osmiumBuffer.get<osmium::Area>(0)};
-
-  dh.area(a);
-  output.flush();
-  output.close();
-
-  ASSERT_EQ(
-      "osmway:21 geo:hasGeometry \"MULTIPOLYGON(((48.0 7.5,48.0 7.6,48.1 7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral .\n"
-      "osmway:21 osm2rdfgeom:convex_hull \"POLYGON(())\"^^geo:wktLiteral .\n"
-      "osmway:21 osm2rdfgeom:envelope \"POLYGON((48.0 7.5,48.0 7.6,48.1 7.6,48.1 7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
-      "osmway:21 osm2rdfgeom:obb \"POLYGON(())\"^^geo:wktLiteral .\n"
-      "osmway:21 osm2rdf:area \"0.000000000000\"^^xsd:double .\n",
-      buffer.str());
-
-  // Cleanup
-  std::cout.rdbuf(sbuf);
-}
-
-// ____________________________________________________________________________
 TEST(Issue24, areaFromWayHasGeometryAsGeoSPARQL) {
   // Capture std::cout
   std::stringstream buffer;
@@ -84,7 +33,6 @@ TEST(Issue24, areaFromWayHasGeometryAsGeoSPARQL) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = false;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -130,59 +78,6 @@ TEST(Issue24, areaFromWayHasGeometryAsGeoSPARQL) {
 }
 
 // ____________________________________________________________________________
-TEST(Issue24, areaFromRelationHasGeometryAsWkt) {
-  // Capture std::cout
-  std::stringstream buffer;
-  std::streambuf* sbuf = std::cout.rdbuf();
-  std::cout.rdbuf(buffer.rdbuf());
-
-  osm2rdf::config::Config config;
-  config.output = "";
-  config.hasGeometryAsWkt = true;
-  config.outputCompress = false;
-  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
-
-  osm2rdf::util::Output output{config, config.output};
-  output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
-  osm2rdf::osm::FactHandler dh{config, &writer};
-
-  // Create osmium object
-  const size_t initial_buffer_size = 10000;
-  osmium::memory::Buffer osmiumBuffer{initial_buffer_size,
-                                      osmium::memory::Buffer::auto_grow::yes};
-  osmium::builder::add_area(osmiumBuffer, osmium::builder::attr::_id(21),
-                            osmium::builder::attr::_outer_ring({
-                                {1, {48.0, 7.51}},
-                                {2, {48.0, 7.61}},
-                                {3, {48.1, 7.61}},
-                                {4, {48.1, 7.51}},
-                                {1, {48.0, 7.51}},
-                            }));
-
-  // Create osm2rdf object from osmium object
-  const osm2rdf::osm::Area a{osmiumBuffer.get<osmium::Area>(0)};
-
-  dh.area(a);
-  output.flush();
-  output.close();
-
-  ASSERT_EQ(
-      "osmrel:10 geo:hasGeometry \"MULTIPOLYGON(((48.0 7.5,48.0 7.6,48.1 "
-      "7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral .\n"
-      "osmrel:10 osm2rdfgeom:convex_hull \"POLYGON(())\"^^geo:wktLiteral .\n"
-      "osmrel:10 osm2rdfgeom:envelope \"POLYGON((48.0 7.5,48.0 7.6,48.1 "
-      "7.6,48.1 7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
-      "osmrel:10 osm2rdfgeom:obb \"POLYGON(())\"^^geo:wktLiteral .\n"
-      "osmrel:10 osm2rdf:area \"0.000000000000\"^^xsd:double .\n",
-      buffer.str());
-
-  // Cleanup
-  std::cout.rdbuf(sbuf);
-}
-
-// ____________________________________________________________________________
 TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
   // Capture std::cout
   std::stringstream buffer;
@@ -191,7 +86,6 @@ TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = false;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -226,62 +120,13 @@ TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
       "osmrel:10 geo:hasGeometry osm2rdfgeom:osm_relarea_10 .\n"
       "osm2rdfgeom:osm_relarea_10 geo:asWKT \"MULTIPOLYGON(((48.0 7.5,48.0 "
       "7.6,48.1 7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral .\n"
-      "osmrel:10 osm2rdfgeom:convex_hull \"POLYGON((48.0 7.5,48.0 7.6,48.1 7.6,48.1 7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
+      "osmrel:10 osm2rdfgeom:convex_hull \"POLYGON((48.0 7.5,48.0 7.6,48.1 "
+      "7.6,48.1 7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
       "osmrel:10 osm2rdfgeom:envelope \"POLYGON((48.0 7.5,48.0 7.6,48.1 "
       "7.6,48.1 7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
-      "osmrel:10 osm2rdfgeom:obb \"POLYGON((48.0 7.6,48.1 7.6,48.1 7.5,48.0 7.5,48.0 7.6))\"^^geo:wktLiteral .\n"
+      "osmrel:10 osm2rdfgeom:obb \"POLYGON((48.0 7.6,48.1 7.6,48.1 7.5,48.0 "
+      "7.5,48.0 7.6))\"^^geo:wktLiteral .\n"
       "osmrel:10 osm2rdf:area \"0.010000000000\"^^xsd:double .\n",
-      buffer.str());
-
-  // Cleanup
-  std::cout.rdbuf(sbuf);
-}
-
-// ____________________________________________________________________________
-TEST(Issue24, nodeHasGeometryAsWkt) {
-  // Capture std::cout
-  std::stringstream buffer;
-  std::streambuf* sbuf = std::cout.rdbuf();
-  std::cout.rdbuf(buffer.rdbuf());
-
-  osm2rdf::config::Config config;
-  config.output = "";
-  config.hasGeometryAsWkt = true;
-  config.outputCompress = false;
-  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
-
-  osm2rdf::util::Output output{config, config.output};
-  output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
-  osm2rdf::osm::FactHandler dh{config, &writer};
-
-  // Create osmium object
-  const size_t initial_buffer_size = 10000;
-  osmium::memory::Buffer osmiumBuffer{initial_buffer_size,
-                                      osmium::memory::Buffer::auto_grow::yes};
-  osmium::builder::add_node(
-      osmiumBuffer, osmium::builder::attr::_id(42),
-      osmium::builder::attr::_location(osmium::Location(7.51, 48.0)));
-
-  // Create osm2rdf object from osmium object
-  const osm2rdf::osm::Node n{osmiumBuffer.get<osmium::Node>(0)};
-
-  dh.node(n);
-  output.flush();
-  output.close();
-
-  ASSERT_EQ(
-      "osmnode:42 rdf:type osm:node .\n"
-      "osmnode:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
-      "osmnode:42 osm2rdf:facts \"0\"^^xsd:integer .\n"
-      "osmnode:42 geo:hasGeometry \"POINT(7.5 48.0)\"^^geo:wktLiteral .\n"
-      "osmnode:42 osm2rdfgeom:convex_hull \"POLYGON((7.5 48.0,7.5 48.0,7.5 "
-      "48.0,7.5 48.0,7.5 48.0))\"^^geo:wktLiteral .\n"
-      "osmnode:42 osm2rdfgeom:envelope \"POLYGON((7.5 48.0,7.5 48.0,7.5 "
-      "48.0,7.5 48.0,7.5 48.0))\"^^geo:wktLiteral .\n"
-      "osmnode:42 osm2rdfgeom:obb \"POLYGON((7.5 48.0,7.5 48.0,7.5 48.0,7.5 "
-      "48.0,7.5 48.0))\"^^geo:wktLiteral .\n",
       buffer.str());
 
   // Cleanup
@@ -297,7 +142,6 @@ TEST(Issue24, nodeHasGeometryAsGeoSPARQL) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = false;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -327,7 +171,8 @@ TEST(Issue24, nodeHasGeometryAsGeoSPARQL) {
       "osmnode:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmnode:42 osm2rdf:facts \"0\"^^xsd:integer .\n"
       "osmnode:42 geo:hasGeometry osm2rdfgeom:osm_node_42 .\n"
-      "osm2rdfgeom:osm_node_42 geo:asWKT \"POINT(7.5 48.0)\"^^geo:wktLiteral .\n"
+      "osm2rdfgeom:osm_node_42 geo:asWKT \"POINT(7.5 48.0)\"^^geo:wktLiteral "
+      ".\n"
       "osmnode:42 osm2rdfgeom:convex_hull \"POLYGON((7.5 48.0,7.5 48.0,7.5 "
       "48.0,7.5 48.0,7.5 48.0))\"^^geo:wktLiteral .\n"
       "osmnode:42 osm2rdfgeom:envelope \"POLYGON((7.5 48.0,7.5 48.0,7.5 "
@@ -342,103 +187,6 @@ TEST(Issue24, nodeHasGeometryAsGeoSPARQL) {
 
 #if BOOST_VERSION >= 107800
 // ____________________________________________________________________________
-TEST(Issue24, relationWithGeometryHasGeometryAsWkt) {
-  // Capture std::cout
-  std::stringstream buffer;
-  std::streambuf* sbuf = std::cout.rdbuf();
-  std::cout.rdbuf(buffer.rdbuf());
-
-  osm2rdf::config::Config config;
-  config.output = "";
-  config.hasGeometryAsWkt = true;
-  config.outputCompress = false;
-  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
-
-  osm2rdf::util::Output output{config, config.output};
-  output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
-  osm2rdf::osm::FactHandler dh{config, &writer};
-
-  // Create osmium object
-  const size_t initial_buffer_size = 10000;
-  osmium::memory::Buffer osmiumBuffer1{initial_buffer_size,
-                                       osmium::memory::Buffer::auto_grow::yes};
-  osmium::memory::Buffer osmiumBuffer2{initial_buffer_size,
-                                       osmium::memory::Buffer::auto_grow::yes};
-  osmium::memory::Buffer osmiumBuffer3{initial_buffer_size,
-                                       osmium::memory::Buffer::auto_grow::yes};
-  osmium::memory::Buffer osmiumBuffer4{initial_buffer_size,
-                                       osmium::memory::Buffer::auto_grow::yes};
-  osmium::memory::Buffer osmiumBuffer5{initial_buffer_size,
-                                       osmium::memory::Buffer::auto_grow::yes};
-  osmium::builder::add_relation(
-      osmiumBuffer1, osmium::builder::attr::_id(42),
-      osmium::builder::attr::_member(osmium::item_type::node, 23, "label"),
-      osmium::builder::attr::_member(osmium::item_type::way, 55, "outer"));
-  osmium::builder::add_node(
-      osmiumBuffer2, osmium::builder::attr::_id(1),
-      osmium::builder::attr::_location(osmium::Location(7.52, 48.0)));
-  osmium::builder::add_node(
-      osmiumBuffer3, osmium::builder::attr::_id(2),
-      osmium::builder::attr::_location(osmium::Location(7.61, 48.0)));
-  osmium::builder::add_node(
-      osmiumBuffer4, osmium::builder::attr::_id(23),
-      osmium::builder::attr::_location(osmium::Location(7.51, 48.0)));
-  osmium::builder::add_way(osmiumBuffer5, osmium::builder::attr::_id(55),
-                           osmium::builder::attr::_nodes({
-                               {1, {48.0, 7.52}},
-                               {2, {48.1, 7.61}},
-                           }));
-
-  osm2rdf::osm::RelationHandler rh = osm2rdf::osm::RelationHandler(config);
-  osm2rdf::osm::LocationHandler* lh =
-      osm2rdf::osm::LocationHandler::create(config);
-  // Create osm2rdf object from osmium object
-  osm2rdf::osm::Relation r{osmiumBuffer1.get<osmium::Relation>(0)};
-  rh.relation(osmiumBuffer1.get<osmium::Relation>(0));
-  // Fill location and relation handler with data.
-  lh->node(osmiumBuffer2.get<osmium::Node>(0));
-  lh->node(osmiumBuffer3.get<osmium::Node>(0));
-  lh->node(osmiumBuffer4.get<osmium::Node>(0));
-  rh.prepare_for_lookup();
-  rh.setLocationHandler(lh);
-  rh.way(osmiumBuffer5.get<osmium::Way>(0));
-
-  r.buildGeometry(rh);
-
-  dh.relation(r);
-  output.flush();
-  output.close();
-
-  ASSERT_EQ(
-      "osmrel:42 rdf:type osm:relation .\n"
-      "osmrel:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
-      "osmrel:42 osm2rdf:facts \"0\"^^xsd:integer .\n"
-      "osmrel:42 osmrel:member _:0_0 .\n"
-      "_:0_0 osm2rdfmember:id osmnode:23 .\n"
-      "_:0_0 osm2rdfmember:role \"label\" .\n"
-      "_:0_0 osm2rdfmember:pos \"0\"^^xsd:integer .\n"
-      "osmrel:42 osmrel:member _:0_1 .\n"
-      "_:0_1 osm2rdfmember:id osmway:55 .\n"
-      "_:0_1 osm2rdfmember:role \"outer\" .\n"
-      "_:0_1 osm2rdfmember:pos \"1\"^^xsd:integer .\n"
-      "osmrel:42 geo:hasGeometry \"GEOMETRYCOLLECTION(POINT(7.5 "
-      "48.0),LINESTRING(7.5 48.0,7.6 48.0))\"^^geo:wktLiteral .\n"
-      "osmrel:42 osm2rdfgeom:convex_hull \"POLYGON((7.5 48.0,7.6 48.0,7.5 "
-      "48.0,7.5 48.0))\"^^geo:wktLiteral .\n"
-      "osmrel:42 osm2rdfgeom:envelope \"POLYGON((7.5 48.0,7.5 48.0,7.6 "
-      "48.0,7.6 48.0,7.5 48.0))\"^^geo:wktLiteral .\n"
-      "osmrel:42 osm2rdfgeom:obb \"POLYGON((7.6 48.0,7.6 48.0,7.5 48.0,7.5 "
-      "48.0,7.6 48.0))\"^^geo:wktLiteral .\n"
-      "osmrel:42 osm2rdf:completeGeometry \"yes\" .\n",
-      buffer.str());
-
-  // Cleanup
-  std::cout.rdbuf(sbuf);
-}
-
-// ____________________________________________________________________________
 TEST(Issue24, relationWithGeometryHasGeometryAsGeoSPARQL) {
   // Capture std::cout
   std::stringstream buffer;
@@ -447,7 +195,6 @@ TEST(Issue24, relationWithGeometryHasGeometryAsGeoSPARQL) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = false;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -538,61 +285,6 @@ TEST(Issue24, relationWithGeometryHasGeometryAsGeoSPARQL) {
 #endif  // BOOST_VERSION >= 107800
 
 // ____________________________________________________________________________
-TEST(Issue24, wayHasGeometryAsWkt) {
-  // Capture std::cout
-  std::stringstream buffer;
-  std::streambuf* sbuf = std::cout.rdbuf();
-  std::cout.rdbuf(buffer.rdbuf());
-
-  osm2rdf::config::Config config;
-  config.output = "";
-  config.hasGeometryAsWkt = true;
-  config.outputCompress = false;
-  config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
-  config.wktPrecision = 1;
-
-  osm2rdf::util::Output output{config, config.output};
-  output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
-  osm2rdf::osm::FactHandler dh{config, &writer};
-
-  // Create osmium object
-  const size_t initial_buffer_size = 10000;
-  osmium::memory::Buffer osmiumBuffer{initial_buffer_size,
-                                      osmium::memory::Buffer::auto_grow::yes};
-  osmium::builder::add_way(osmiumBuffer, osmium::builder::attr::_id(42),
-                           osmium::builder::attr::_nodes({
-                               {1, {48.0, 7.51}},
-                               {2, {48.1, 7.61}},
-                           }));
-
-  // Create osm2rdf object from osmium object
-  const osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
-
-  dh.way(w);
-  output.flush();
-  output.close();
-
-  ASSERT_EQ(
-      "osmway:42 rdf:type osm:way .\n"
-      "osmway:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
-      "osmway:42 osm2rdf:facts \"0\"^^xsd:integer .\n"
-      "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
-      "7.6)\"^^geo:wktLiteral .\n"
-      "osmway:42 osm2rdfgeom:convex_hull \"POLYGON((48.0 7.5,48.1 7.6,48.0 "
-      "7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
-      "osmway:42 osm2rdfgeom:envelope \"POLYGON((48.0 7.5,48.0 7.6,48.1 "
-      "7.6,48.1 7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
-      "osmway:42 osm2rdfgeom:obb \"POLYGON((48.1 7.6,48.1 7.6,48.0 7.5,48.0 "
-      "7.5,48.1 7.6))\"^^geo:wktLiteral .\n"
-      "osmway:42 osm2rdf:length \"0.141421\"^^xsd:double .\n",
-      buffer.str());
-
-  // Cleanup
-  std::cout.rdbuf(sbuf);
-}
-
-// ____________________________________________________________________________
 TEST(Issue24, wayHasGeometryAsGeoSPARQL) {
   // Capture std::cout
   std::stringstream buffer;
@@ -601,7 +293,6 @@ TEST(Issue24, wayHasGeometryAsGeoSPARQL) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = false;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -54,7 +54,6 @@ TEST(OSM_FactHandler, areaFromWay) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -87,7 +86,9 @@ TEST(OSM_FactHandler, areaFromWay) {
   output.close();
 
   ASSERT_EQ(
-      "osmway:21 geo:hasGeometry \"MULTIPOLYGON(((48.0 7.5,48.0 7.6,48.1 "
+      "osmway:21 geo:hasGeometry osm2rdfgeom:osm_wayarea_21 .\n"
+      "osm2rdfgeom:osm_wayarea_21 geo:asWKT \"MULTIPOLYGON(((48.0 7.5,48.0 "
+      "7.6,48.1 "
       "7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral .\n"
       "osmway:21 osm2rdfgeom:convex_hull \"POLYGON((48.0 7.5,48.0 7.6,48.1 "
       "7.6,48.1 7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
@@ -111,7 +112,6 @@ TEST(OSM_FactHandler, areaFromRelation) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -144,7 +144,9 @@ TEST(OSM_FactHandler, areaFromRelation) {
   output.close();
 
   ASSERT_EQ(
-      "osmrel:10 geo:hasGeometry \"MULTIPOLYGON(((48.0 7.5,48.0 7.6,48.1 "
+      "osmrel:10 geo:hasGeometry osm2rdfgeom:osm_relarea_10 .\n"
+      "osm2rdfgeom:osm_relarea_10 geo:asWKT \"MULTIPOLYGON(((48.0 7.5,48.0 "
+      "7.6,48.1 "
       "7.6,48.1 7.5,48.0 7.5)))\"^^geo:wktLiteral .\n"
       "osmrel:10 osm2rdfgeom:convex_hull \"POLYGON((48.0 7.5,48.0 7.6,48.1 "
       "7.6,48.1 7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
@@ -168,7 +170,6 @@ TEST(OSM_FactHandler, node) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -199,7 +200,9 @@ TEST(OSM_FactHandler, node) {
       "osmnode:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmnode:42 osmkey:city \"Freiburg\" .\n"
       "osmnode:42 osm2rdf:facts \"1\"^^xsd:integer .\n"
-      "osmnode:42 geo:hasGeometry \"POINT(7.5 48.0)\"^^geo:wktLiteral .\n"
+      "osmnode:42 geo:hasGeometry osm2rdfgeom:osm_node_42 .\n"
+      "osm2rdfgeom:osm_node_42 geo:asWKT \"POINT(7.5 48.0)\"^^geo:wktLiteral "
+      ".\n"
       "osmnode:42 osm2rdfgeom:convex_hull \"POLYGON((7.5 48.0,7.5 48.0,7.5 "
       "48.0,7.5 48.0,7.5 48.0))\"^^geo:wktLiteral .\n"
       "osmnode:42 osm2rdfgeom:envelope \"POLYGON((7.5 48.0,7.5 48.0,7.5 "
@@ -221,7 +224,6 @@ TEST(OSM_FactHandler, relation) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -283,7 +285,6 @@ TEST(OSM_FactHandler, relationWithGeometry) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -359,7 +360,8 @@ TEST(OSM_FactHandler, relationWithGeometry) {
       "_:0_1 osm2rdfmember:id osmway:55 .\n"
       "_:0_1 osm2rdfmember:role \"outer\" .\n"
       "_:0_1 osm2rdfmember:pos \"1\"^^xsd:integer .\n"
-      "osmrel:42 geo:hasGeometry \"GEOMETRYCOLLECTION(POINT(7.5 "
+      "osmrel:42 geo:hasGeometry osm2rdfgeom:osm_relation_42 .\n"
+      "osm2rdfgeom:osm_relation_42 geo:asWKT \"GEOMETRYCOLLECTION(POINT(7.5 "
       "48.0),LINESTRING(7.5 48.0,7.6 48.0))\"^^geo:wktLiteral .\n"
       "osmrel:42 osm2rdfgeom:convex_hull \"POLYGON((7.5 48.0,7.6 48.0,7.5 "
       "48.0,7.5 48.0))\"^^geo:wktLiteral .\n"
@@ -384,7 +386,6 @@ TEST(OSM_FactHandler, way) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -417,7 +418,8 @@ TEST(OSM_FactHandler, way) {
       "osmway:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmway:42 osmkey:city \"Freiburg\" .\n"
       "osmway:42 osm2rdf:facts \"1\"^^xsd:integer .\n"
-      "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
+      "osmway:42 geo:hasGeometry osm2rdf:way_42 .\n"
+      "osm2rdf:way_42 geo:asWKT \"LINESTRING(48.0 7.5,48.1 "
       "7.6)\"^^geo:wktLiteral .\n"
       "osmway:42 osm2rdfgeom:convex_hull \"POLYGON((48.0 7.5,48.1 7.6,48.0 "
       "7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
@@ -441,7 +443,6 @@ TEST(OSM_FactHandler, wayAddWayNodeGeoemtry) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -480,13 +481,16 @@ TEST(OSM_FactHandler, wayAddWayNodeGeoemtry) {
       "_:0_0 osmway:node osmnode:1 .\n"
       "_:0_0 osm2rdfmember:pos \"0\"^^xsd:integer .\n"
       "osmnode:1 rdf:type osm:node .\n"
-      "osmnode:1 geo:hasGeometry \"POINT(48.0 7.5)\"^^geo:wktLiteral .\n"
+      "osmnode:1 geo:hasGeometry osm2rdfgeom:osm_node_1 .\n"
+      "osm2rdfgeom:osm_node_1 geo:asWKT \"POINT(48.0 7.5)\"^^geo:wktLiteral .\n"
       "osmway:42 osmway:node _:0_1 .\n"
       "_:0_1 osmway:node osmnode:2 .\n"
       "_:0_1 osm2rdfmember:pos \"1\"^^xsd:integer .\n"
       "osmnode:2 rdf:type osm:node .\n"
-      "osmnode:2 geo:hasGeometry \"POINT(48.1 7.6)\"^^geo:wktLiteral .\n"
-      "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
+      "osmnode:2 geo:hasGeometry osm2rdfgeom:osm_node_2 .\n"
+      "osm2rdfgeom:osm_node_2 geo:asWKT \"POINT(48.1 7.6)\"^^geo:wktLiteral .\n"
+      "osmway:42 geo:hasGeometry osm2rdf:way_42 .\n"
+      "osm2rdf:way_42 geo:asWKT \"LINESTRING(48.0 7.5,48.1 "
       "7.6)\"^^geo:wktLiteral .\n"
       "osmway:42 osm2rdfgeom:convex_hull \"POLYGON((48.0 7.5,48.1 7.6,48.0 "
       "7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
@@ -510,7 +514,6 @@ TEST(OSM_FactHandler, wayAddWayNodeOrder) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -550,7 +553,8 @@ TEST(OSM_FactHandler, wayAddWayNodeOrder) {
       "osmway:42 osmway:node _:0_1 .\n"
       "_:0_1 osmway:node osmnode:2 .\n"
       "_:0_1 osm2rdfmember:pos \"1\"^^xsd:integer .\n"
-      "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
+      "osmway:42 geo:hasGeometry osm2rdf:way_42 .\n"
+      "osm2rdf:way_42 geo:asWKT \"LINESTRING(48.0 7.5,48.1 "
       "7.6)\"^^geo:wktLiteral .\n"
       "osmway:42 osm2rdfgeom:convex_hull \"POLYGON((48.0 7.5,48.1 7.6,48.0 "
       "7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
@@ -574,7 +578,6 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataShortWay) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -617,7 +620,8 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataShortWay) {
       "_:0_1 osm2rdfmember:pos \"1\"^^xsd:integer .\n"
       "_:0_0 osmway:next_node osmnode:2 .\n"
       "_:0_0 osmway:next_node_distance \"15657.137001\"^^xsd:decimal .\n"
-      "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
+      "osmway:42 geo:hasGeometry osm2rdf:way_42 .\n"
+      "osm2rdf:way_42 geo:asWKT \"LINESTRING(48.0 7.5,48.1 "
       "7.6)\"^^geo:wktLiteral .\n"
       "osmway:42 osm2rdfgeom:convex_hull \"POLYGON((48.0 7.5,48.1 7.6,48.0 "
       "7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
@@ -641,7 +645,6 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataLongerWay) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -697,7 +700,8 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataLongerWay) {
       "_:0_3 osm2rdfmember:pos \"3\"^^xsd:integer .\n"
       "_:0_2 osmway:next_node osmnode:3 .\n"
       "_:0_2 osmway:next_node_distance \"11024.108103\"^^xsd:decimal .\n"
-      "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 7.6,48.1 7.5,48.0 "
+      "osmway:42 geo:hasGeometry osm2rdf:way_42 .\n"
+      "osm2rdf:way_42 geo:asWKT \"LINESTRING(48.0 7.5,48.1 7.6,48.1 7.5,48.0 "
       "7.5)\"^^geo:wktLiteral .\n"
       "osmway:42 osm2rdfgeom:convex_hull \"POLYGON((48.0 7.5,48.1 7.6,48.1 "
       "7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
@@ -721,7 +725,6 @@ TEST(OSM_FactHandler, wayAddWayMetaData) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -755,7 +758,8 @@ TEST(OSM_FactHandler, wayAddWayMetaData) {
       "osmway:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
       "osmway:42 osmkey:city \"Freiburg\" .\n"
       "osmway:42 osm2rdf:facts \"1\"^^xsd:integer .\n"
-      "osmway:42 geo:hasGeometry \"LINESTRING(48.0 7.5,48.1 "
+      "osmway:42 geo:hasGeometry osm2rdf:way_42 .\n"
+      "osm2rdf:way_42 geo:asWKT \"LINESTRING(48.0 7.5,48.1 "
       "7.6)\"^^geo:wktLiteral .\n"
       "osmway:42 osm2rdfgeom:convex_hull \"POLYGON((48.0 7.5,48.1 7.6,48.0 "
       "7.5,48.0 7.5))\"^^geo:wktLiteral .\n"
@@ -782,7 +786,6 @@ TEST(OSM_FactHandler, writeBoostGeometryWay) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -821,7 +824,6 @@ TEST(OSM_FactHandler, writeBoostGeometryWaySimplify1) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -867,7 +869,6 @@ TEST(OSM_FactHandler, writeBoostGeometryWaySimplify2) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -909,7 +910,6 @@ TEST(OSM_FactHandler, writeBoostGeometryWaySimplify3) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -952,7 +952,6 @@ TEST(OSM_FactHandler, writeBoxPrecision1) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -992,7 +991,6 @@ TEST(OSM_FactHandler, writeBoxPrecision2) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 2;
@@ -1032,7 +1030,6 @@ TEST(OSM_FactHandler, writeTag_AdminLevel) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1070,7 +1067,6 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger2) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1107,7 +1103,6 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger3) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1144,7 +1139,6 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_Integer) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1182,7 +1176,6 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerPositive) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1220,7 +1213,6 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerNegative) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1258,7 +1250,6 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerWS) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1296,7 +1287,6 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerWS2) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1334,7 +1324,6 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1371,7 +1360,6 @@ TEST(OSM_FactHandler, writeTag_KeyIRI) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1408,7 +1396,6 @@ TEST(OSM_FactHandler, writeTag_KeyNotIRI) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1447,7 +1434,6 @@ TEST(OSM_FactHandler, writeTagList) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1497,7 +1483,6 @@ TEST(OSM_FactHandler, writeTagListRefSingle) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1538,7 +1523,6 @@ TEST(OSM_FactHandler, writeTagListRefDouble) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.semicolonTagKeys.insert("ref");
@@ -1583,7 +1567,6 @@ TEST(OSM_FactHandler, writeTagListRefMultiple) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.semicolonTagKeys.insert("ref");
@@ -1631,7 +1614,6 @@ TEST(OSM_FactHandler, writeTagListWikidata) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1678,7 +1660,6 @@ TEST(OSM_FactHandler, writeTagListWikidataMultiple) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1725,7 +1706,6 @@ TEST(OSM_FactHandler, writeTagListWikipediaWithLang) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1772,7 +1752,6 @@ TEST(OSM_FactHandler, writeTagListWikipediaWithoutLang) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1819,7 +1798,6 @@ TEST(OSM_FactHandler, writeTagListSkipWikiLinks) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.skipWikiLinks = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
@@ -1872,7 +1850,6 @@ TEST(OSM_FactHandler, writeTagListStartDateInvalid) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1914,7 +1891,6 @@ TEST(OSM_FactHandler, writeTagListStartDateInvalid2) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1956,7 +1932,6 @@ TEST(OSM_FactHandler, writeTagListStartDateInvalid3) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1998,7 +1973,6 @@ TEST(OSM_FactHandler, writeTagListStartDateYear1) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2045,7 +2019,6 @@ TEST(OSM_FactHandler, writeTagListStartDateYear2) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2092,7 +2065,6 @@ TEST(OSM_FactHandler, writeTagListStartDateYear3) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2139,7 +2111,6 @@ TEST(OSM_FactHandler, writeTagListStartDateYear4) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2186,7 +2157,6 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth1) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2233,7 +2203,6 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth2) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2280,7 +2249,6 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth3) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2327,7 +2295,6 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth4) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2374,7 +2341,6 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay1) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2421,7 +2387,6 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay2) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2468,7 +2433,6 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay3) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2515,7 +2479,6 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay4) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 

--- a/tests/ttl/Writer.cpp
+++ b/tests/ttl/Writer.cpp
@@ -126,7 +126,6 @@ TEST(TTL_WriterNT, writeHeader) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
@@ -152,7 +151,6 @@ TEST(TTL_WriterTTL, writeHeader) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
@@ -180,7 +178,6 @@ TEST(TTL_WriterQLEVER, writeHeader) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
@@ -602,7 +599,6 @@ TEST(TTL_WriterNT, writeStatisticJson) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
@@ -664,7 +660,6 @@ TEST(TTL_WriterTTL, writeStatisticJson) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
@@ -727,7 +722,6 @@ TEST(TTL_WriterQLEVER, writeStatisticJson) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.hasGeometryAsWkt = true;
   config.outputCompress = false;
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};


### PR DESCRIPTION
This removes the ambiguity introduced with ad-freiburg/osm2rdf#24 which resurfaced in ad-freiburg/qlever#1219