### PR TITLE
Add option `--aux-geo-file` to supply one or multipl auxiliary geo files for the computation of geometric triples

### DIFF
--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -23,6 +23,7 @@
 #include <filesystem>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include "osm2rdf/config/Constants.h"
 #include "osm2rdf/ttl/Format.h"
@@ -70,6 +71,9 @@ struct Config {
 
   // Default settings for data
   std::unordered_set<std::string> semicolonTagKeys;
+
+  // Auxilary geo files
+  std::vector<std::string> auxGeoFiles;
 
   // Statistics
   bool writeRDFStatistics = false;

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -280,6 +280,13 @@ const static inline std::string SEMICOLON_TAG_KEYS_OPTION_LONG =
     "split-tag-key-by-semicolon";
 const static inline std::string SEMICOLON_TAG_KEYS_OPTION_HELP = "";
 
+const static inline std::string AUX_GEO_FILES_INFO =
+    "Auxiliary geo files for computing spatial relations";
+const static inline std::string AUX_GEO_FILES_OPTION_SHORT = "";
+const static inline std::string AUX_GEO_FILES_OPTION_LONG =
+    "aux-geo-files";
+const static inline std::string AUX_GEO_FILES_OPTION_HELP = "";
+
 const static inline std::string WKT_PRECISION_INFO =
     "Dumping WKT with precision: ";
 const static inline std::string WKT_PRECISION_OPTION_SHORT = "";

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -288,6 +288,12 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
       osm2rdf::config::constants::SKIP_WIKI_LINKS_OPTION_LONG,
       osm2rdf::config::constants::SKIP_WIKI_LINKS_OPTION_HELP);
 
+  auto auxGeoFilesOp =
+      parser.add<popl::Value<std::string>, popl::Attribute::advanced>(
+          osm2rdf::config::constants::AUX_GEO_FILES_OPTION_SHORT,
+          osm2rdf::config::constants::AUX_GEO_FILES_OPTION_LONG,
+          osm2rdf::config::constants::AUX_GEO_FILES_OPTION_HELP);
+
   auto semicolonTagKeysOp =
       parser.add<popl::Value<std::string>, popl::Attribute::advanced>(
           osm2rdf::config::constants::SEMICOLON_TAG_KEYS_OPTION_SHORT,
@@ -444,6 +450,11 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
     if (semicolonTagKeysOp->is_set()) {
       for (size_t i = 0; i < semicolonTagKeysOp->count(); ++i) {
         semicolonTagKeys.insert(semicolonTagKeysOp->value(i));
+      }
+    }
+    if (auxGeoFilesOp->is_set()) {
+      for (size_t i = 0; i < auxGeoFilesOp->count(); ++i) {
+        auxGeoFiles.push_back(auxGeoFilesOp->value(i));
       }
     }
 


### PR DESCRIPTION
The expected format is exactly the same as for `spatialjoin`. Multiple files can be given by specifying `--aux-geo-file` multiple times.

For example, if the auxiliary geo file will contain the line

`Vorarlberg      MULTIPOLYGON(((9.5307487 47.270581, 9.531256 47.2701589 [...]`

then the output will contain like

`Vorarlberg ogc:sfIntersects osmway:439469919 .`
