### PR TITLE
Fix double writing of centroids, convex hull, envelope and oriented bounding box for areas derived from ways

### DIFF
--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -310,17 +310,21 @@ void osm2rdf::osm::FactHandler<W>::way(const osm2rdf::osm::Way& way) {
     writeGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, way.geom());
   }
 
-  if (_config.addCentroids) {
-    const std::string& centroidObj =
-        _writer->generateIRI(NAMESPACE__OSM2RDF_GEOM,
-                             DATASET_ID[_config.sourceDataset] +
-                                 "_way_centroid_" + std::to_string(way.id()));
-    _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_CENTROID, centroidObj);
-    writeGeometry(centroidObj, IRI__GEOSPARQL__AS_WKT, way.centroid());
+  if (!way.isArea()) {
+    // only write these triples if the way is not an area, otherwise they
+    // are already written in the area handler
+    if (_config.addCentroids) {
+      const std::string& centroidObj =
+          _writer->generateIRI(NAMESPACE__OSM2RDF_GEOM,
+                               DATASET_ID[_config.sourceDataset] +
+                                   "_way_centroid_" + std::to_string(way.id()));
+      _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_CENTROID, centroidObj);
+      writeGeometry(centroidObj, IRI__GEOSPARQL__AS_WKT, way.centroid());
+    }
+    writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, way.convexHull());
+    writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, way.envelope());
+    writeGeometry(subj, IRI__OSM2RDF_GEOM__OBB, way.orientedBoundingBox());
   }
-  writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, way.convexHull());
-  writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, way.envelope());
-  writeGeometry(subj, IRI__OSM2RDF_GEOM__OBB, way.orientedBoundingBox());
 
   if (_config.addWayMetadata) {
     _writer->writeTriple(subj, IRI__OSMWAY_IS_CLOSED,

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -665,12 +665,7 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataLongerWay) {
       ".\n_:0_2 osmway:next_node osmnode:3 .\n_:0_2 osmway:next_node_distance "
       "\"11024.108103\"^^xsd:decimal .\nosmway:42 geo:hasGeometry "
       "osm2rdf:way_42 .\nosm2rdf:way_42 geo:asWKT \"LINESTRING(48 7.5,48.1 "
-      "7.6,48.1 7.5,48 7.5)\"^^geo:wktLiteral .\nosmway:42 "
-      "osm2rdfgeom:convex_hull \"POLYGON((48 7.5,48.1 7.6,48.1 7.5,48 "
-      "7.5))\"^^geo:wktLiteral .\nosmway:42 osm2rdfgeom:envelope \"POLYGON((48 "
-      "7.5,48.1 7.5,48.1 7.6,48 7.6,48 7.5))\"^^geo:wktLiteral .\nosmway:42 "
-      "osm2rdfgeom:obb \"POLYGON((48.1 7.6,48.1 7.6,48.1 7.5,48 7.5,48.1 "
-      "7.6))\"^^geo:wktLiteral .\nosmway:42 osm2rdf:length "
+      "7.6,48.1 7.5,48 7.5)\"^^geo:wktLiteral .\nosmway:42 osm2rdf:length "
       "\"0.341421\"^^xsd:double .\n",
       buffer.str());
 


### PR DESCRIPTION
For ways, the centroid, the convex hull, the envelope and the oriented bounding box were written without checking whether the way was an area. These triples were then again written for the area. Without the centroids, we never noticed the duplicate triples, as they were always equivalent. For the centroids, however, this is no longer the case, as the mean of all points on a line typically greatly differs from the mean of all points in a polygon bounded by that line.

This PR fixes this behavior.