### PR TITLE
Also handle untagged ways

### DIFF
--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -286,9 +286,6 @@ void osm2rdf::osm::OsmiumHandler<W>::relation(
 template <typename W>
 void osm2rdf::osm::OsmiumHandler<W>::way(const osmium::Way& way) {
   _waysSeen++;
-  if (way.tags().empty()) {
-    return;
-  }
   try {
     const auto& osmWay = osm2rdf::osm::Way(way);
 

--- a/tests/issues/Issue15.cpp
+++ b/tests/issues/Issue15.cpp
@@ -65,7 +65,7 @@ TEST(Issue15, Relation_8291361_expected) {
   ASSERT_THAT(printedState,
               ::testing::HasSubstr("relations seen:1 dumped: 1 geometry: 0\n"));
   ASSERT_THAT(printedState,
-              ::testing::HasSubstr("ways seen:47 dumped: 1 geometry: 0\n"));
+              ::testing::HasSubstr("ways seen:47 dumped: 47 geometry: 0\n"));
   const auto printedData = coutBuffer.str();
   ASSERT_THAT(
       printedData,
@@ -115,7 +115,7 @@ TEST(Issue15, Relation_8291361_failed) {
   ASSERT_THAT(printedState,
               ::testing::HasSubstr("relations seen:1 dumped: 1 geometry: 0\n"));
   ASSERT_THAT(printedState,
-              ::testing::HasSubstr("ways seen:47 dumped: 1 geometry: 0\n"));
+              ::testing::HasSubstr("ways seen:47 dumped: 47 geometry: 0\n"));
   const auto printedData = coutBuffer.str();
   ASSERT_THAT(
       printedData,

--- a/tests/osm/OsmiumHandler.cpp
+++ b/tests/osm/OsmiumHandler.cpp
@@ -183,7 +183,7 @@ TEST(OSM_OsmiumHandler, noFacts) {
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
   ASSERT_EQ(0, oh.waysDumped());
-  ASSERT_EQ(1, oh.wayGeometriesHandled());
+  ASSERT_EQ(2, oh.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -221,7 +221,7 @@ TEST(OSM_OsmiumHandler, noGeometricRelations) {
   ASSERT_EQ(2, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(1, oh.waysDumped());
+  ASSERT_EQ(2, oh.waysDumped());
   ASSERT_EQ(0, oh.wayGeometriesHandled());
 
   // Cleanup
@@ -260,8 +260,8 @@ TEST(OSM_OsmiumHandler, noAreaFacts) {
   ASSERT_EQ(2, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(1, oh.waysDumped());
-  ASSERT_EQ(1, oh.wayGeometriesHandled());
+  ASSERT_EQ(2, oh.waysDumped());
+  ASSERT_EQ(2, oh.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -299,8 +299,8 @@ TEST(OSM_OsmiumHandler, noNodeFacts) {
   ASSERT_EQ(2, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(1, oh.waysDumped());
-  ASSERT_EQ(1, oh.wayGeometriesHandled());
+  ASSERT_EQ(2, oh.waysDumped());
+  ASSERT_EQ(2, oh.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -338,8 +338,8 @@ TEST(OSM_OsmiumHandler, noRelationFacts) {
   ASSERT_EQ(0, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(1, oh.waysDumped());
-  ASSERT_EQ(1, oh.wayGeometriesHandled());
+  ASSERT_EQ(2, oh.waysDumped());
+  ASSERT_EQ(2, oh.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -378,7 +378,7 @@ TEST(OSM_OsmiumHandler, noWayFacts) {
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
   ASSERT_EQ(0, oh.waysDumped());
-  ASSERT_EQ(1, oh.wayGeometriesHandled());
+  ASSERT_EQ(2, oh.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -416,8 +416,8 @@ TEST(OSM_OsmiumHandler, noAreaGeometricRelations) {
   ASSERT_EQ(2, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(1, oh.waysDumped());
-  ASSERT_EQ(1, oh.wayGeometriesHandled());
+  ASSERT_EQ(2, oh.waysDumped());
+  ASSERT_EQ(2, oh.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -455,8 +455,8 @@ TEST(OSM_OsmiumHandler, noNodeGeometricRelations) {
   ASSERT_EQ(2, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(1, oh.waysDumped());
-  ASSERT_EQ(1, oh.wayGeometriesHandled());
+  ASSERT_EQ(2, oh.waysDumped());
+  ASSERT_EQ(2, oh.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -494,7 +494,7 @@ TEST(OSM_OsmiumHandler, noWayGeometricRelations) {
   ASSERT_EQ(2, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(1, oh.waysDumped());
+  ASSERT_EQ(2, oh.waysDumped());
   ASSERT_EQ(0, oh.wayGeometriesHandled());
 
   // Cleanup


### PR DESCRIPTION
So far, we are completely skipping untagged ways, as these are almost always inner rings of polygonal areas, and will appear in the geometry of the respective relation. However, some meta information (for example, their node members) is lost this way.

There are only around 21 M untagged ways in the entire OSM dataset, which is less than 2 % of all ways. With this PR, osm2rdf handles untagged ways in exactly the same manner as tagged ways.