### PR TITLE
Protect box ids access, Bump libosmium version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,10 @@ add_compile_options(-DGTEST_HAS_TR1_TUPLE=0 -DGTEST_USE_OWN_TR1_TUPLE=0)
 # Optimization
 add_compile_options("$<$<CONFIG:Release>:-march=native>" "$<$<CONFIG:Release>:-flto=auto>" "$<$<CONFIG:Release>:-ffast-math>" "$<$<CONFIG:Release>:-Ofast>")
 
-add_compile_options("$<$<CONFIG:Debug>:-g>" "$<$<CONFIG:Debug>:-Og>" "$<$<CONFIG:Debug>:-fsanitize=address>")
+add_compile_options("$<$<CONFIG:Debug>:-g>" "$<$<CONFIG:Debug>:-Og>")
 
-add_link_options("$<$<CONFIG:Debug>:-fsanitize=address>")
+# add_compile_options("$<$<CONFIG:Debug>:-fsanitize=address>")
+# add_link_options("$<$<CONFIG:Debug>:-fsanitize=address>")
 
 # ----------------------------------------------------------------------------
 # External programs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,10 +49,12 @@ endif()
 
 add_compile_options(-Wall -Wextra -Wno-missing-field-initializers)
 add_compile_options(-DGTEST_HAS_TR1_TUPLE=0 -DGTEST_USE_OWN_TR1_TUPLE=0)
-# Basic optimization
-add_compile_options(-march=native -flto=auto)
-# Enable fast-math
-add_compile_options(-ffast-math)
+# Optimization
+add_compile_options("$<$<CONFIG:Release>:-march=native>" "$<$<CONFIG:Release>:-flto=auto>" "$<$<CONFIG:Release>:-ffast-math>" "$<$<CONFIG:Release>:-Ofast>")
+
+add_compile_options("$<$<CONFIG:Debug>:-g>" "$<$<CONFIG:Debug>:-Og>" "$<$<CONFIG:Debug>:-fsanitize=address>")
+
+add_link_options("$<$<CONFIG:Debug>:-fsanitize=address>")
 
 # ----------------------------------------------------------------------------
 # External programs

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,8 @@ target_link_libraries(osm2rdf_library PRIVATE
         Threads::Threads
         ${EXPAT_LIBRARIES}
         ${BZIP2_LIBRARIES}
-        ${ZLIB_LIBRARIES})
+        ${ZLIB_LIBRARIES}
+	)
 
 # Link OpenMP if found
 if (OpenMP_CXX_FOUND)

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -177,6 +177,23 @@ void GeometryHandler<W>::area(const Area& area) {
       pack(getBoxIds(area.geom(), envelopes, innerGeom, outerGeom,
                      totPoints > MIN_CUTOUT_POINTS ? &cutouts : 0));
 
+  if (area.objId() == 1949881) {
+    std::cout << "Envelopes: ";
+    for (const auto& e : envelopes) std::cout << boost::geometry::wkt(e) << std::endl;
+
+    std::cout << "Inner: ";
+    std::cout << boost::geometry::wkt(innerGeom) << std::endl;
+
+    std::cout << "Outer: ";
+    std::cout << boost::geometry::wkt(outerGeom) << std::endl;
+
+    std::cout << "Convex hull: ";
+    std::cout << boost::geometry::wkt(convexHull) << std::endl;
+
+    std::cout << "Box IDs: ";
+    for (const auto& bt : boxIds) std::cout << "(" << bt.first << ", " << bt.second << ") " << std::endl;
+  }
+
 #pragma omp critical(areaDataInsert)
   {
     if (area.hasName()) {
@@ -2558,6 +2575,7 @@ BoxIdList GeometryHandler<W>::getBoxIds(
       std::floor((envelopes[0].max_corner().get<1>() + 90.0) / GRID_H) + 1;
 
   BoxIdList boxIds;
+  return boxIds;
 
   getBoxIds(area, inner, outer, envelopes, startX, endX, startY, endY,
             (endX - startX + 3) / 4, (endY - startY + 3) / 4, &boxIds, area,

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -634,7 +634,7 @@ void GeometryHandler<W>::prepareDAG() {
 
         if (areaFromType == AreaFromType::WAY) {
           // we are contained in an area derived from a way.
-          const auto& relations = _areaBorderWaysIndex.find(areaObjId);
+          auto relations = _areaBorderWaysIndex.find(areaObjId);
           if (relations != _areaBorderWaysIndex.end()) {
             for (auto r : relations->second) {
               if (r.second) {
@@ -2172,6 +2172,12 @@ bool GeometryHandler<W>::areaInAreaApprox(const SpatialAreaValue& a,
   const auto& areaGeom = std::get<2>(b);
   const auto& areaConvexHull = std::get<10>(b);
 
+  assert(entryBoxIds.size() > 0);
+  assert(areaBoxIds.size() > 0);
+
+  if (entryBoxIds.front().first > 0) assert(entryBoxIds.size() > 1);
+  if (areaBoxIds.front().first > 0) assert(areaBoxIds.size() > 1);
+
   if (areaArea / entryArea <= 1.0 - _config.approxContainsSlack) {
     stats->skippedByAreaSize();
     return false;
@@ -2592,6 +2598,8 @@ void GeometryHandler<W>::boxIdIsect(const BoxIdList& idsA,
   geomRelInf->fullContained = 0;
 
   if (idsA[0].first == 0 || idsB[0].first == 0) return;
+
+  assert(idsA.size() > 1 && idsB.size() > 1);
 
   // shortcuts
   if (abs(idsA[1].first) > abs(idsB.back().first) + idsB.back().second) {

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -2591,6 +2591,8 @@ void GeometryHandler<W>::boxIdIsect(const BoxIdList& idsA,
                                     GeomRelationInfo* geomRelInf) const {
   geomRelInf->fullContained = 0;
 
+  if (idsA[0].first == 0 || idsB[0].first == 0) return;
+
   // shortcuts
   if (abs(idsA[1].first) > abs(idsB.back().first) + idsB.back().second) {
     return;

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -325,7 +325,6 @@ bool GeometryHandler<W>::innerOuterDouglasPeucker(
 
   // L and R should be different points.
   if (L.get<0>() == R.get<0>() && L.get<1>() == R.get<1>()) {
-    std::cerr << "DOUGLAS PEUCKER FAIL!" << std::endl;
     // TODO: handle
     return false;
   }

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -599,15 +599,19 @@ void GeometryHandler<W>::prepareDAG() {
             // progressBar) reduction(+ : stats) default(none) schedule(dynamic)
 
     for (uint32_t i = 0; i < _spatialStorageArea.size(); i++) {
+      std::cout << "R" << std::endl;
       const auto& entry = _spatialStorageArea[i];
       const auto& entryId = std::get<1>(entry);
       const auto& entryArea = std::get<4>(entry);
+      std::cout << std::get<3>(entry) << std::endl;
 
       // Set containing all areas we are inside of
       SkipSet skip;
       std::unordered_set<Area::id_t> skipByContainedInInner;
 
+      std::cout << "S" << std::endl;
       const auto& queryResult = indexQryCover(entry);
+      std::cout << "T" << std::endl;
 
       for (const auto& areaRef : queryResult) {
         const auto& area = _spatialStorageArea[areaRef.second];

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -572,10 +572,10 @@ void GeometryHandler<W>::prepareDAG() {
 
     progressBar.update(entryCount);
 
-#pragma omp parallel for shared(                                               \
-        tmpDirectedAreaGraph, std::cout, std::cerr,                            \
-            osm2rdf::ttl::constants::IRI__GEOSPARQL__HAS_GEOMETRY, entryCount, \
-            progressBar) reduction(+ : stats) default(none) schedule(dynamic)
+// #pragma omp parallel for shared(                                               \
+        // tmpDirectedAreaGraph, std::cout, std::cerr,                            \
+            // osm2rdf::ttl::constants::IRI__GEOSPARQL__HAS_GEOMETRY, entryCount, \
+            // progressBar) reduction(+ : stats) default(none) schedule(dynamic)
 
     for (uint32_t i = 0; i < _spatialStorageArea.size(); i++) {
       const auto& entry = _spatialStorageArea[i];
@@ -590,6 +590,7 @@ void GeometryHandler<W>::prepareDAG() {
 
       for (const auto& areaRef : queryResult) {
         const auto& area = _spatialStorageArea[areaRef.second];
+        std::cout << std::get<3>(entry) << " vs " << std::get<3>(area) << std::endl;
         const auto& areaId = std::get<1>(area);
         const auto& areaObjId = std::get<3>(area);
         const auto& areaArea = std::get<4>(area);

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -2575,7 +2575,6 @@ BoxIdList GeometryHandler<W>::getBoxIds(
       std::floor((envelopes[0].max_corner().get<1>() + 90.0) / GRID_H) + 1;
 
   BoxIdList boxIds;
-  return boxIds;
 
   getBoxIds(area, inner, outer, envelopes, startX, endX, startY, endY,
             (endX - startX + 3) / 4, (endY - startY + 3) / 4, &boxIds, area,


### PR DESCRIPTION
This PR contains the stuff added during the debug process for #80 that we should keep in master. This mainly includes some safeguards in `areaInAreaApprox` and `boxIdIsect` which explicitly catch and handle situations that should never happen, but might.

I also bumped the `libosmium` version to v2.20.0 

Note that the segfaults in #80 were not related to these changes. The reason for them is still unknown, but they were only reproducible with Boost 1.78, not with previous or later versions.