### PR TITLE
Speed up dumping and fix some memory issues

### DIFF
--- a/.github/workflows/docker-build-gz.yml
+++ b/.github/workflows/docker-build-gz.yml
@@ -1,0 +1,57 @@
+name: End-to-end test, GZ output (docker build)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  merge_group:
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: End-to-end test, GZ output (docker build)
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile: [ Dockerfile]
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+
+      - name: Build the docker image
+        run: |
+          set -v
+          docker build -f ${{matrix.dockerfile}} -t osm2rdf .
+          docker run --rm osm2rdf --help
+
+      - name: Build TTL for Malta and check its validity
+        run: |
+          set -v
+          mkdir osm-malta && cd $_
+          curl -L -o osm-malta.pbf https://download.geofabrik.de/europe/malta-latest.osm.pbf
+          ls -l osm-malta.pbf
+          docker run --rm -v $(pwd):/data osm2rdf /data/osm-malta.pbf -o /data/osm-malta.ttl --output-compression gz
+          ls -l osm-malta.pbf osm-malta.ttl.gz
+          docker run --rm -v $(pwd):/data stain/jena riot --validate /data/osm-malta.ttl.gz
+
+      - name: Build QLever index and count the number of geometries
+        run: |
+          set -v
+          cd osm-malta
+          docker run -u $(id -u):$(id -g) -v $(pwd):/data -w /data --entrypoint bash adfreiburg/qlever -c "zcat osm-malta.ttl.gz | IndexBuilderMain -F ttl -f - -i osm-malta"
+          docker run -d -p 7000:7000 -v $(pwd):/data -w /data --entrypoint bash --name qlever adfreiburg/qlever -c "ServerMain -i /data/osm-malta -p 7000"
+          sleep 5
+          docker logs qlever
+          RESULT_JSON=$(curl http://localhost:7000 --data-urlencode "query=PREFIX geo: <http://www.opengis.net/ont/geosparql#> SELECT (COUNT(?geometry) AS ?count) WHERE { ?osm_id geo:hasGeometry ?geometry }")
+          echo "${RESULT_JSON}"
+          NUM_GEOMS=$(echo "${RESULT_JSON}" | jq --exit-status --raw-output .results.bindings[0].count.value)
+          echo ${NUM_GEOMS} | numfmt --grouping
+          test ${NUM_GEOMS} -gt 100000

--- a/.github/workflows/docker-build-uncompressed.yml
+++ b/.github/workflows/docker-build-uncompressed.yml
@@ -38,7 +38,7 @@ jobs:
           mkdir osm-malta && cd $_
           curl -L -o osm-malta.pbf https://download.geofabrik.de/europe/malta-latest.osm.pbf
           ls -l osm-malta.pbf
-          docker run --rm -v $(pwd):/data osm2rdf /data/osm-malta.pbf --output-no-compress -o /data/osm-malta.ttl
+          docker run --rm -v $(pwd):/data osm2rdf /data/osm-malta.pbf --output-compression none -o /data/osm-malta.ttl
           ls -l osm-malta.pbf osm-malta.ttl
           docker run --rm -v $(pwd):/data stain/jena riot --validate /data/osm-malta.ttl
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,19 +79,19 @@ set(INSTALL_GTEST OFF)
 set(BENCHMARK_ENABLE_INSTALL OFF)
 
 # find_package(Git QUIET)
-# if (GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-    # # Update submodules as needed
-    # option(GIT_SUBMODULE "Check submodules during build" ON)
-    # if (GIT_SUBMODULE)
-        # message(STATUS "Submodule update")
-        # execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-                # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                # RESULT_VARIABLE GIT_SUBMOD_RESULT)
-        # if (NOT GIT_SUBMOD_RESULT EQUAL "0")
-            # message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
-        # endif ()
-    # endif ()
-# endif ()
+if (GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+	# Update submodules as needed
+	option(GIT_SUBMODULE "Check submodules during build" ON)
+	if (GIT_SUBMODULE)
+		message(STATUS "Submodule update")
+		execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+				WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+				RESULT_VARIABLE GIT_SUBMOD_RESULT)
+		if (NOT GIT_SUBMOD_RESULT EQUAL "0")
+			message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+		endif ()
+	endif ()
+endif ()
 
 if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vendor/google/googletest/CMakeLists.txt")
     message(FATAL_ERROR "The submodules were not downloaded! GIT_SUBMODULE was turned off or failed. Please update submodules and try again.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ set(INSTALL_GMOCK OFF)
 set(INSTALL_GTEST OFF)
 set(BENCHMARK_ENABLE_INSTALL OFF)
 
-# find_package(Git QUIET)
+find_package(Git QUIET)
 if (GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
 	# Update submodules as needed
 	option(GIT_SUBMODULE "Check submodules during build" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,20 +78,20 @@ set(INSTALL_GMOCK OFF)
 set(INSTALL_GTEST OFF)
 set(BENCHMARK_ENABLE_INSTALL OFF)
 
-find_package(Git QUIET)
-if (GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-    # Update submodules as needed
-    option(GIT_SUBMODULE "Check submodules during build" ON)
-    if (GIT_SUBMODULE)
-        message(STATUS "Submodule update")
-        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                RESULT_VARIABLE GIT_SUBMOD_RESULT)
-        if (NOT GIT_SUBMOD_RESULT EQUAL "0")
-            message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
-        endif ()
-    endif ()
-endif ()
+# find_package(Git QUIET)
+# if (GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    # # Update submodules as needed
+    # option(GIT_SUBMODULE "Check submodules during build" ON)
+    # if (GIT_SUBMODULE)
+        # message(STATUS "Submodule update")
+        # execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                # WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                # RESULT_VARIABLE GIT_SUBMOD_RESULT)
+        # if (NOT GIT_SUBMOD_RESULT EQUAL "0")
+            # message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+        # endif ()
+    # endif ()
+# endif ()
 
 if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vendor/google/googletest/CMakeLists.txt")
     message(FATAL_ERROR "The submodules were not downloaded! GIT_SUBMODULE was turned off or failed. Please update submodules and try again.")

--- a/apps/osm2rdf-stats.cpp
+++ b/apps/osm2rdf-stats.cpp
@@ -64,7 +64,7 @@ class OsmiumIdHandler : public osmium::handler::Handler {
       osmium::io::ReaderWithProgressBar reader{true, input_file,
                                                osmium::osm_entity_bits::object};
       osm2rdf::osm::LocationHandler* locationHandler =
-          osm2rdf::osm::LocationHandler::create(_config);
+          osm2rdf::osm::LocationHandler::create(_config, 0, 0);
       while (true) {
         osmium::memory::Buffer buf = reader.read();
         if (!buf) {

--- a/apps/osm2rdf.cpp
+++ b/apps/osm2rdf.cpp
@@ -100,7 +100,9 @@ int main(int argc, char** argv) {
 #endif
 
   try {
-    if (config.outputFormat == "nt") {
+    if (config.outputFormat == "qlever") {
+      run<osm2rdf::ttl::format::QLEVER>(config);
+    } else if (config.outputFormat == "nt") {
       run<osm2rdf::ttl::format::NT>(config);
     } else if (config.outputFormat == "ttl") {
       run<osm2rdf::ttl::format::TTL>(config);

--- a/apps/osm2rdf.cpp
+++ b/apps/osm2rdf.cpp
@@ -100,9 +100,7 @@ int main(int argc, char** argv) {
 #endif
 
   try {
-    if (config.outputFormat == "qlever") {
-      run<osm2rdf::ttl::format::QLEVER>(config);
-    } else if (config.outputFormat == "nt") {
+    if (config.outputFormat == "nt") {
       run<osm2rdf::ttl::format::NT>(config);
     } else if (config.outputFormat == "ttl") {
       run<osm2rdf::ttl::format::TTL>(config);

--- a/apps/osm2rdf.cpp
+++ b/apps/osm2rdf.cpp
@@ -28,6 +28,7 @@
 #include "osm2rdf/ttl/Writer.h"
 #include "osm2rdf/util/Ram.h"
 #include "osm2rdf/util/Time.h"
+#include "osmium/util/memory.hpp"
 
 #if defined(_OPENMP)
 #include "omp.h"
@@ -46,8 +47,25 @@ void run(const osm2rdf::config::Config& config) {
   osm2rdf::ttl::Writer<T> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
-  osmiumHandler.handle();
+  osm2rdf::osm::GeometryHandler<T> geomHandler(config, &writer);
+
+  {
+    osm2rdf::osm::OsmiumHandler osmiumHandler{config, &geomHandler, &writer};
+    osmiumHandler.handle();
+  }
+
+  if (!config.noGeometricRelations) {
+    std::cerr << std::endl;
+    std::cerr << osm2rdf::util::currentTimeFormatted()
+              << "Calculating geometric relations ..." << std::endl;
+    geomHandler.calculateRelations();
+    std::cerr << osm2rdf::util::currentTimeFormatted() << "... done"
+              << std::endl;
+  }
+
+  osmium::MemoryUsage memory;
+  std::cerr << osm2rdf::util::formattedTimeSpacer
+            << "Memory used: " << memory.peak() << " MBytes" << std::endl;
 
   // All work done, close output
   output.close();

--- a/apps/osm2rdf.cpp
+++ b/apps/osm2rdf.cpp
@@ -51,7 +51,8 @@ void run(const osm2rdf::config::Config& config) {
   osm2rdf::osm::GeometryHandler<T> geomHandler(config, &writer);
 
   {
-    osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
+    osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler,
+                                              &geomHandler};
     osmiumHandler.handle();
   }
 

--- a/apps/osm2rdf.cpp
+++ b/apps/osm2rdf.cpp
@@ -47,10 +47,11 @@ void run(const osm2rdf::config::Config& config) {
   osm2rdf::ttl::Writer<T> writer{config, &output};
   writer.writeHeader();
 
+  osm2rdf::osm::FactHandler<T> factHandler(config, &writer);
   osm2rdf::osm::GeometryHandler<T> geomHandler(config, &writer);
 
   {
-    osm2rdf::osm::OsmiumHandler osmiumHandler{config, &geomHandler, &writer};
+    osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
     osmiumHandler.handle();
   }
 

--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -37,6 +37,12 @@ enum GeoTriplesMode {
   full = 1
 };
 
+enum CompressFormat {
+  NONE = 0,
+  BZ2 = 1,
+  GZ = 2,
+};
+
 enum SourceDataset {
   OSM = 0,
   OHM = 1
@@ -94,7 +100,7 @@ struct Config {
   std::string outputFormat = "qlever";
   osm2rdf::util::OutputMergeMode mergeOutput =
       osm2rdf::util::OutputMergeMode::CONCATENATE;
-  bool outputCompress = true;
+  CompressFormat outputCompress = BZ2;
   bool outputKeepFiles = false;
 
   // osmium location cache

--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -91,7 +91,7 @@ struct Config {
 
   // Output, empty for stdout
   std::filesystem::path output;
-  std::string outputFormat = "qlever";
+  std::string outputFormat = "ttl";
   osm2rdf::util::OutputMergeMode mergeOutput =
       osm2rdf::util::OutputMergeMode::CONCATENATE;
   bool outputCompress = true;

--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -91,7 +91,7 @@ struct Config {
 
   // Output, empty for stdout
   std::filesystem::path output;
-  std::string outputFormat = "ttl";
+  std::string outputFormat = "qlever";
   osm2rdf::util::OutputMergeMode mergeOutput =
       osm2rdf::util::OutputMergeMode::CONCATENATE;
   bool outputCompress = true;

--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -44,7 +44,7 @@ enum SourceDataset {
 
 struct Config {
   // Select what to do
-  std::string storeLocationsOnDisk;
+  std::string storeLocations;
 
   bool noFacts = false;
   bool noAreaFacts = false;

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -81,13 +81,13 @@ const static inline std::string OUTPUT_NO_COMPRESS_OPTION_LONG =
 const static inline std::string OUTPUT_NO_COMPRESS_OPTION_HELP =
     "Do not compress output";
 
-const static inline std::string STORE_LOCATIONS_ON_DISK_INFO =
-    "Storing locations osmium locations on disk:";
-const static inline std::string STORE_LOCATIONS_ON_DISK_SHORT = "";
-const static inline std::string STORE_LOCATIONS_ON_DISK_LONG =
-    "store-locations-on-disk";
-const static inline std::string STORE_LOCATIONS_ON_DISK_HELP =
-    "Store locations on disk, optional valid values: sparse (default), dense";
+const static inline std::string STORE_LOCATIONS_INFO =
+    "Storing locations osmium locations:";
+const static inline std::string STORE_LOCATIONS_SHORT = "";
+const static inline std::string STORE_LOCATIONS_LONG = "store-locations";
+const static inline std::string STORE_LOCATIONS_HELP =
+    "Method used to store locations, valid values: mem-flex (default), "
+    "mem-dense, disk-sparse, disk-dense ";
 
 const static inline std::string NO_FACTS_INFO = "Not dumping facts";
 const static inline std::string NO_FACTS_OPTION_SHORT = "";

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -26,6 +26,7 @@
 namespace osm2rdf::config::constants {
 
 const static inline std::string BZIP2_EXTENSION = ".bz2";
+const static inline std::string GZ_EXTENSION = ".gz";
 const static inline std::string STATS_EXTENSION = ".stats";
 const static inline std::string CONTAINS_STATS_EXTENSION = ".contains-stats";
 const static inline std::string JSON_EXTENSION = ".json";
@@ -75,11 +76,11 @@ const static inline std::string OUTPUT_KEEP_FILES_OPTION_HELP =
 const static inline std::string OUTPUT_KEEP_FILES_OPTION_INFO =
     "Keeping temporary output files";
 
-const static inline std::string OUTPUT_NO_COMPRESS_OPTION_SHORT = "";
-const static inline std::string OUTPUT_NO_COMPRESS_OPTION_LONG =
-    "output-no-compress";
-const static inline std::string OUTPUT_NO_COMPRESS_OPTION_HELP =
-    "Do not compress output";
+const static inline std::string OUTPUT_COMPRESS_OPTION_SHORT = "";
+const static inline std::string OUTPUT_COMPRESS_OPTION_LONG =
+    "output-compression";
+const static inline std::string OUTPUT_COMPRESS_OPTION_HELP =
+    "Output file compression, valid values: none, bz2, gz2";
 
 const static inline std::string STORE_LOCATIONS_INFO =
     "Storing locations osmium locations:";

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -65,7 +65,7 @@ const static inline std::string OUTPUT_FORMAT_INFO = "Output format:";
 const static inline std::string OUTPUT_FORMAT_OPTION_SHORT = "";
 const static inline std::string OUTPUT_FORMAT_OPTION_LONG = "output-format";
 const static inline std::string OUTPUT_FORMAT_OPTION_HELP =
-    "Output format, valid values: nt, ttl, qlever";
+    "Output format, valid values: nt, ttl";
 
 const static inline std::string OUTPUT_KEEP_FILES_OPTION_SHORT = "";
 const static inline std::string OUTPUT_KEEP_FILES_OPTION_LONG =

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -65,7 +65,7 @@ const static inline std::string OUTPUT_FORMAT_INFO = "Output format:";
 const static inline std::string OUTPUT_FORMAT_OPTION_SHORT = "";
 const static inline std::string OUTPUT_FORMAT_OPTION_LONG = "output-format";
 const static inline std::string OUTPUT_FORMAT_OPTION_HELP =
-    "Output format, valid values: nt, ttl";
+    "Output format, valid values: nt, ttl, qlever";
 
 const static inline std::string OUTPUT_KEEP_FILES_OPTION_SHORT = "";
 const static inline std::string OUTPUT_KEEP_FILES_OPTION_LONG =

--- a/include/osm2rdf/osm/CountHandler.h
+++ b/include/osm2rdf/osm/CountHandler.h
@@ -35,11 +35,16 @@ class CountHandler : public osmium::handler::Handler {
   size_t numRelations() const;
   size_t numWays() const;
 
+  size_t minNodeId() const { return _minId; };
+  size_t maxNodeId() const { return _maxId; };
+
  protected:
   size_t _numNodes = 0;
   size_t _numRelations = 0;
   size_t _numWays = 0;
   bool _firstPassDone = false;
+  size_t _minId = std::numeric_limits<size_t>::max();
+  size_t _maxId = 0;
 };
 }
 

--- a/include/osm2rdf/osm/DenseMemIndex.h
+++ b/include/osm2rdf/osm/DenseMemIndex.h
@@ -1,0 +1,54 @@
+// Copyright 2024, University of Freiburg
+// Authors: Patrick Brosi <brosi@cs.uni-freiburg.de>.
+
+// This file is part of osm2rdf.
+//
+// osm2rdf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// osm2rdf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef OSM2RDF_OSM_DENSEMEMINDEX_H
+#define OSM2RDF_OSM_DENSEMEMINDEX_H
+
+#include <osmium/index/index.hpp>
+#include <osmium/index/map.hpp>
+
+namespace osm2rdf::osm {
+
+template <typename TId, typename TValue>
+class DenseMemIndex : public osmium::index::map::Map<TId, TValue> {
+ public:
+  explicit DenseMemIndex(size_t minNodeId, size_t maxNodeId);
+
+  size_t size() const noexcept final { return _index.size(); }
+
+  size_t used_memory() const noexcept final {
+    return sizeof(DenseMemIndex) + _index.size() * sizeof(TValue);
+  }
+
+  void set(const TId id, const TValue value) final;
+
+  TValue get_noexcept(const TId id) const noexcept final;
+
+  TValue get(const TId id) const final;
+
+  void clear() final;
+
+  void sort() final{};
+
+ private:
+  size_t _offset;
+  std::vector<TValue> _index;
+};
+}  // namespace osm2rdf::osm
+
+#endif  // OSM2RDF_OSM_DENSEMEMINDEX_H

--- a/include/osm2rdf/osm/FactHandler.h
+++ b/include/osm2rdf/osm/FactHandler.h
@@ -58,8 +58,6 @@ class FactHandler {
   FRIEND_TEST(OSM_FactHandler, writeBoxPrecision1);
   FRIEND_TEST(OSM_FactHandler, writeBoxPrecision2);
 
-  void writeTag(const std::string& s, const osmium::Tag& tag);
-
   void writeTag(const std::string& s, const osm2rdf::osm::Tag& tag);
   FRIEND_TEST(OSM_FactHandler, writeTag_AdminLevel);
   FRIEND_TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger);
@@ -74,7 +72,6 @@ class FactHandler {
   FRIEND_TEST(OSM_FactHandler, writeTag_KeyNotIRI);
 
   void writeTagList(const std::string& s, const osm2rdf::osm::TagList& tags);
-  void writeTagList(const std::string& s, const osmium::TagList& tags);
   FRIEND_TEST(OSM_FactHandler, writeTagList);
   FRIEND_TEST(OSM_FactHandler, writeTagListWikidata);
   FRIEND_TEST(OSM_FactHandler, writeTagListRefSingle);

--- a/include/osm2rdf/osm/FactHandler.h
+++ b/include/osm2rdf/osm/FactHandler.h
@@ -58,6 +58,8 @@ class FactHandler {
   FRIEND_TEST(OSM_FactHandler, writeBoxPrecision1);
   FRIEND_TEST(OSM_FactHandler, writeBoxPrecision2);
 
+  void writeTag(const std::string& s, const osmium::Tag& tag);
+
   void writeTag(const std::string& s, const osm2rdf::osm::Tag& tag);
   FRIEND_TEST(OSM_FactHandler, writeTag_AdminLevel);
   FRIEND_TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger);
@@ -72,6 +74,7 @@ class FactHandler {
   FRIEND_TEST(OSM_FactHandler, writeTag_KeyNotIRI);
 
   void writeTagList(const std::string& s, const osm2rdf::osm::TagList& tags);
+  void writeTagList(const std::string& s, const osmium::TagList& tags);
   FRIEND_TEST(OSM_FactHandler, writeTagList);
   FRIEND_TEST(OSM_FactHandler, writeTagListWikidata);
   FRIEND_TEST(OSM_FactHandler, writeTagListRefSingle);

--- a/include/osm2rdf/osm/Node.h
+++ b/include/osm2rdf/osm/Node.h
@@ -34,12 +34,8 @@ class Node {
   explicit Node(const osmium::NodeRef& nodeRef);
   [[nodiscard]] id_t id() const noexcept;
   [[nodiscard]] std::time_t timestamp() const noexcept;
-  [[nodiscard]] const ::util::geo::DBox envelope() const noexcept;
   [[nodiscard]] const ::util::geo::DPoint& geom() const noexcept;
   [[nodiscard]] const osm2rdf::osm::TagList& tags() const noexcept;
-  [[nodiscard]] const ::util::geo::DPolygon convexHull() const noexcept;
-  [[nodiscard]] const ::util::geo::DPolygon orientedBoundingBox() const noexcept;
-  [[nodiscard]] const ::util::geo::DPoint centroid() const noexcept;
 
   bool operator==(const osm2rdf::osm::Node& other) const noexcept;
   bool operator!=(const osm2rdf::osm::Node& other) const noexcept;

--- a/include/osm2rdf/osm/OsmiumHandler.h
+++ b/include/osm2rdf/osm/OsmiumHandler.h
@@ -37,10 +37,8 @@ template <typename W>
 class OsmiumHandler : public osmium::handler::Handler {
  public:
   OsmiumHandler(const osm2rdf::config::Config& config,
-                osm2rdf::osm::GeometryHandler<W>* geomHandler,
-                osm2rdf::ttl::Writer<W>* writer);
-  OsmiumHandler(const osm2rdf::config::Config& config,
-                osm2rdf::ttl::Writer<W>* writer);
+                osm2rdf::osm::FactHandler<W>* factHandler,
+                osm2rdf::osm::GeometryHandler<W>* geomHandler);
   void handle();
   void area(const osmium::Area& area);
   void node(const osmium::Node& node);
@@ -62,12 +60,8 @@ class OsmiumHandler : public osmium::handler::Handler {
 
  protected:
   osm2rdf::config::Config _config;
-  osm2rdf::osm::FactHandler<W> _factHandler;
+  osm2rdf::osm::FactHandler<W>* _factHandler;
   osm2rdf::osm::GeometryHandler<W>* _geometryHandler;
-
-  // geometry handler used by default if no other handler is given to the
-  // constructor
-  osm2rdf::osm::GeometryHandler<W> _ownGeometryHandler;
 
   osm2rdf::osm::RelationHandler _relationHandler;
   osm2rdf::util::ProgressBar _progressBar;

--- a/include/osm2rdf/osm/OsmiumHandler.h
+++ b/include/osm2rdf/osm/OsmiumHandler.h
@@ -37,6 +37,9 @@ template <typename W>
 class OsmiumHandler : public osmium::handler::Handler {
  public:
   OsmiumHandler(const osm2rdf::config::Config& config,
+                osm2rdf::osm::GeometryHandler<W>* geomHandler,
+                osm2rdf::ttl::Writer<W>* writer);
+  OsmiumHandler(const osm2rdf::config::Config& config,
                 osm2rdf::ttl::Writer<W>* writer);
   void handle();
   void area(const osmium::Area& area);
@@ -60,7 +63,12 @@ class OsmiumHandler : public osmium::handler::Handler {
  protected:
   osm2rdf::config::Config _config;
   osm2rdf::osm::FactHandler<W> _factHandler;
-  osm2rdf::osm::GeometryHandler<W> _geometryHandler;
+  osm2rdf::osm::GeometryHandler<W>* _geometryHandler;
+
+  // geometry handler used by default if no other handler is given to the
+  // constructor
+  osm2rdf::osm::GeometryHandler<W> _ownGeometryHandler;
+
   osm2rdf::osm::RelationHandler _relationHandler;
   osm2rdf::util::ProgressBar _progressBar;
   size_t _areasSeen = 0;

--- a/include/osm2rdf/osm/Relation.h
+++ b/include/osm2rdf/osm/Relation.h
@@ -65,6 +65,7 @@ class Relation {
   ::util::geo::DPolygon _convexHull;
   ::util::geo::DPolygon _obb;
   bool _hasCompleteGeometry;
+  bool _isArea;
 };
 
 }  // namespace osm2rdf::osm

--- a/include/osm2rdf/osm/RelationHandler.h
+++ b/include/osm2rdf/osm/RelationHandler.h
@@ -39,7 +39,6 @@ class RelationHandler : public osmium::handler::Handler {
   osm2rdf::config::Config _config;
   osm2rdf::osm::LocationHandler* _locationHandler = nullptr;
   std::unordered_map<uint64_t, std::vector<uint64_t>> _ways;
-  std::unordered_map<uint64_t, std::vector<uint64_t>> _relations;
   bool _firstPassDone = false;
 };
 }

--- a/include/osm2rdf/osm/RelationHandler.h
+++ b/include/osm2rdf/osm/RelationHandler.h
@@ -33,12 +33,12 @@ class RelationHandler : public osmium::handler::Handler {
   void setLocationHandler(osm2rdf::osm::LocationHandler* locationHandler);
   bool hasLocationHandler() const;
   osmium::Location get_node_location(const uint64_t nodeId) const;
-  std::vector<uint64_t> get_noderefs_of_way(const uint64_t wayId);
+  std::vector<uint64_t> get_noderefs_of_way(const uint32_t wayId);
 
  protected:
   osm2rdf::config::Config _config;
   osm2rdf::osm::LocationHandler* _locationHandler = nullptr;
-  std::unordered_map<uint64_t, std::vector<uint64_t>> _ways;
+  std::unordered_map<uint32_t, std::vector<uint32_t>> _ways;
   bool _firstPassDone = false;
 };
 }

--- a/include/osm2rdf/osm/RelationHandler.h
+++ b/include/osm2rdf/osm/RelationHandler.h
@@ -33,12 +33,17 @@ class RelationHandler : public osmium::handler::Handler {
   void setLocationHandler(osm2rdf::osm::LocationHandler* locationHandler);
   bool hasLocationHandler() const;
   osmium::Location get_node_location(const uint64_t nodeId) const;
-  std::vector<uint64_t> get_noderefs_of_way(const uint32_t wayId);
+  std::vector<uint64_t> get_noderefs_of_way(const uint64_t wayId);
+
+ private:
+  std::vector<uint32_t> getCompressedIDs(const osmium::Way& way) const;
+  std::vector<uint64_t> getNodeRefs(const std::vector<uint32_t>& refs) const;
 
  protected:
   osm2rdf::config::Config _config;
   osm2rdf::osm::LocationHandler* _locationHandler = nullptr;
-  std::unordered_map<uint32_t, std::vector<uint32_t>> _ways;
+  std::unordered_map<uint32_t, std::vector<uint32_t>> _ways32;
+  std::unordered_map<uint64_t, std::vector<uint32_t>> _ways64;
   bool _firstPassDone = false;
 };
 }

--- a/include/osm2rdf/osm/TagList.h
+++ b/include/osm2rdf/osm/TagList.h
@@ -20,13 +20,13 @@
 #define OSM2RDF_OSM_TAGLIST_H_
 
 #include <string>
-#include <unordered_map>
+#include <map>
 
 #include "osmium/tags/taglist.hpp"
 
 namespace osm2rdf::osm {
 
-typedef std::unordered_map<std::string, std::string> TagList;
+typedef std::map<std::string, std::string> TagList;
 
 // Convert an osmium::TagList into a osm2rdf::osm::TagList
 osm2rdf::osm::TagList convertTagList(const osmium::TagList& tagList);

--- a/include/osm2rdf/osm/TagList.h
+++ b/include/osm2rdf/osm/TagList.h
@@ -26,7 +26,7 @@
 
 namespace osm2rdf::osm {
 
-typedef std::map<std::string, std::string> TagList;
+typedef std::vector<std::pair<std::string, std::string>> TagList;
 
 // Convert an osmium::TagList into a osm2rdf::osm::TagList
 osm2rdf::osm::TagList convertTagList(const osmium::TagList& tagList);

--- a/include/osm2rdf/osm/Way.h
+++ b/include/osm2rdf/osm/Way.h
@@ -33,6 +33,7 @@ class Way {
  public:
   typedef uint32_t id_t;
   Way();
+  void finalize();
   explicit Way(const osmium::Way& way);
   [[nodiscard]] id_t id() const noexcept;
   [[nodiscard]] std::time_t timestamp() const noexcept;
@@ -59,6 +60,7 @@ class Way {
   ::util::geo::DPolygon _convexHull;
   ::util::geo::DPolygon _obb;
   osm2rdf::osm::TagList _tags;
+  bool _hasAreaTag;
 };
 
 }  // namespace osm2rdf::osm

--- a/include/osm2rdf/ttl/Constants.h
+++ b/include/osm2rdf/ttl/Constants.h
@@ -76,6 +76,7 @@ inline std::string IRI__OSMWAY_IS_CLOSED;
 inline std::string IRI__OSMWAY_NEXT_NODE;
 inline std::string IRI__OSMWAY_NEXT_NODE_DISTANCE;
 inline std::string IRI__OSMWAY_NODE;
+inline std::string IRI__OSM2RDF_FACTS;
 inline std::string IRI__OSMWAY_NODE_COUNT;
 inline std::string IRI__OSMWAY_UNIQUE_NODE_COUNT;
 inline std::string IRI__OSM_NODE;

--- a/include/osm2rdf/ttl/Constants.h
+++ b/include/osm2rdf/ttl/Constants.h
@@ -70,6 +70,7 @@ inline std::string IRI__OSM2RDF_GEOM__OBB;
 inline std::string IRI__OSM2RDF_MEMBER__ID;
 inline std::string IRI__OSM2RDF_MEMBER__ROLE;
 inline std::string IRI__OSM2RDF_MEMBER__POS;
+inline std::string IRI__OSM2RDF__LENGTH;
 inline std::string IRI__OSMMETA_TIMESTAMP;
 inline std::string IRI__OSMWAY_IS_CLOSED;
 inline std::string IRI__OSMWAY_NEXT_NODE;

--- a/include/osm2rdf/ttl/Writer.h
+++ b/include/osm2rdf/ttl/Writer.h
@@ -109,6 +109,14 @@ class Writer {
   void writeTriple(const std::string& s, const std::string& p,
                    const std::string& o, size_t part);
 
+  // Write a single RDF line with a literal. The contents of s, p, a and b are
+  // not checked.
+  void writeLiteralTripleUnsafe(const std::string& s, const std::string& p,
+                                const std::string& a, const std::string& b);
+  void writeLiteralTripleUnsafe(const std::string& s, const std::string& p,
+                                const std::string& a, const std::string& b,
+                                size_t part);
+
   // addPrefix adds the given prefix and value. If the prefix already exists
   // false is returned.
   bool addPrefix(const std::string& prefix, std::string_view value);
@@ -156,6 +164,8 @@ class Writer {
   std::string IRIREF(std::string_view p, std::string_view v);
   FRIEND_TEST(WriterGrammarNT, RULE_8_IRIREF);
   FRIEND_TEST(WriterGrammarTTL, RULE_18_IRIREF);
+
+  std::string IRIREFUnsafe(std::string_view p, std::string_view v);
 
   std::string PrefixedNameUnsafe(std::string_view p, std::string_view v);
   std::string PrefixedName(std::string_view p, std::string_view v);
@@ -213,7 +223,6 @@ class Writer {
   uint64_t* _lineCount;
   // Number of parts.
   std::size_t _numOuts;
-
 };
 }  // namespace osm2rdf::ttl
 

--- a/include/osm2rdf/ttl/Writer.h
+++ b/include/osm2rdf/ttl/Writer.h
@@ -109,6 +109,11 @@ class Writer {
   void writeTriple(const std::string& s, const std::string& p,
                    const std::string& o, size_t part);
 
+  void writeIRILiteralTriple(const std::string& s, const std::string& p, const std::string& v,
+                   const std::string& o);
+  void writeIRILiteralTriple(const std::string& s, const std::string& p, const std::string& v,
+                   const std::string& o, size_t part);
+
   // Write a single RDF line with a literal. The contents of s, p, a and b are
   // not checked.
   void writeLiteralTripleUnsafe(const std::string& s, const std::string& p,
@@ -127,7 +132,7 @@ class Writer {
   // generateBlankNode creates a new unique identifier for a blank node.
   std::string generateBlankNode();
 
-  // generateIRI creates a IRI from given prefix p and string value v.
+  // Creates a IRI from given prefix p and string value v.
   // Assumes that both p and v are "safe", that is, they can be used
   // directly in the TTL
   std::string generateIRIUnsafe(std::string_view p, std::string_view v);
@@ -137,15 +142,28 @@ class Writer {
   // generateIRI creates a IRI from given prefix p and string value v.
   std::string generateIRI(std::string_view p, std::string_view v);
 
+  // Writes an IRI from given prefix p and string value v.
+  // Assumes that both p and v are "safe", that is, they can be used
+  // directly in the TTL
+  void writeIRIUnsafe(std::string_view p, std::string_view v, size_t part);
+
+  // Writes  a IRI from given prefix p and ID value v.
+  void writeIRI(std::string_view p, uint64_t v, size_t part);
+  // Writes a IRI from given prefix p and string value v.
+  void writeIRI(std::string_view p, std::string_view v, size_t part);
+
   // generateLangTag creates a LangTag from the given string.
   std::string generateLangTag(std::string_view s);
   // generateLangTag creates a Literal from the given string value v.
-  // If suffix s is not empty, it will be appended as is.
   std::string generateLiteral(std::string_view v, std::string_view s);
+  std::string generateLiteral(std::string_view v);
 
   // Assumes that both p and v are "safe", that is, they can be used
   // directly in the TTL
   std::string generateLiteralUnsafe(std::string_view v, std::string_view s);
+
+  void writeLiteral(std::string_view v, size_t part);
+  void writeLiteralUnsafe(std::string_view v, std::string_view s, size_t part);
 
   // -------------------------------------------------------------------------
   // Following functions are used by the ones above. These functions implement
@@ -153,6 +171,9 @@ class Writer {
   // -------------------------------------------------------------------------
   std::string formatIRI(std::string_view p, std::string_view v);
   std::string formatIRIUnsafe(std::string_view p, std::string_view v);
+
+  void writeFormattedIRI(std::string_view p, std::string_view v, size_t part);
+  void writeFormattedIRIUnsafe(std::string_view p, std::string_view v, size_t part);
 
   std::string STRING_LITERAL_QUOTE(std::string_view s);
   FRIEND_TEST(WriterGrammarNT, RULE_9_STRING_LITERAL_QUOTE);
@@ -170,6 +191,9 @@ class Writer {
   std::string PrefixedNameUnsafe(std::string_view p, std::string_view v);
   std::string PrefixedName(std::string_view p, std::string_view v);
   FRIEND_TEST(WriterGrammarTTL, RULE_136s_PREFIXEDNAME);
+
+  void writePrefixedNameUnsafe(std::string_view p, std::string_view v, size_t part);
+  void writePrefixedName(std::string_view p, std::string_view v, size_t part);
 
   std::string encodeIRIREF(std::string_view s);
   FRIEND_TEST(WriterGrammarNT, RULE_8_IRIREF_CONVERT);

--- a/include/osm2rdf/ttl/Writer.h
+++ b/include/osm2rdf/ttl/Writer.h
@@ -109,10 +109,17 @@ class Writer {
   void writeTriple(const std::string& s, const std::string& p,
                    const std::string& o, size_t part);
 
-  void writeIRILiteralTriple(const std::string& s, const std::string& p, const std::string& v,
-                   const std::string& o);
-  void writeIRILiteralTriple(const std::string& s, const std::string& p, const std::string& v,
-                   const std::string& o, size_t part);
+  void writeIRILiteralTriple(const std::string& s, const std::string& p,
+                             const std::string& v, const std::string& o);
+  void writeIRILiteralTriple(const std::string& s, const std::string& p,
+                             const std::string& v, const std::string& o,
+                             size_t part);
+
+  void writeUnsafeIRILiteralTriple(const std::string& s, const std::string& p,
+                                   const std::string& v, const std::string& o);
+  void writeUnsafeIRILiteralTriple(const std::string& s, const std::string& p,
+                                   const std::string& v, const std::string& o,
+                                   size_t part);
 
   // Write a single RDF line with a literal. The contents of s, p, a and b are
   // not checked.
@@ -173,7 +180,8 @@ class Writer {
   std::string formatIRIUnsafe(std::string_view p, std::string_view v);
 
   void writeFormattedIRI(std::string_view p, std::string_view v, size_t part);
-  void writeFormattedIRIUnsafe(std::string_view p, std::string_view v, size_t part);
+  void writeFormattedIRIUnsafe(std::string_view p, std::string_view v,
+                               size_t part);
 
   std::string STRING_LITERAL_QUOTE(std::string_view s);
   FRIEND_TEST(WriterGrammarNT, RULE_9_STRING_LITERAL_QUOTE);
@@ -192,7 +200,8 @@ class Writer {
   std::string PrefixedName(std::string_view p, std::string_view v);
   FRIEND_TEST(WriterGrammarTTL, RULE_136s_PREFIXEDNAME);
 
-  void writePrefixedNameUnsafe(std::string_view p, std::string_view v, size_t part);
+  void writePrefixedNameUnsafe(std::string_view p, std::string_view v,
+                               size_t part);
   void writePrefixedName(std::string_view p, std::string_view v, size_t part);
 
   std::string encodeIRIREF(std::string_view s);
@@ -208,6 +217,8 @@ class Writer {
 
   std::string encodePN_LOCAL(std::string_view s);
   FRIEND_TEST(WriterGrammarTTL, RULE_168s_PN_LOCAL);
+
+  int8_t checkPN_LOCAL(std::string_view s);
 
   std::string encodePN_PREFIX(std::string_view s);
   FRIEND_TEST(WriterGrammarTTL, RULE_167s_PN_PREFIX);

--- a/include/osm2rdf/util/Output.h
+++ b/include/osm2rdf/util/Output.h
@@ -20,6 +20,7 @@
 #define OSM2RDF_UTIL_OUTPUT_H
 
 #include <bzlib.h>
+#include <zlib.h>
 #include <fstream>
 #include <vector>
 
@@ -79,6 +80,7 @@ class Output {
 
   std::vector<FILE*> _rawFiles;
   std::vector<BZFILE*> _files;
+  std::vector<gzFile> _gzFiles;
   std::vector<size_t> _outBufPos;
 
   std::vector<size_t> _lines;

--- a/include/osm2rdf/util/Output.h
+++ b/include/osm2rdf/util/Output.h
@@ -25,7 +25,7 @@
 
 #include "osm2rdf/config/Config.h"
 
-static const size_t BUFFER_S = 1024 * 1024 * 50;
+static const size_t BUFFER_S = 1024 * 1024 * 100;
 
 namespace osm2rdf::util {
 
@@ -80,6 +80,8 @@ class Output {
   std::vector<FILE*> _rawFiles;
   std::vector<BZFILE*> _files;
   std::vector<size_t> _outBufPos;
+
+  std::vector<size_t> _lines;
 
   // true if output goes to stdout
   bool _toStdOut;

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -152,10 +152,10 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
   oss << "\n"
       << prefix << "Num Threads: " << numThreads;
 
-  if (!storeLocationsOnDisk.empty()) {
+  if (!storeLocations.empty()) {
     oss << "\n"
-        << prefix << osm2rdf::config::constants::STORE_LOCATIONS_ON_DISK_INFO
-        << " " << storeLocationsOnDisk;
+        << prefix << osm2rdf::config::constants::STORE_LOCATIONS_INFO
+        << " " << storeLocations;
   }
 
   if (writeRDFStatistics) {
@@ -182,11 +182,11 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
                                osm2rdf::config::constants::HELP_OPTION_LONG,
                                osm2rdf::config::constants::HELP_OPTION_HELP);
 
-  auto storeLocationsOnDiskOp =
-      parser.add<popl::Implicit<std::string>, popl::Attribute::advanced>(
-          osm2rdf::config::constants::STORE_LOCATIONS_ON_DISK_SHORT,
-          osm2rdf::config::constants::STORE_LOCATIONS_ON_DISK_LONG,
-          osm2rdf::config::constants::STORE_LOCATIONS_ON_DISK_HELP, "sparse");
+  auto storeLocationsOp =
+      parser.add<popl::Value<std::string>, popl::Attribute::advanced>(
+          osm2rdf::config::constants::STORE_LOCATIONS_SHORT,
+          osm2rdf::config::constants::STORE_LOCATIONS_LONG,
+          osm2rdf::config::constants::STORE_LOCATIONS_HELP, "mem-flex");
 
   auto noAreasOp = parser.add<popl::Switch, popl::Attribute::advanced>(
       osm2rdf::config::constants::NO_AREA_OPTION_SHORT,
@@ -386,8 +386,8 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
     // Skip passes
     noFacts = noFactsOp->is_set();
 
-    if (storeLocationsOnDiskOp->is_set()) {
-      storeLocationsOnDisk = storeLocationsOnDiskOp->value();
+    if (storeLocationsOp->is_set()) {
+      storeLocations = storeLocationsOp->value();
     }
 
     // Select types to dump

--- a/src/osm/Area.cpp
+++ b/src/osm/Area.cpp
@@ -44,7 +44,6 @@ void osm2rdf::osm::Area::finalize() noexcept {
 osm2rdf::osm::Area::Area(const osmium::Area& area) : Area() {
   _id = area.positive_id();
   _objId = static_cast<osm2rdf::osm::Area::id_t>(area.orig_id());
-  _hasName = (area.tags()["name"] != nullptr);
 
   double lonMin = std::numeric_limits<double>::infinity();
   double latMin = std::numeric_limits<double>::infinity();
@@ -139,7 +138,7 @@ const ::util::geo::DPoint osm2rdf::osm::Area::centroid() const noexcept {
 bool osm2rdf::osm::Area::operator==(
     const osm2rdf::osm::Area& other) const noexcept {
   return _id == other._id && _objId == other._objId &&
-         _hasName == other._hasName && _geomArea == other._geomArea &&
+         _geomArea == other._geomArea &&
          _envelopeArea == other._envelopeArea && _envelope == other._envelope &&
          _geom == other._geom;
 }
@@ -149,9 +148,6 @@ bool osm2rdf::osm::Area::operator!=(
     const osm2rdf::osm::Area& other) const noexcept {
   return !(*this == other);
 }
-
-// ____________________________________________________________________________
-bool osm2rdf::osm::Area::hasName() const noexcept { return _hasName; }
 
 // ____________________________________________________________________________
 bool osm2rdf::osm::Area::fromWay() const noexcept {

--- a/src/osm/CountHandler.cpp
+++ b/src/osm/CountHandler.cpp
@@ -27,6 +27,8 @@ void osm2rdf::osm::CountHandler::prepare_for_lookup() {
 
 // ____________________________________________________________________________
 void osm2rdf::osm::CountHandler::node(const osmium::Node& node){
+  if (node.id() < _minId) _minId = node.id();
+  if (node.id() > _maxId) _maxId = node.id();
   if (_firstPassDone || node.tags().empty())  {
     return;
   }

--- a/src/osm/CountHandler.cpp
+++ b/src/osm/CountHandler.cpp
@@ -27,8 +27,8 @@ void osm2rdf::osm::CountHandler::prepare_for_lookup() {
 
 // ____________________________________________________________________________
 void osm2rdf::osm::CountHandler::node(const osmium::Node& node){
-  if (node.id() < _minId) _minId = node.id();
-  if (node.id() > _maxId) _maxId = node.id();
+  if (node.positive_id() < _minId) _minId = node.positive_id();
+  if (node.positive_id() > _maxId) _maxId = node.positive_id();
   if (_firstPassDone || node.tags().empty())  {
     return;
   }
@@ -36,16 +36,16 @@ void osm2rdf::osm::CountHandler::node(const osmium::Node& node){
 }
 
 // ____________________________________________________________________________
-void osm2rdf::osm::CountHandler::relation(const osmium::Relation& rel) {
-  if (_firstPassDone || rel.tags().empty()) {
+void osm2rdf::osm::CountHandler::relation(const osmium::Relation&) {
+  if (_firstPassDone) {
     return;
   }
   _numRelations++;
 }
 
 // ____________________________________________________________________________
-void osm2rdf::osm::CountHandler::way(const osmium::Way& way) {
-  if (_firstPassDone || way.tags().empty()) {
+void osm2rdf::osm::CountHandler::way(const osmium::Way&) {
+  if (_firstPassDone) {
     return;
   }
   _numWays++;

--- a/src/osm/DenseMemIndex.cpp
+++ b/src/osm/DenseMemIndex.cpp
@@ -1,0 +1,71 @@
+// Copyright 2024, University of Freiburg
+// Authors: Patrick Brosi <brosi@cs.uni-freiburg.de>.
+
+// This file is part of osm2rdf.
+//
+// osm2rdf is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// osm2rdf is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "osm2rdf/osm/DenseMemIndex.h"
+#include "osmium/osm/node.hpp"
+#include <iostream>
+
+// ____________________________________________________________________________
+template <typename TId, typename TValue>
+osm2rdf::osm::DenseMemIndex<TId, TValue>::DenseMemIndex(size_t minNodeId,
+                                                        size_t maxNodeId)
+    : _offset(minNodeId), _index(maxNodeId - minNodeId + 1) {
+}
+
+// ____________________________________________________________________________
+template <typename TId, typename TValue>
+void osm2rdf::osm::DenseMemIndex<TId, TValue>::set(const TId id,
+                                                   const TValue value) {
+  assert(id >= _offset);
+  assert(id < _index.size() + _offset);
+  _index[id - _offset] = value;
+}
+
+// ____________________________________________________________________________
+template <typename TId, typename TValue>
+TValue osm2rdf::osm::DenseMemIndex<TId, TValue>::get_noexcept(
+    const TId id) const noexcept {
+  return _index[id - _offset];
+}
+
+// ____________________________________________________________________________
+template <typename TId, typename TValue>
+TValue osm2rdf::osm::DenseMemIndex<TId, TValue>::get(const TId id) const {
+  if (id < _offset) {
+    throw osmium::not_found{id};
+  }
+  if (id >= _index.size() + _offset) {
+    throw osmium::not_found{id};
+  }
+  const auto value = get_noexcept(id);
+  if (value == osmium::index::empty_value<TValue>()) {
+    throw osmium::not_found{id};
+  }
+  return value;
+}
+
+// ____________________________________________________________________________
+template <typename TId, typename TValue>
+void osm2rdf::osm::DenseMemIndex<TId, TValue>::clear() {
+  _index.clear();
+  _index.shrink_to_fit();
+  _offset = 0;
+}
+
+template class osm2rdf::osm::DenseMemIndex<osmium::unsigned_object_id_type,
+                                           osmium::Location>;

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -598,3 +598,4 @@ bool osm2rdf::osm::FactHandler<W>::hasSuffix(const std::string& subj,
 // ____________________________________________________________________________
 template class osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT>;
 template class osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL>;
+template class osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER>;

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -563,10 +563,10 @@ template <typename W>
 void osm2rdf::osm::FactHandler<W>::writeSecondsAsISO(const std::string& subj,
                                                      const std::string& pred,
                                                      const std::time_t& time) {
-  char out[100];
+  char out[50];
 
   struct tm t;
-  strftime(out, 100, "%Y-%m-%dT%X", gmtime_r(&time, &t));
+  strftime(out, 50, "%Y-%m-%dT%X", gmtime_r(&time, &t));
 
   _writer->writeLiteralTripleUnsafe(subj, pred, out, "^^" + IRI__XSD_DATE_TIME);
 }

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -38,13 +38,14 @@ using osm2rdf::ttl::constants::IRI__GEOSPARQL__AS_WKT;
 using osm2rdf::ttl::constants::IRI__GEOSPARQL__HAS_CENTROID;
 using osm2rdf::ttl::constants::IRI__GEOSPARQL__HAS_GEOMETRY;
 using osm2rdf::ttl::constants::IRI__GEOSPARQL__WKT_LITERAL;
+using osm2rdf::ttl::constants::IRI__OSM2RDF__LENGTH;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__CONVEX_HULL;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__ENVELOPE;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__OBB;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_MEMBER__ID;
+using osm2rdf::ttl::constants::IRI__OSM2RDF_FACTS;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_MEMBER__POS;
 using osm2rdf::ttl::constants::IRI__OSM2RDF_MEMBER__ROLE;
-using osm2rdf::ttl::constants::IRI__OSM2RDF__LENGTH;
 using osm2rdf::ttl::constants::IRI__OSM_NODE;
 using osm2rdf::ttl::constants::IRI__OSM_RELATION;
 using osm2rdf::ttl::constants::IRI__OSM_TAG;
@@ -99,7 +100,12 @@ void osm2rdf::osm::FactHandler<W>::area(const osm2rdf::osm::Area& area) {
                                    std::to_string(area.objId()));
 
   _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
-  writeGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, area.geom());
+
+  if (area.geom().size() == 1) {
+    writeGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, area.geom()[0]);
+  } else {
+    writeGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, area.geom());
+  }
 
   if (_config.addCentroids) {
     const std::string& centroidObj = _writer->generateIRIUnsafe(
@@ -124,12 +130,13 @@ void osm2rdf::osm::FactHandler<W>::area(const osm2rdf::osm::Area& area) {
 // ____________________________________________________________________________
 template <typename W>
 void osm2rdf::osm::FactHandler<W>::node(const osm2rdf::osm::Node& node) {
-  const std::string& subj =
-      _writer->generateIRI(NODE_NAMESPACE[_config.sourceDataset], node.id());
+  const std::string& subj = _writer->generateIRI(
+      NODE_NAMESPACE[_config.sourceDataset], node.id());
 
   _writer->writeTriple(subj, IRI__RDF_TYPE, IRI__OSM_NODE);
 
   writeSecondsAsISO(subj, IRI__OSMMETA_TIMESTAMP, node.timestamp());
+
   writeTagList(subj, node.tags());
 
   const std::string& geomObj = _writer->generateIRIUnsafe(
@@ -145,11 +152,16 @@ void osm2rdf::osm::FactHandler<W>::node(const osm2rdf::osm::Node& node) {
                                      "_node_centroid_" +
                                      std::to_string(node.id()));
     _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_CENTROID, centroidObj);
-    writeGeometry(centroidObj, IRI__GEOSPARQL__AS_WKT, node.centroid());
+    writeGeometry(centroidObj, IRI__GEOSPARQL__AS_WKT, node.geom());
   }
-  writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, node.convexHull());
-  writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, node.envelope());
-  writeGeometry(subj, IRI__OSM2RDF_GEOM__OBB, node.orientedBoundingBox());
+
+  const auto& hullWKT = ::util::geo::getWKT(::util::geo::DPolygon{{node.geom(), node.geom()},{}}, _config.wktPrecision);
+
+  _writer->writeLiteralTripleUnsafe(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, hullWKT,
+      "^^" + IRI__GEOSPARQL__WKT_LITERAL);
+  _writer->writeLiteralTripleUnsafe(subj, IRI__OSM2RDF_GEOM__OBB, hullWKT,
+      "^^" + IRI__GEOSPARQL__WKT_LITERAL);
+  writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, ::util::geo::DBox{node.geom(), node.geom()});
 }
 
 // ____________________________________________________________________________
@@ -335,8 +347,7 @@ void osm2rdf::osm::FactHandler<W>::way(const osm2rdf::osm::Way& way) {
   }
 
   _writer->writeLiteralTripleUnsafe(
-      subj, IRI__OSM2RDF__LENGTH,
-      std::to_string(::util::geo::len(way.geom())),
+      subj, IRI__OSM2RDF__LENGTH, std::to_string(::util::geo::len(way.geom())),
       "^^" + osm2rdf::ttl::constants::IRI__XSD_DOUBLE);
 }
 
@@ -381,6 +392,54 @@ void osm2rdf::osm::FactHandler<W>::writeBox(
 // ____________________________________________________________________________
 template <typename W>
 void osm2rdf::osm::FactHandler<W>::writeTag(const std::string& subj,
+                                            const osmium::Tag& tag) {
+  const std::string& key = tag.key();
+  const std::string& value = tag.value();
+  if (key == "admin_level") {
+    std::string rTrimmed;
+
+    // right trim, left trim is done by strtoll
+    auto end = std::find_if(value.rbegin(), value.rend(),
+                            [](int c) { return std::isspace(c) == 0; });
+    rTrimmed = value.substr(0, end.base() - value.begin());
+
+    char* firstNonMatched;
+    int64_t lvl = strtoll(rTrimmed.c_str(), &firstNonMatched,
+                          osm2rdf::osm::constants::BASE10_BASE);
+
+    // if integer, dump as xsd:integer
+    if (firstNonMatched != rTrimmed.c_str() && (*firstNonMatched) == 0) {
+      _writer->writeIRILiteralTriple(
+          subj, NAMESPACE__OSM_TAG, key,
+          _writer->generateLiteralUnsafe(std::to_string(lvl),
+                                         "^^" + IRI__XSD_INTEGER));
+    } else {
+      _writer->writeIRILiteralTriple(subj, NAMESPACE__OSM_TAG, key, value);
+    }
+  } else {
+    try {
+      _writer->writeIRILiteralTriple(subj, NAMESPACE__OSM_TAG, key, value);
+    } catch (const std::domain_error&) {
+      const std::string& blankNode = _writer->generateBlankNode();
+
+      // NOTE: if a domain_error occured, it occured during the writing of the
+      // predicate, and we already wrote the subject above. Simple start again
+      // with an empty subject.
+      _writer->writeTriple("\b", IRI__OSM_TAG, blankNode);
+
+      _writer->writeTriple(blankNode,
+                           _writer->generateIRI(NAMESPACE__OSM_TAG, "key"),
+                           _writer->generateLiteral(key));
+      _writer->writeTriple(blankNode,
+                           _writer->generateIRI(NAMESPACE__OSM_TAG, "value"),
+                           _writer->generateLiteral(value));
+    }
+  }
+}
+
+// ____________________________________________________________________________
+template <typename W>
+void osm2rdf::osm::FactHandler<W>::writeTag(const std::string& subj,
                                             const osm2rdf::osm::Tag& tag) {
   const std::string& key = tag.first;
   const std::string& value = tag.second;
@@ -398,25 +457,23 @@ void osm2rdf::osm::FactHandler<W>::writeTag(const std::string& subj,
 
     // if integer, dump as xsd:integer
     if (firstNonMatched != rTrimmed.c_str() && (*firstNonMatched) == 0) {
-      _writer->writeIRILiteralTriple(subj, NAMESPACE__OSM_TAG, key,
-                           _writer->generateLiteralUnsafe(std::to_string(lvl),
-                                                   "^^" + IRI__XSD_INTEGER));
+      _writer->writeIRILiteralTriple(
+          subj, NAMESPACE__OSM_TAG, key,
+          _writer->generateLiteralUnsafe(std::to_string(lvl),
+                                         "^^" + IRI__XSD_INTEGER));
     } else {
-      _writer->writeIRILiteralTriple(subj, NAMESPACE__OSM_TAG, key,
-                           value);
+      _writer->writeIRILiteralTriple(subj, NAMESPACE__OSM_TAG, key, value);
     }
   } else {
     try {
-      _writer->writeIRILiteralTriple(subj, NAMESPACE__OSM_TAG, key,
-                           value);
+      _writer->writeIRILiteralTriple(subj, NAMESPACE__OSM_TAG, key, value);
     } catch (const std::domain_error&) {
       const std::string& blankNode = _writer->generateBlankNode();
 
-      // NOTE: if a domain_error occured, it occured during the writing of the predicate,
-      // and we already wrote the subject above.
-      // Simple start again with an empty subject.
+      // NOTE: if a domain_error occured, it occured during the writing of the
+      // predicate, and we already wrote the subject above. Simple start again
+      // with an empty subject.
       _writer->writeTriple("\b", IRI__OSM_TAG, blankNode);
-
 
       _writer->writeTriple(blankNode,
                            _writer->generateIRI(NAMESPACE__OSM_TAG, "key"),
@@ -426,6 +483,145 @@ void osm2rdf::osm::FactHandler<W>::writeTag(const std::string& subj,
                            _writer->generateLiteral(value));
     }
   }
+}
+
+// ____________________________________________________________________________
+template <typename W>
+void osm2rdf::osm::FactHandler<W>::writeTagList(const std::string& subj,
+                                                const osmium::TagList& tags) {
+
+  size_t tagTripleCount = 0;
+  for (const auto& tag : tags) {
+    const std::string& key = tag.key();
+    const std::string& value = tag.value();
+    // Special handling for ref tag splitting. Maybe generalize this...
+    if (_config.semicolonTagKeys.find(key) != _config.semicolonTagKeys.end() &&
+        value.find(';') != std::string::npos) {
+      size_t end;
+      size_t start = 0;
+      while ((end = value.find(';', start)) != std::string::npos) {
+        const std::string& partialValue = value.substr(start, (end - start));
+        writeTag(subj, osm2rdf::osm::Tag(key, partialValue));
+        tagTripleCount++;
+        start = end + 1;
+      };
+      const std::string& partialValue = value.substr(start, value.size());
+      writeTag(subj, osm2rdf::osm::Tag(key, partialValue));
+      tagTripleCount++;
+    } else {
+      writeTag(subj, tag);
+      tagTripleCount++;
+    }
+
+    // Handling for wiki tags
+    if (!_config.skipWikiLinks &&
+        (key == "wikidata" || hasSuffix(key, ":wikidata"))) {
+      // Only take first wikidata entry if ; is found
+      std::string valueTmp = value;
+      const auto end = valueTmp.find(';');
+      if (end != std::string::npos) {
+        valueTmp = valueTmp.erase(end);
+      }
+      // Remove all but Q and digits to ensure Qdddddd format
+      valueTmp.erase(
+          remove_if(valueTmp.begin(), valueTmp.end(),
+                    [](char chr) { return (chr != 'Q' && isdigit(chr) == 0); }),
+          valueTmp.end());
+
+
+
+      _writer->writeTriple(
+          subj, _writer->generateIRI(NAMESPACE__OSM2RDF_TAG, key),
+          _writer->generateIRI(NAMESPACE__WIKIDATA_ENTITY, valueTmp));
+      tagTripleCount++;
+    }
+    if (!_config.skipWikiLinks &&
+        (key == "wikipedia" || hasSuffix(key, ":wikipedia"))) {
+      const auto pos = value.find(':');
+      if (pos != std::string::npos) {
+        const std::string& lang = value.substr(0, pos);
+        const std::string& entry = value.substr(pos + 1);
+        _writer->writeTriple(
+            subj, _writer->generateIRI(NAMESPACE__OSM2RDF_TAG, key),
+            _writer->generateIRI("https://" + lang + ".wikipedia.org/wiki/",
+                                 entry));
+        tagTripleCount++;
+      } else {
+        _writer->writeTriple(
+            subj, _writer->generateIRI(NAMESPACE__OSM2RDF_TAG, key),
+            _writer->generateIRI("https://www.wikipedia.org/wiki/", value));
+        tagTripleCount++;
+      }
+    }
+    if (key == "start_date" || key == "end_date") {
+      // Abort if non digit and not -
+      if (std::any_of(value.cbegin(), value.cend(),
+                      [](char c) { return isdigit(c) == 0 && c != '-'; })) {
+        continue;
+      }
+
+      // Skip if empty
+      if (value.empty()) {
+        continue;
+      }
+      // Skip if only '-'
+      size_t minusCount = std::count(value.begin(), value.end(), '-');
+      if (minusCount == value.size()) {
+        continue;
+      }
+
+      std::string newValue;
+      newValue.reserve(value.size());
+      std::ostringstream tmp;
+      tmp << std::setfill('0');
+
+      size_t last = 0;
+      size_t next;
+      auto resultType = 0;
+      for (size_t i = 0; i < (minusCount + 1); ++i) {
+        next = value.find('-', last);
+        if (i == 0 && next == 0) {
+          newValue += '-';
+          last = next + 1;
+          continue;
+        }
+        auto val = std::atoi(value.substr(last, next - last).c_str());
+
+        // basic validity checks according to ISO 8601
+        if (resultType == 1 && (val < 1 || val > 12)) {
+          resultType = 9;  // error
+          break;
+        }
+
+        if (resultType == 2 && (val < 1 || val > 31)) {
+          resultType = 9;  // error
+          break;
+        }
+
+        tmp << std::setw(resultType == 0 ? 4 : 2) << std::dec << val;
+        newValue += tmp.str().substr(0, resultType == 0 ? 4 : 2) + '-';
+        tmp.seekp(0);
+        resultType++;
+        last = next + 1;
+      }
+      if (resultType > 3) {
+        // Invalid length
+        continue;
+      }
+      std::string typeString[3] = {IRI__XSD_YEAR, IRI__XSD_YEAR_MONTH,
+                                   IRI__XSD_DATE};
+      _writer->writeTriple(
+          subj, _writer->generateIRIUnsafe(NAMESPACE__OSM2RDF_TAG, key),
+          _writer->generateLiteralUnsafe(
+              newValue.substr(0, newValue.size() - 1),
+              "^^" + typeString[resultType - 1]));
+    }
+  }
+
+  _writer->writeTriple(
+      subj, osm2rdf::ttl::constants::IRI__OSM2RDF_FACTS,
+      _writer->generateLiteralUnsafe(std::to_string(tagTripleCount),
+                                     "^^" + IRI__XSD_INTEGER));
 }
 
 // ____________________________________________________________________________
@@ -568,10 +764,10 @@ template <typename W>
 void osm2rdf::osm::FactHandler<W>::writeSecondsAsISO(const std::string& subj,
                                                      const std::string& pred,
                                                      const std::time_t& time) {
-  char out[50];
+  char out[25];
 
   struct tm t;
-  strftime(out, 50, "%Y-%m-%dT%X", gmtime_r(&time, &t));
+  strftime(out, 25, "%Y-%m-%dT%X", gmtime_r(&time, &t));
 
   _writer->writeLiteralTripleUnsafe(subj, pred, out, "^^" + IRI__XSD_DATE_TIME);
 }

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -249,7 +249,7 @@ void osm2rdf::osm::FactHandler<W>::way(const osm2rdf::osm::Way& way) {
   writeSecondsAsISO(subj, IRI__OSMMETA_TIMESTAMP, way.timestamp());
   writeTagList(subj, way.tags());
 
-  if (_config.addWayNodeOrder) {
+  if (_config.addWayNodeOrder && way.nodes().size()) {
     size_t wayOrder = 0;
     std::string lastBlankNode;
     auto lastNode = way.nodes().front();

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -598,4 +598,3 @@ bool osm2rdf::osm::FactHandler<W>::hasSuffix(const std::string& subj,
 // ____________________________________________________________________________
 template class osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT>;
 template class osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL>;
-template class osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER>;

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -216,7 +216,8 @@ template <typename W>
     const ::util::geo::DPoint& loc) {
   auto point = ::util::geo::latLngToWebMerc(
       ::util::geo::DPoint(loc.getX(), loc.getY()));  // locs are lon/lat
-  return ::util::geo::I32Point{static_cast<int>(point.getX() * PREC), static_cast<int>(point.getY() * PREC)};
+  return ::util::geo::I32Point{static_cast<int>(point.getX() * PREC),
+                               static_cast<int>(point.getY() * PREC)};
 }
 
 // ____________________________________________________________________________
@@ -262,7 +263,7 @@ void GeometryHandler<W>::calculateRelations() {
   }
 
   // read optional auxiliary geo data
-  for (const auto& auxFile :_config.auxGeoFiles) {
+  for (const auto& auxFile : _config.auxGeoFiles) {
     if (auxFile.size() == 0) continue;
     const static size_t CACHE_SIZE = 1024 * 1024 * 100;
     unsigned char* buf = new unsigned char[CACHE_SIZE];
@@ -274,7 +275,7 @@ void GeometryHandler<W>::calculateRelations() {
       throw std::runtime_error("Could not read auxiliary geo file " + auxFile);
     }
 
-    ::util::JobQueue<ParseBatch> jobs(1000);  // the WKT parse jobs
+    ::util::JobQueue<ParseBatch> jobs(1000);             // the WKT parse jobs
     std::vector<std::thread> thrds(_config.numThreads);  // the parse workers
     for (size_t i = 0; i < thrds.size(); i++)
       thrds[i] = std::thread(&processQueue, &jobs, i, &_sweeper);

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -322,4 +322,3 @@ std::string GeometryHandler<W>::areaNS(AreaFromType type) const {
 // ____________________________________________________________________________
 template class osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT>;
 template class osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL>;
-template class osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER>;

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -322,3 +322,4 @@ std::string GeometryHandler<W>::areaNS(AreaFromType type) const {
 // ____________________________________________________________________________
 template class osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT>;
 template class osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL>;
+template class osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER>;

--- a/src/osm/LocationHandler.cpp
+++ b/src/osm/LocationHandler.cpp
@@ -16,11 +16,10 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "osm2rdf/osm/LocationHandler.h"
-
 #include <iostream>
 
 #include "osm2rdf/config/Config.h"
+#include "osm2rdf/osm/LocationHandler.h"
 #include "osmium/handler/node_locations_for_ways.hpp"
 #include "osmium/index/map/dense_file_array.hpp"
 #include "osmium/index/map/flex_mem.hpp"
@@ -28,16 +27,23 @@
 
 // ____________________________________________________________________________
 osm2rdf::osm::LocationHandler* osm2rdf::osm::LocationHandler::create(
-    const osm2rdf::config::Config& config) {
-  if (config.storeLocationsOnDisk == "sparse") {
-    return new osm2rdf::osm::LocationHandlerFSSparse(config);
+    const osm2rdf::config::Config& config, size_t nodeIdMin, size_t nodeIdMax) {
+  if (config.storeLocations == "disk-sparse") {
+    return new osm2rdf::osm::LocationHandlerFSSparse(config, nodeIdMin,
+                                                     nodeIdMax);
   }
 
-  if (config.storeLocationsOnDisk == "dense") {
-    return new osm2rdf::osm::LocationHandlerFSDense(config);
+  if (config.storeLocations == "disk-dense") {
+    return new osm2rdf::osm::LocationHandlerFSDense(config, nodeIdMin,
+                                                    nodeIdMax);
   }
 
-  return new osm2rdf::osm::LocationHandlerRAM(config);
+  if (config.storeLocations == "mem-dense") {
+    return new osm2rdf::osm::LocationHandlerRAMDense(config, nodeIdMin,
+                                                     nodeIdMax);
+  }
+
+  return new osm2rdf::osm::LocationHandlerRAMFlex(config, nodeIdMin, nodeIdMax);
 }
 
 // ____________________________________________________________________________
@@ -62,7 +68,7 @@ void osm2rdf::osm::LocationHandlerImpl<T>::way(osmium::Way& way) {
 // ____________________________________________________________________________
 template <typename T>
 osm2rdf::osm::LocationHandlerImpl<T>::LocationHandlerImpl(
-    const osm2rdf::config::Config& /*unused*/)
+    const osm2rdf::config::Config& /*unused*/, size_t, size_t)
     : _handler(_index) {
   _handler.ignore_errors();
 }
@@ -70,7 +76,7 @@ osm2rdf::osm::LocationHandlerImpl<T>::LocationHandlerImpl(
 // ____________________________________________________________________________
 osm2rdf::osm::LocationHandlerImpl<osmium::index::map::SparseFileArray<
     osmium::unsigned_object_id_type, osmium::Location>>::
-    LocationHandlerImpl(const osm2rdf::config::Config& config)
+    LocationHandlerImpl(const osm2rdf::config::Config& config, size_t, size_t)
     : _cacheFile(config.getTempPath("osmium", "n2l.sparse.cache")),
       _index(_cacheFile.fileDescriptor()),
       _handler(_index) {
@@ -94,15 +100,14 @@ void osm2rdf::osm::LocationHandlerImpl<osmium::index::map::SparseFileArray<
 
 // ____________________________________________________________________________
 void osm2rdf::osm::LocationHandlerImpl<osmium::index::map::SparseFileArray<
-    osmium::unsigned_object_id_type,
-    osmium::Location>>::way(osmium::Way& way) {
+    osmium::unsigned_object_id_type, osmium::Location>>::way(osmium::Way& way) {
   _handler.way(way);
 }
 
 // ____________________________________________________________________________
 osm2rdf::osm::LocationHandlerImpl<osmium::index::map::DenseFileArray<
     osmium::unsigned_object_id_type, osmium::Location>>::
-    LocationHandlerImpl(const osm2rdf::config::Config& config)
+    LocationHandlerImpl(const osm2rdf::config::Config& config, size_t, size_t)
     : _cacheFile(config.getTempPath("osmium", "n2l.dense.cache")),
       _index(_cacheFile.fileDescriptor()),
       _handler(_index) {
@@ -118,14 +123,42 @@ void osm2rdf::osm::LocationHandlerImpl<osmium::index::map::DenseFileArray<
 
 // ____________________________________________________________________________
 void osm2rdf::osm::LocationHandlerImpl<osmium::index::map::DenseFileArray<
-    osmium::unsigned_object_id_type,
-    osmium::Location>>::way(osmium::Way& way) {
+    osmium::unsigned_object_id_type, osmium::Location>>::way(osmium::Way& way) {
   _handler.way(way);
 }
 
 // ____________________________________________________________________________
 osmium::Location
 osm2rdf::osm::LocationHandlerImpl<osmium::index::map::DenseFileArray<
+    osmium::unsigned_object_id_type, osmium::Location>>::
+    get_node_location(const osmium::object_id_type nodeId) const {
+  return _handler.get_node_location(nodeId);
+}
+
+// ____________________________________________________________________________
+osm2rdf::osm::LocationHandlerImpl<osm2rdf::osm::DenseMemIndex<
+    osmium::unsigned_object_id_type, osmium::Location>>::
+    LocationHandlerImpl(const osm2rdf::config::Config&, size_t nodeIdMin,
+                        size_t nodeIdMax)
+    : _index(nodeIdMin, nodeIdMax), _handler(_index) {
+  _handler.ignore_errors();
+}
+
+// ____________________________________________________________________________
+void osm2rdf::osm::LocationHandlerImpl<osm2rdf::osm::DenseMemIndex<
+    osmium::unsigned_object_id_type,
+    osmium::Location>>::node(const osmium::Node& node) {
+  _handler.node(node);
+}
+
+// ____________________________________________________________________________
+void osm2rdf::osm::LocationHandlerImpl<osm2rdf::osm::DenseMemIndex<
+    osmium::unsigned_object_id_type, osmium::Location>>::way(osmium::Way& way) {
+  _handler.way(way);
+}
+
+// ____________________________________________________________________________
+osmium::Location osm2rdf::osm::LocationHandlerImpl<osm2rdf::osm::DenseMemIndex<
     osmium::unsigned_object_id_type, osmium::Location>>::
     get_node_location(const osmium::object_id_type nodeId) const {
   return _handler.get_node_location(nodeId);

--- a/src/osm/Node.cpp
+++ b/src/osm/Node.cpp
@@ -58,27 +58,6 @@ const ::util::geo::DPoint& osm2rdf::osm::Node::geom() const noexcept {
 }
 
 // ____________________________________________________________________________
-const ::util::geo::DBox osm2rdf::osm::Node::envelope() const noexcept {
-  return ::util::geo::getBoundingBox(_geom);
-}
-
-// ____________________________________________________________________________
-const ::util::geo::DPolygon osm2rdf::osm::Node::convexHull() const noexcept {
-  return ::util::geo::convexHull(_geom);
-}
-
-// ____________________________________________________________________________
-const ::util::geo::DPolygon osm2rdf::osm::Node::orientedBoundingBox()
-    const noexcept {
-  return convexHull();
-}
-
-// ____________________________________________________________________________
-const ::util::geo::DPoint osm2rdf::osm::Node::centroid() const noexcept {
-  return _geom;
-}
-
-// ____________________________________________________________________________
 const osm2rdf::osm::TagList& osm2rdf::osm::Node::tags() const noexcept {
   return _tags;
 }

--- a/src/osm/Node.cpp
+++ b/src/osm/Node.cpp
@@ -34,7 +34,7 @@ osm2rdf::osm::Node::Node(const osmium::Node& node) {
   _timestamp = node.timestamp().seconds_since_epoch();
   const auto& loc = node.location();
   _geom = ::util::geo::DPoint{loc.lon(), loc.lat()};
-  _tags = osm2rdf::osm::convertTagList(node.tags());
+  _tags = std::move(osm2rdf::osm::convertTagList(node.tags()));
 }
 
 // ____________________________________________________________________________

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -371,3 +371,4 @@ size_t osm2rdf::osm::OsmiumHandler<W>::wayGeometriesHandled() const {
 // ____________________________________________________________________________
 template class osm2rdf::osm::OsmiumHandler<osm2rdf::ttl::format::NT>;
 template class osm2rdf::osm::OsmiumHandler<osm2rdf::ttl::format::TTL>;
+template class osm2rdf::osm::OsmiumHandler<osm2rdf::ttl::format::QLEVER>;

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -93,7 +93,8 @@ void osm2rdf::osm::OsmiumHandler<W>::handle() {
       osmium::io::Reader reader{input_file, osmium::osm_entity_bits::object,
                                 pool};
       osm2rdf::osm::LocationHandler* locationHandler =
-          osm2rdf::osm::LocationHandler::create(_config, countHandler.minNodeId(), countHandler.maxNodeId());
+          osm2rdf::osm::LocationHandler::create(
+              _config, countHandler.minNodeId(), countHandler.maxNodeId());
       _relationHandler.setLocationHandler(locationHandler);
 
       size_t numTasks = 0;
@@ -104,17 +105,17 @@ void osm2rdf::osm::OsmiumHandler<W>::handle() {
         numTasks += countHandler.numNodes();
       }
       if (!_config.noFacts && !_config.noRelationFacts) {
-				numTasks += countHandler.numRelations();
+        numTasks += countHandler.numRelations();
       }
       if (!_config.noGeometricRelations &&
           !_config.noRelationGeometricRelations) {
-				numTasks += countHandler.numRelations();
+        numTasks += countHandler.numRelations();
       }
       if (!_config.noFacts && !_config.noWayFacts) {
-				numTasks += countHandler.numWays();
+        numTasks += countHandler.numWays();
       }
       if (!_config.noGeometricRelations && !_config.noWayGeometricRelations) {
-				numTasks += countHandler.numWays();
+        numTasks += countHandler.numWays();
       }
 
       _progressBar = osm2rdf::util::ProgressBar{numTasks, true};
@@ -194,16 +195,20 @@ void osm2rdf::osm::OsmiumHandler<W>::node(const osmium::Node& node) {
 #pragma omp task
     {
       if (!_config.noFacts && !_config.noNodeFacts) {
-        _nodesDumped++;
         _factHandler->node(osmNode);
 #pragma omp critical(progress)
-        _progressBar.update(_numTasksDone++);
+        {
+          _nodesDumped++;
+          _progressBar.update(_numTasksDone++);
+        }
       }
       if (!_config.noGeometricRelations && !_config.noNodeGeometricRelations) {
-        _nodeGeometriesHandled++;
         _geometryHandler->node(osmNode);
 #pragma omp critical(progress)
-        _progressBar.update(_numTasksDone++);
+        {
+          _nodeGeometriesHandled++;
+          _progressBar.update(_numTasksDone++);
+        }
       }
     };
   } catch (const osmium::invalid_location& e) {
@@ -233,27 +238,29 @@ void osm2rdf::osm::OsmiumHandler<W>::relation(
       }
 
       if (!_config.noFacts && !_config.noRelationFacts) {
-        _relationsDumped++;
         _factHandler->relation(osmRelation);
 #pragma omp critical(progress)
-				_progressBar.update(_numTasksDone++);
+        {
+          _relationsDumped++;
+          _progressBar.update(_numTasksDone++);
+        }
       }
 
       if (!_config.noGeometricRelations &&
           !_config.noRelationGeometricRelations) {
         _geometryHandler->relation(osmRelation);
 #pragma omp critical(progress)
-				_progressBar.update(_numTasksDone++);
+        _progressBar.update(_numTasksDone++);
       }
     }
   } catch (const osmium::invalid_location& e) {
     if (!_config.noFacts && !_config.noRelationFacts) {
-			_progressBar.update(_numTasksDone++);
+      _progressBar.update(_numTasksDone++);
     }
 
     if (!_config.noGeometricRelations &&
         !_config.noRelationGeometricRelations) {
-			_progressBar.update(_numTasksDone++);
+      _progressBar.update(_numTasksDone++);
     }
     return;
   }
@@ -269,28 +276,32 @@ void osm2rdf::osm::OsmiumHandler<W>::way(const osmium::Way& way) {
 #pragma omp task
     {
       if (!_config.noFacts && !_config.noWayFacts) {
-        _waysDumped++;
         if (!osmWay.isArea()) {  // avoid double calculation of OBB and hull
           osmWay.finalize();
         }
         _factHandler->way(osmWay);
 #pragma omp critical(progress)
-				_progressBar.update(_numTasksDone++);
+        {
+          _waysDumped++;
+          _progressBar.update(_numTasksDone++);
+        }
       }
 
       if (!_config.noGeometricRelations && !_config.noWayGeometricRelations) {
-        _wayGeometriesHandled++;
         _geometryHandler->way(osmWay);
 #pragma omp critical(progress)
-				_progressBar.update(_numTasksDone++);
+        {
+          _wayGeometriesHandled++;
+          _progressBar.update(_numTasksDone++);
+        }
       }
     }
   } catch (const osmium::invalid_location& e) {
     if (!_config.noFacts && !_config.noWayFacts) {
-			_progressBar.update(_numTasksDone++);
+      _progressBar.update(_numTasksDone++);
     }
     if (!_config.noGeometricRelations && !_config.noWayGeometricRelations) {
-			_progressBar.update(_numTasksDone++);
+      _progressBar.update(_numTasksDone++);
     }
     return;
   }

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -255,7 +255,7 @@ void osm2rdf::osm::OsmiumHandler<W>::relation(
 #pragma omp task
     {
       if (!osmRelation.isArea() && _relationHandler.hasLocationHandler()) {
-        osmRelation.buildGeometry(_relationHandler);
+				osmRelation.buildGeometry(_relationHandler);
       }
 
       if (!_config.noFacts && !_config.noRelationFacts) {
@@ -272,7 +272,7 @@ void osm2rdf::osm::OsmiumHandler<W>::relation(
           !_config.noRelationGeometricRelations) {
 #pragma omp task
         {
-          _geometryHandler->relation(osmRelation);
+					_geometryHandler->relation(osmRelation);
 #pragma omp critical(progress)
           _progressBar.update(_numTasksDone++);
         };
@@ -302,7 +302,7 @@ void osm2rdf::osm::OsmiumHandler<W>::way(const osmium::Way& way) {
       _waysDumped++;
 #pragma omp task
       {
-        _factHandler.way(osmWay);
+				_factHandler.way(osmWay);
 #pragma omp critical(progress)
         _progressBar.update(_numTasksDone++);
       };
@@ -311,7 +311,7 @@ void osm2rdf::osm::OsmiumHandler<W>::way(const osmium::Way& way) {
       _wayGeometriesHandled++;
 #pragma omp task
       {
-        _geometryHandler->way(osmWay);
+				_geometryHandler->way(osmWay);
 #pragma omp critical(progress)
         _progressBar.update(_numTasksDone++);
       };

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -371,4 +371,3 @@ size_t osm2rdf::osm::OsmiumHandler<W>::wayGeometriesHandled() const {
 // ____________________________________________________________________________
 template class osm2rdf::osm::OsmiumHandler<osm2rdf::ttl::format::NT>;
 template class osm2rdf::osm::OsmiumHandler<osm2rdf::ttl::format::TTL>;
-template class osm2rdf::osm::OsmiumHandler<osm2rdf::ttl::format::QLEVER>;

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -255,7 +255,7 @@ void osm2rdf::osm::OsmiumHandler<W>::relation(
 #pragma omp task
     {
       if (!osmRelation.isArea() && _relationHandler.hasLocationHandler()) {
-				osmRelation.buildGeometry(_relationHandler);
+        osmRelation.buildGeometry(_relationHandler);
       }
 
       if (!_config.noFacts && !_config.noRelationFacts) {
@@ -272,7 +272,7 @@ void osm2rdf::osm::OsmiumHandler<W>::relation(
           !_config.noRelationGeometricRelations) {
 #pragma omp task
         {
-					_geometryHandler->relation(osmRelation);
+          _geometryHandler->relation(osmRelation);
 #pragma omp critical(progress)
           _progressBar.update(_numTasksDone++);
         };
@@ -302,7 +302,7 @@ void osm2rdf::osm::OsmiumHandler<W>::way(const osmium::Way& way) {
       _waysDumped++;
 #pragma omp task
       {
-				_factHandler.way(osmWay);
+        _factHandler.way(osmWay);
 #pragma omp critical(progress)
         _progressBar.update(_numTasksDone++);
       };
@@ -311,7 +311,7 @@ void osm2rdf::osm::OsmiumHandler<W>::way(const osmium::Way& way) {
       _wayGeometriesHandled++;
 #pragma omp task
       {
-				_geometryHandler->way(osmWay);
+        _geometryHandler->way(osmWay);
 #pragma omp critical(progress)
         _progressBar.update(_numTasksDone++);
       };

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -302,7 +302,7 @@ void osm2rdf::osm::OsmiumHandler<W>::way(const osmium::Way& way) {
       _waysDumped++;
 #pragma omp task
       {
-        _factHandler.way(osmWay);
+       _factHandler.way(osmWay);
 #pragma omp critical(progress)
         _progressBar.update(_numTasksDone++);
       };

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -104,17 +104,17 @@ void osm2rdf::osm::OsmiumHandler<W>::handle() {
         numTasks += countHandler.numNodes();
       }
       if (!_config.noFacts && !_config.noRelationFacts) {
-        numTasks += countHandler.numRelations();
+				numTasks += countHandler.numRelations();
       }
       if (!_config.noGeometricRelations &&
           !_config.noRelationGeometricRelations) {
-        numTasks += countHandler.numRelations();
+				numTasks += countHandler.numRelations();
       }
       if (!_config.noFacts && !_config.noWayFacts) {
-        numTasks += countHandler.numWays();
+				numTasks += countHandler.numWays();
       }
       if (!_config.noGeometricRelations && !_config.noWayGeometricRelations) {
-        numTasks += countHandler.numWays();
+				numTasks += countHandler.numWays();
       }
 
       _progressBar = osm2rdf::util::ProgressBar{numTasks, true};
@@ -236,24 +236,24 @@ void osm2rdf::osm::OsmiumHandler<W>::relation(
         _relationsDumped++;
         _factHandler->relation(osmRelation);
 #pragma omp critical(progress)
-        _progressBar.update(_numTasksDone++);
+				_progressBar.update(_numTasksDone++);
       }
 
       if (!_config.noGeometricRelations &&
           !_config.noRelationGeometricRelations) {
         _geometryHandler->relation(osmRelation);
 #pragma omp critical(progress)
-        _progressBar.update(_numTasksDone++);
+				_progressBar.update(_numTasksDone++);
       }
     }
   } catch (const osmium::invalid_location& e) {
     if (!_config.noFacts && !_config.noRelationFacts) {
-      _progressBar.update(_numTasksDone++);
+			_progressBar.update(_numTasksDone++);
     }
 
     if (!_config.noGeometricRelations &&
         !_config.noRelationGeometricRelations) {
-      _progressBar.update(_numTasksDone++);
+			_progressBar.update(_numTasksDone++);
     }
     return;
   }
@@ -275,22 +275,22 @@ void osm2rdf::osm::OsmiumHandler<W>::way(const osmium::Way& way) {
         }
         _factHandler->way(osmWay);
 #pragma omp critical(progress)
-        _progressBar.update(_numTasksDone++);
+				_progressBar.update(_numTasksDone++);
       }
 
       if (!_config.noGeometricRelations && !_config.noWayGeometricRelations) {
         _wayGeometriesHandled++;
         _geometryHandler->way(osmWay);
 #pragma omp critical(progress)
-        _progressBar.update(_numTasksDone++);
+				_progressBar.update(_numTasksDone++);
       }
     }
   } catch (const osmium::invalid_location& e) {
     if (!_config.noFacts && !_config.noWayFacts) {
-      _progressBar.update(_numTasksDone++);
+			_progressBar.update(_numTasksDone++);
     }
     if (!_config.noGeometricRelations && !_config.noWayGeometricRelations) {
-      _progressBar.update(_numTasksDone++);
+			_progressBar.update(_numTasksDone++);
     }
     return;
   }

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -93,7 +93,7 @@ void osm2rdf::osm::OsmiumHandler<W>::handle() {
       osmium::io::Reader reader{input_file, osmium::osm_entity_bits::object,
                                 pool};
       osm2rdf::osm::LocationHandler* locationHandler =
-          osm2rdf::osm::LocationHandler::create(_config);
+          osm2rdf::osm::LocationHandler::create(_config, countHandler.minNodeId(), countHandler.maxNodeId());
       _relationHandler.setLocationHandler(locationHandler);
 
       size_t numTasks = 0;

--- a/src/osm/Relation.cpp
+++ b/src/osm/Relation.cpp
@@ -117,7 +117,7 @@ void osm2rdf::osm::Relation::buildGeometry(
         _hasCompleteGeometry = false;
       }
 
-			::util::geo::DLine way;
+      ::util::geo::DLine way;
       way.reserve(nodeRefs.size());
       for (const auto& nodeRef : nodeRefs) {
         const auto& res = relationHandler.get_node_location(nodeRef);

--- a/src/osm/Relation.cpp
+++ b/src/osm/Relation.cpp
@@ -42,6 +42,10 @@ osm2rdf::osm::Relation::Relation(const osmium::Relation& relation) {
     _members.emplace_back(member);
   }
   _hasCompleteGeometry = false;
+
+  auto typeTag = relation.tags()["type"];
+  _isArea = typeTag != nullptr && (strcmp(typeTag, "multipolygon") == 0 ||
+                                   strcmp(typeTag, "boundary") == 0);
 }
 
 // ____________________________________________________________________________
@@ -60,13 +64,7 @@ const osm2rdf::osm::TagList& osm2rdf::osm::Relation::tags() const noexcept {
 }
 
 // ____________________________________________________________________________
-bool osm2rdf::osm::Relation::isArea() const noexcept {
-  const auto& typeTag = _tags.find("type");
-  if (typeTag != _tags.end()) {
-    return typeTag->second == "multipolygon" || typeTag->second == "boundary";
-  }
-  return false;
-}
+bool osm2rdf::osm::Relation::isArea() const noexcept { return _isArea; }
 
 // ____________________________________________________________________________
 const std::vector<osm2rdf::osm::RelationMember>&

--- a/src/osm/RelationHandler.cpp
+++ b/src/osm/RelationHandler.cpp
@@ -87,7 +87,7 @@ void osm2rdf::osm::RelationHandler::way(const osmium::Way& way) {
   }
   if (_ways.find(way.positive_id()) != _ways.end()) {
     std::vector<uint64_t> ids;
-		ids.reserve(way.nodes().size());
+    ids.reserve(way.nodes().size());
     for (const auto& nodeRef : way.nodes()) {
       ids.push_back(nodeRef.positive_ref());
     }

--- a/src/osm/RelationHandler.cpp
+++ b/src/osm/RelationHandler.cpp
@@ -50,19 +50,19 @@ osmium::Location osm2rdf::osm::RelationHandler::get_node_location(
 }
 
 // ____________________________________________________________________________
-std::vector<uint64_t> osm2rdf::osm::RelationHandler::get_noderefs_of_way(
-    const uint32_t wayId) {
+std::vector<uint64_t> osm2rdf::osm::RelationHandler::getNodeRefs(
+    const std::vector<uint32_t>& refs) const {
   std::vector<uint64_t> ret;
-  ret.reserve(_ways[wayId].size());
+  ret.reserve(refs.size());
 
-  for (size_t i = 0; i < _ways[wayId].size(); i++) {
-    if (_ways[wayId][i] >> 31 == 0) {
-      ret.push_back(_ways[wayId][i]);
+  for (size_t i = 0; i < refs.size(); i++) {
+    if (refs[i] >> 31 == 0) {
+      ret.push_back(refs[i]);
     } else {
       uint64_t fullId;
 
-      fullId = static_cast<uint64_t>(_ways[wayId][i] << 1 >> 1) << 32;
-      fullId += _ways[wayId][i + 1];
+      fullId = static_cast<uint64_t>(refs[i] << 1 >> 1) << 32;
+      fullId += refs[i + 1];
 
       ret.push_back(fullId);
       i++;
@@ -70,6 +70,16 @@ std::vector<uint64_t> osm2rdf::osm::RelationHandler::get_noderefs_of_way(
   }
 
   return ret;
+}
+
+// ____________________________________________________________________________
+std::vector<uint64_t> osm2rdf::osm::RelationHandler::get_noderefs_of_way(
+    const uint64_t wayId) {
+  if (wayId > std::numeric_limits<uint32_t>::max()) {
+    return getNodeRefs(_ways64[wayId]);
+  } else {
+    return getNodeRefs(_ways32[wayId]);
+  }
 }
 
 // ____________________________________________________________________________
@@ -90,11 +100,39 @@ void osm2rdf::osm::RelationHandler::relation(const osmium::Relation& relation) {
     if (relationMember.type() == osmium::item_type::way) {
       if (relationMember.positive_ref() >
           std::numeric_limits<uint32_t>::max()) {
-        throw std::out_of_range("Way ID is too large");
+        _ways64[relationMember.positive_ref()] = {};
+      } else {
+        _ways32[relationMember.positive_ref()] = {};
       }
-      _ways[relationMember.positive_ref()] = {};
     }
   }
+}
+
+// ____________________________________________________________________________
+std::vector<uint32_t> osm2rdf::osm::RelationHandler::getCompressedIDs(
+    const osmium::Way& way) const {
+  std::vector<uint32_t> compressed;
+  compressed.reserve(way.nodes().size() / 2);
+
+  for (const auto& nodeRef : way.nodes()) {
+    size_t nid = nodeRef.positive_ref();
+    if (nid <= std::numeric_limits<int32_t>::max()) {
+      // handle normally
+      compressed.push_back(nid);
+    } else if (nid <=
+               (static_cast<size_t>(std::numeric_limits<int64_t>::max()))) {
+      // handle with continuation
+      int32_t lower = nid << 32 >> 32;
+      int32_t upper = nid >> 32;
+      upper = upper | (1 << 31);
+      compressed.push_back(upper);
+      compressed.push_back(lower);
+    } else {
+      throw std::out_of_range("Node ID is too large");
+    }
+  }
+
+  return compressed;
 }
 
 // ____________________________________________________________________________
@@ -104,31 +142,12 @@ void osm2rdf::osm::RelationHandler::way(const osmium::Way& way) {
   }
 
   if (way.positive_id() > std::numeric_limits<uint32_t>::max()) {
-    throw std::out_of_range("Way ID is too large");
-  }
-
-  if (_ways.find(way.positive_id()) != _ways.end()) {
-    std::vector<uint32_t> compressed;
-    compressed.reserve(way.nodes().size() / 2);
-
-    for (const auto& nodeRef : way.nodes()) {
-      size_t nid = nodeRef.positive_ref();
-      if (nid <= std::numeric_limits<int32_t>::max()) {
-        // handle normally
-        compressed.push_back(nid);
-      } else if (nid <=
-                 (static_cast<size_t>(std::numeric_limits<int64_t>::max()))) {
-        // handle with continuation
-        int32_t lower = nid << 32 >> 32;
-        int32_t upper = nid >> 32;
-        upper = upper | (1 << 31);
-        compressed.push_back(upper);
-        compressed.push_back(lower);
-      } else {
-        throw std::out_of_range("Node ID is too large");
-      }
+    if (_ways64.find(way.positive_id()) != _ways64.end()) {
+      _ways64[way.positive_id()] = std::move(getCompressedIDs(way));
     }
-
-    _ways[way.positive_id()] = std::move(compressed);
+  } else {
+    if (_ways32.find(way.positive_id()) != _ways32.end()) {
+      _ways32[way.positive_id()] = std::move(getCompressedIDs(way));
+    }
   }
 }

--- a/src/osm/RelationHandler.cpp
+++ b/src/osm/RelationHandler.cpp
@@ -16,9 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
-#include "osm2rdf/osm/RelationHandler.h"
-
 #include <iostream>
+
+#include "osm2rdf/osm/RelationHandler.h"
 
 // ____________________________________________________________________________
 osm2rdf::osm::RelationHandler::RelationHandler(
@@ -60,13 +60,18 @@ void osm2rdf::osm::RelationHandler::relation(const osmium::Relation& relation) {
   if (_firstPassDone) {
     return;
   }
+
+  // skip area relations completely
+  for (const auto& tag : relation.tags()) {
+    if (strcmp(tag.key(), "type") == 0 &&
+        (strcmp(tag.value(), "multipolygon") == 0 || strcmp(tag.value(), "boundary") == 0))
+      return;
+  }
+
   for (const auto& relationMember : relation.cmembers()) {
     switch (relationMember.type()) {
       case osmium::item_type::way:
         _ways[relationMember.positive_ref()] = {};
-        break;
-      case osmium::item_type::relation:
-        _relations[relationMember.positive_ref()] = {};
         break;
       default:
         break;

--- a/src/osm/RelationHandler.cpp
+++ b/src/osm/RelationHandler.cpp
@@ -64,7 +64,8 @@ void osm2rdf::osm::RelationHandler::relation(const osmium::Relation& relation) {
   // skip area relations completely
   for (const auto& tag : relation.tags()) {
     if (strcmp(tag.key(), "type") == 0 &&
-        (strcmp(tag.value(), "multipolygon") == 0 || strcmp(tag.value(), "boundary") == 0))
+        (strcmp(tag.value(), "multipolygon") == 0 ||
+         strcmp(tag.value(), "boundary") == 0))
       return;
   }
 
@@ -86,6 +87,7 @@ void osm2rdf::osm::RelationHandler::way(const osmium::Way& way) {
   }
   if (_ways.find(way.positive_id()) != _ways.end()) {
     std::vector<uint64_t> ids;
+		ids.reserve(way.nodes().size());
     for (const auto& nodeRef : way.nodes()) {
       ids.push_back(nodeRef.positive_ref());
     }

--- a/src/osm/TagList.cpp
+++ b/src/osm/TagList.cpp
@@ -25,11 +25,12 @@
 osm2rdf::osm::TagList osm2rdf::osm::convertTagList(
     const osmium::TagList& tagList) {
   osm2rdf::osm::TagList result;
+  result.reserve(tagList.size());
 
   for (const auto& tag : tagList) {
     std::string key{tag.key()};
     std::replace(key.begin(), key.end(), ' ', '_');
-    result[std::move(key)] = tag.value();
+    result.push_back({key, tag.value()});
   }
   return result;
 }

--- a/src/osm/TagList.cpp
+++ b/src/osm/TagList.cpp
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <algorithm>
 #include "osm2rdf/osm/TagList.h"
 
 #include "osmium/tags/taglist.hpp"
@@ -27,14 +28,8 @@ osm2rdf::osm::TagList osm2rdf::osm::convertTagList(
 
   for (const auto& tag : tagList) {
     std::string key{tag.key()};
-    for (size_t pos = 0; pos < key.size(); ++pos) {
-      switch (key[pos]) {
-        case ' ':
-          key[pos] = '_';
-          break;
-      }
-    }
-    result[key] = tag.value();
+    std::replace(key.begin(), key.end(), ' ', '_');
+    result[std::move(key)] = tag.value();
   }
   return result;
 }

--- a/src/osm/Way.cpp
+++ b/src/osm/Way.cpp
@@ -38,6 +38,9 @@ osm2rdf::osm::Way::Way(const osmium::Way& way) {
   _nodes.reserve(way.nodes().size());
   _geom.reserve(way.nodes().size());
 
+  auto areaTag = way.tags()["area"];
+  _hasAreaTag = areaTag != nullptr && strcmp(areaTag, "no") != 0;
+
   double lonMin = std::numeric_limits<double>::infinity();
   double latMin = std::numeric_limits<double>::infinity();
   double lonMax = -std::numeric_limits<double>::infinity();
@@ -65,6 +68,10 @@ osm2rdf::osm::Way::Way(const osmium::Way& way) {
     }
   }
   _envelope = {{lonMin, latMin}, {lonMax, latMax}};
+}
+
+// ____________________________________________________________________________
+void osm2rdf::osm::Way::finalize() {
   _convexHull = ::util::geo::convexHull(_geom);
   _obb = ::util::geo::convexHull(::util::geo::getOrientedEnvelope(_geom));
 }
@@ -126,13 +133,7 @@ bool osm2rdf::osm::Way::isArea() const noexcept {
   if (!closed()) {
     return false;
   }
-  const auto& areaTag = _tags.find("area");
-  if (areaTag != _tags.end()) {
-    if (areaTag->second == "no") {
-      return false;
-    }
-  }
-  return true;
+  return _hasAreaTag;
 }
 
 // ____________________________________________________________________________

--- a/src/osm/Way.cpp
+++ b/src/osm/Way.cpp
@@ -34,7 +34,7 @@ osm2rdf::osm::Way::Way() {
 osm2rdf::osm::Way::Way(const osmium::Way& way) {
   _id = way.positive_id();
   _timestamp = way.timestamp().seconds_since_epoch();
-  _tags = osm2rdf::osm::convertTagList(way.tags());
+  _tags = std::move(osm2rdf::osm::convertTagList(way.tags()));
   _nodes.reserve(way.nodes().size());
   _geom.reserve(way.nodes().size());
 

--- a/src/osm/Way.cpp
+++ b/src/osm/Way.cpp
@@ -39,7 +39,7 @@ osm2rdf::osm::Way::Way(const osmium::Way& way) {
   _geom.reserve(way.nodes().size());
 
   auto areaTag = way.tags()["area"];
-  _hasAreaTag = areaTag != nullptr && strcmp(areaTag, "no") != 0;
+  _hasAreaTag = areaTag == nullptr || strcmp(areaTag, "no") != 0;
 
   double lonMin = std::numeric_limits<double>::infinity();
   double latMin = std::numeric_limits<double>::infinity();

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -159,6 +159,8 @@ osm2rdf::ttl::Writer<T>::Writer(const osm2rdf::config::Config& config,
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM, "way");
   osm2rdf::ttl::constants::IRI__RDF_TYPE =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__RDF, "type");
+  osm2rdf::ttl::constants::IRI__OSM2RDF_FACTS =
+      generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM2RDF, "facts");
 
   osm2rdf::ttl::constants::IRI__XSD_DATE =
       generateIRI(osm2rdf::ttl::constants::NAMESPACE__XML_SCHEMA, "date");
@@ -573,7 +575,7 @@ std::string osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>::formatIRIUnsafe(
   if (prefix != _prefixes.end()) {
     return PrefixedNameUnsafe(p, v);
   }
-  return IRIREF(p, v);
+  return IRIREFUnsafe(p, v);
 }
 
 // ____________________________________________________________________________
@@ -1143,7 +1145,7 @@ void osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>::writeFormattedIRIUnsafe(
     writePrefixedNameUnsafe(p, v, part);
     return;
   }
-  _out->write(IRIREF(p, v), part);
+  _out->write(IRIREFUnsafe(p, v), part);
 }
 
 // ____________________________________________________________________________

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -614,43 +614,7 @@ std::string osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>::formatIRIUnsafe(
 
 // ____________________________________________________________________________
 template <>
-std::string osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER>::formatIRIUnsafe(
-    std::string_view p, std::string_view v) {
-  // TTL: [135s] iri
-  //      https://www.w3.org/TR/turtle/#grammar-production-iri
-  //      [18]   IRIREF (same as NT)
-  //      https://www.w3.org/TR/turtle/#grammar-production-IRIREF
-  //      [136s] PrefixedName
-  //      https://www.w3.org/TR/turtle/#grammar-production-PrefixedName
-  auto prefix = _prefixes.find(std::string{p});
-  // If known prefix -> PrefixedName
-  if (prefix != _prefixes.end()) {
-    return PrefixedNameUnsafe(p, v);
-  }
-  return IRIREFUnsafe(p, v);
-}
-
-// ____________________________________________________________________________
-template <>
 std::string osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>::formatIRI(
-    std::string_view p, std::string_view v) {
-  // TTL: [135s] iri
-  //      https://www.w3.org/TR/turtle/#grammar-production-iri
-  //      [18]   IRIREF (same as NT)
-  //      https://www.w3.org/TR/turtle/#grammar-production-IRIREF
-  //      [136s] PrefixedName
-  //      https://www.w3.org/TR/turtle/#grammar-production-PrefixedName
-  auto prefix = _prefixes.find(std::string{p});
-  // If known prefix -> PrefixedName
-  if (prefix != _prefixes.end()) {
-    return PrefixedName(p, v);
-  }
-  return IRIREF(p, v);
-}
-
-// ____________________________________________________________________________
-template <>
-std::string osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER>::formatIRI(
     std::string_view p, std::string_view v) {
   // TTL: [135s] iri
   //      https://www.w3.org/TR/turtle/#grammar-production-iri
@@ -908,33 +872,6 @@ std::string osm2rdf::ttl::Writer<T>::encodeIRIREF(std::string_view s) {
       continue;
     }
     uint8_t length = utf8Length(c);
-    tmp += s.substr(pos, length);
-    pos += length - 1;
-  }
-  return tmp;
-}
-
-// ____________________________________________________________________________
-template <>
-std::string osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER>::encodeIRIREF(
-    std::string_view s) {
-  // NT:  [8]   IRIREF
-  //      https://www.w3.org/TR/n-triples/#grammar-production-IRIREF
-  // TTL: [18]  IRIREF
-  //      https://www.w3.org/TR/turtle/#grammar-production-IRIREF
-  std::string tmp;
-  tmp.reserve(s.size() * 2);
-  for (size_t pos = 0; pos < s.size(); ++pos) {
-    uint8_t length = utf8Length(s[pos]);
-    // Force non-allowed chars to PERCENT
-    if (length == k1Byte) {
-      if ((s[pos] >= 0x00 && s[pos] <= ' ') || s[pos] == '<' || s[pos] == '>' ||
-          s[pos] == '{' || s[pos] == '}' || s[pos] == '\"' || s[pos] == '|' ||
-          s[pos] == '^' || s[pos] == '`' || s[pos] == '\\') {
-        tmp += encodePERCENT(s.substr(pos, 1));
-        continue;
-      }
-    }
     tmp += s.substr(pos, length);
     pos += length - 1;
   }
@@ -1269,47 +1206,7 @@ void osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>::writeFormattedIRIUnsafe(
 
 // ____________________________________________________________________________
 template <>
-void osm2rdf::ttl::Writer<
-    osm2rdf::ttl::format::QLEVER>::writeFormattedIRIUnsafe(std::string_view p,
-                                                           std::string_view v,
-                                                           size_t part) {
-  // TTL: [135s] iri
-  //      https://www.w3.org/TR/turtle/#grammar-production-iri
-  //      [18]   IRIREF (same as NT)
-  //      https://www.w3.org/TR/turtle/#grammar-production-IRIREF
-  //      [136s] PrefixedName
-  //      https://www.w3.org/TR/turtle/#grammar-production-PrefixedName
-  auto prefix = _prefixes.find(std::string{p});
-  // If known prefix -> PrefixedName
-  if (prefix != _prefixes.end()) {
-    writePrefixedNameUnsafe(p, v, part);
-    return;
-  }
-  _out->write(IRIREFUnsafe(p, v), part);
-}
-
-// ____________________________________________________________________________
-template <>
 void osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>::writeFormattedIRI(
-    std::string_view p, std::string_view v, size_t part) {
-  // TTL: [135s] iri
-  //      https://www.w3.org/TR/turtle/#grammar-production-iri
-  //      [18]   IRIREF (same as NT)
-  //      https://www.w3.org/TR/turtle/#grammar-production-IRIREF
-  //      [136s] PrefixedName
-  //      https://www.w3.org/TR/turtle/#grammar-production-PrefixedName
-  auto prefix = _prefixes.find(std::string{p});
-  // If known prefix -> PrefixedName
-  if (prefix != _prefixes.end()) {
-    writePrefixedName(p, v, part);
-    return;
-  }
-  _out->write(IRIREF(p, v), part);
-}
-
-// ____________________________________________________________________________
-template <>
-void osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER>::writeFormattedIRI(
     std::string_view p, std::string_view v, size_t part) {
   // TTL: [135s] iri
   //      https://www.w3.org/TR/turtle/#grammar-production-iri
@@ -1329,4 +1226,3 @@ void osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER>::writeFormattedIRI(
 // ____________________________________________________________________________
 template class osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT>;
 template class osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>;
-template class osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER>;

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -256,6 +256,7 @@ void osm2rdf::ttl::Writer<T>::writeHeader() {
     writeTriple("@prefix", prefix + ":", "<" + iriref + ">", 0);
     _headerLines[0]++;
   }
+  flush();
 }
 
 // ____________________________________________________________________________

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -256,7 +256,7 @@ void osm2rdf::ttl::Writer<T>::writeHeader() {
     writeTriple("@prefix", prefix + ":", "<" + iriref + ">", 0);
     _headerLines[0]++;
   }
-  flush();
+  _out->flush();
 }
 
 // ____________________________________________________________________________

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -615,7 +615,43 @@ std::string osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>::formatIRIUnsafe(
 
 // ____________________________________________________________________________
 template <>
+std::string osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER>::formatIRIUnsafe(
+    std::string_view p, std::string_view v) {
+  // TTL: [135s] iri
+  //      https://www.w3.org/TR/turtle/#grammar-production-iri
+  //      [18]   IRIREF (same as NT)
+  //      https://www.w3.org/TR/turtle/#grammar-production-IRIREF
+  //      [136s] PrefixedName
+  //      https://www.w3.org/TR/turtle/#grammar-production-PrefixedName
+  auto prefix = _prefixes.find(std::string{p});
+  // If known prefix -> PrefixedName
+  if (prefix != _prefixes.end()) {
+    return PrefixedNameUnsafe(p, v);
+  }
+  return IRIREFUnsafe(p, v);
+}
+
+// ____________________________________________________________________________
+template <>
 std::string osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>::formatIRI(
+    std::string_view p, std::string_view v) {
+  // TTL: [135s] iri
+  //      https://www.w3.org/TR/turtle/#grammar-production-iri
+  //      [18]   IRIREF (same as NT)
+  //      https://www.w3.org/TR/turtle/#grammar-production-IRIREF
+  //      [136s] PrefixedName
+  //      https://www.w3.org/TR/turtle/#grammar-production-PrefixedName
+  auto prefix = _prefixes.find(std::string{p});
+  // If known prefix -> PrefixedName
+  if (prefix != _prefixes.end()) {
+    return PrefixedName(p, v);
+  }
+  return IRIREF(p, v);
+}
+
+// ____________________________________________________________________________
+template <>
+std::string osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER>::formatIRI(
     std::string_view p, std::string_view v) {
   // TTL: [135s] iri
   //      https://www.w3.org/TR/turtle/#grammar-production-iri
@@ -873,6 +909,33 @@ std::string osm2rdf::ttl::Writer<T>::encodeIRIREF(std::string_view s) {
       continue;
     }
     uint8_t length = utf8Length(c);
+    tmp += s.substr(pos, length);
+    pos += length - 1;
+  }
+  return tmp;
+}
+
+// ____________________________________________________________________________
+template <>
+std::string osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER>::encodeIRIREF(
+    std::string_view s) {
+  // NT:  [8]   IRIREF
+  //      https://www.w3.org/TR/n-triples/#grammar-production-IRIREF
+  // TTL: [18]  IRIREF
+  //      https://www.w3.org/TR/turtle/#grammar-production-IRIREF
+  std::string tmp;
+  tmp.reserve(s.size() * 2);
+  for (size_t pos = 0; pos < s.size(); ++pos) {
+    uint8_t length = utf8Length(s[pos]);
+    // Force non-allowed chars to PERCENT
+    if (length == k1Byte) {
+      if ((s[pos] >= 0x00 && s[pos] <= ' ') || s[pos] == '<' || s[pos] == '>' ||
+          s[pos] == '{' || s[pos] == '}' || s[pos] == '\"' || s[pos] == '|' ||
+          s[pos] == '^' || s[pos] == '`' || s[pos] == '\\') {
+        tmp += encodePERCENT(s.substr(pos, 1));
+        continue;
+      }
+    }
     tmp += s.substr(pos, length);
     pos += length - 1;
   }
@@ -1207,7 +1270,47 @@ void osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>::writeFormattedIRIUnsafe(
 
 // ____________________________________________________________________________
 template <>
+void osm2rdf::ttl::Writer<
+    osm2rdf::ttl::format::QLEVER>::writeFormattedIRIUnsafe(std::string_view p,
+                                                           std::string_view v,
+                                                           size_t part) {
+  // TTL: [135s] iri
+  //      https://www.w3.org/TR/turtle/#grammar-production-iri
+  //      [18]   IRIREF (same as NT)
+  //      https://www.w3.org/TR/turtle/#grammar-production-IRIREF
+  //      [136s] PrefixedName
+  //      https://www.w3.org/TR/turtle/#grammar-production-PrefixedName
+  auto prefix = _prefixes.find(std::string{p});
+  // If known prefix -> PrefixedName
+  if (prefix != _prefixes.end()) {
+    writePrefixedNameUnsafe(p, v, part);
+    return;
+  }
+  _out->write(IRIREFUnsafe(p, v), part);
+}
+
+// ____________________________________________________________________________
+template <>
 void osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>::writeFormattedIRI(
+    std::string_view p, std::string_view v, size_t part) {
+  // TTL: [135s] iri
+  //      https://www.w3.org/TR/turtle/#grammar-production-iri
+  //      [18]   IRIREF (same as NT)
+  //      https://www.w3.org/TR/turtle/#grammar-production-IRIREF
+  //      [136s] PrefixedName
+  //      https://www.w3.org/TR/turtle/#grammar-production-PrefixedName
+  auto prefix = _prefixes.find(std::string{p});
+  // If known prefix -> PrefixedName
+  if (prefix != _prefixes.end()) {
+    writePrefixedName(p, v, part);
+    return;
+  }
+  _out->write(IRIREF(p, v), part);
+}
+
+// ____________________________________________________________________________
+template <>
+void osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER>::writeFormattedIRI(
     std::string_view p, std::string_view v, size_t part) {
   // TTL: [135s] iri
   //      https://www.w3.org/TR/turtle/#grammar-production-iri
@@ -1227,3 +1330,4 @@ void osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>::writeFormattedIRI(
 // ____________________________________________________________________________
 template class osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT>;
 template class osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL>;
+template class osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER>;

--- a/src/util/Output.cpp
+++ b/src/util/Output.cpp
@@ -104,7 +104,11 @@ void osm2rdf::util::Output::close() {
   }
 
   if (_toStdOut) {
-    // nothing to do
+    for (size_t i = 0; i < _partCount; ++i) {
+      _lines[i] = 0;
+      _outBuffers[i][_outBufPos[i]] = '\0';
+      std::cout << reinterpret_cast<const char*>(_outBuffers[i]);
+    }
   } else if (_config.outputCompress) {
 #pragma omp parallel for
     for (size_t i = 0; i < _partCount; ++i) {

--- a/src/util/Output.cpp
+++ b/src/util/Output.cpp
@@ -45,6 +45,7 @@ osm2rdf::util::Output::Output(const osm2rdf::config::Config& config,
       _partCount(partCount),
       _partCountDigits(std::floor(std::log10(partCount)) + 1),
       _outBuffers(_partCount),
+      _lines(_partCount),
       _toStdOut(_config.output.empty()) {}
 
 // ____________________________________________________________________________
@@ -199,7 +200,10 @@ void osm2rdf::util::Output::concatenate() {
 // ____________________________________________________________________________
 void osm2rdf::util::Output::writeNewLine(size_t part) {
   write('\n', part);
-  if (_toStdOut) flush(part);
+  _lines[part]++;
+  if (_toStdOut) {
+    if (_lines[part] > 50) flush(part);
+  }
 }
 
 // ____________________________________________________________________________
@@ -309,6 +313,7 @@ void osm2rdf::util::Output::flush() {
 // ____________________________________________________________________________
 void osm2rdf::util::Output::flush(size_t i) {
   if (_toStdOut) {
+    _lines[i] = 0;
     _outBuffers[i][_outBufPos[i]] = '\0';
     std::cout << reinterpret_cast<const char*>(_outBuffers[i]);
   } else if (_config.outputCompress) {

--- a/src/util/Output.cpp
+++ b/src/util/Output.cpp
@@ -17,6 +17,7 @@
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include <bzlib.h>
+#include <zlib.h>
 
 #include <cassert>
 #include <cmath>
@@ -30,6 +31,10 @@
 
 #include "osm2rdf/config/Config.h"
 #include "osm2rdf/util/Output.h"
+
+using osm2rdf::config::BZ2;
+using osm2rdf::config::GZ;
+using osm2rdf::config::NONE;
 
 // ____________________________________________________________________________
 osm2rdf::util::Output::Output(const osm2rdf::config::Config& config,
@@ -56,26 +61,40 @@ bool osm2rdf::util::Output::open() {
   assert(_partCount > 0);
 
   _rawFiles.resize(_partCount);
+  _gzFiles.resize(_partCount);
   _files.resize(_partCount);
   _outBufPos.resize(_partCount);
 
   for (size_t i = 0; i < _partCount; i++) {
-    _rawFiles[i] = fopen(partFilename(i).c_str(), "w");
+    if (_config.outputCompress == BZ2 || _config.outputCompress == NONE) {
+      _rawFiles[i] = fopen(partFilename(i).c_str(), "w");
 
-    if (_rawFiles[i] == NULL) {
-      std::stringstream ss;
-      ss << "Could not open file '" << partFilename(i)
-         << "' for writing:\n";
-      ss << strerror(errno) << std::endl;
-      throw std::runtime_error(ss.str());
+      if (_rawFiles[i] == NULL) {
+        std::stringstream ss;
+        ss << "Could not open file '" << partFilename(i)
+           << "' for writing:\n";
+        ss << strerror(errno) << std::endl;
+        throw std::runtime_error(ss.str());
+      }
     }
 
-    if (_config.outputCompress) {
+    if (_config.outputCompress == BZ2) {
       int err = 0;
       _files[i] = BZ2_bzWriteOpen(&err, _rawFiles[i], 3, 0, 30);
       if (err != BZ_OK) {
         std::stringstream ss;
         ss << "Could not open bzip2 file '" << partFilename(i)
+           << "' for writing:\n";
+        ss << strerror(errno) << std::endl;
+        throw std::runtime_error(ss.str());
+      }
+    }
+
+    if (_config.outputCompress == GZ) {
+      _gzFiles[i] = gzopen(partFilename(i).c_str(), "w");
+      if (_gzFiles[i] == Z_NULL) {
+        std::stringstream ss;
+        ss << "Could not open gz file '" << partFilename(i)
            << "' for writing:\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
@@ -109,7 +128,7 @@ void osm2rdf::util::Output::close() {
       _outBuffers[i][_outBufPos[i]] = '\0';
       std::cout << reinterpret_cast<const char*>(_outBuffers[i]);
     }
-  } else if (_config.outputCompress) {
+  } else if (_config.outputCompress == BZ2) {
 #pragma omp parallel for
     for (size_t i = 0; i < _partCount; ++i) {
       int err = 0;
@@ -124,6 +143,20 @@ void osm2rdf::util::Output::close() {
       }
       BZ2_bzWriteClose(&err, _files[i], 0, 0, 0);
       fclose(_rawFiles[i]);
+    }
+  } else if (_config.outputCompress == GZ) {
+#pragma omp parallel for
+    for (size_t i = 0; i < _partCount; ++i) {
+      int r = gzwrite(_gzFiles[i], _outBuffers[i], _outBufPos[i]);
+      if (r != (int)_outBufPos[i]) {
+        gzclose(_gzFiles[i]);
+        std::stringstream ss;
+        ss << "Could not write to gz file '"
+           << partFilename(i) << "':\n";
+        ss << strerror(errno) << std::endl;
+        throw std::runtime_error(ss.str());
+      }
+      gzclose(_gzFiles[i]);
     }
   } else {
 #pragma omp parallel for
@@ -215,7 +248,7 @@ void osm2rdf::util::Output::write(std::string_view strv, size_t t) {
   assert(t < _partCount);
   if (_toStdOut) {
     // on output to stdout, we only flush on newlines
-  } else if (_config.outputCompress) {
+  } else if (_config.outputCompress == BZ2) {
     if (_outBufPos[t] + strv.size() + 1 >= BUFFER_S) {
       int err = 0;
       BZ2_bzWrite(&err, _files[t], _outBuffers[t], _outBufPos[t]);
@@ -223,6 +256,19 @@ void osm2rdf::util::Output::write(std::string_view strv, size_t t) {
         BZ2_bzWriteClose(&err, _files[t], 0, 0, 0);
         std::stringstream ss;
         ss << "Could not write to bzip2 file '"
+           << partFilename(t) << "':\n";
+        ss << strerror(errno) << std::endl;
+        throw std::runtime_error(ss.str());
+      }
+      _outBufPos[t] = 0;
+    }
+  } else if (_config.outputCompress == GZ) {
+    if (_outBufPos[t] + strv.size() + 1 >= BUFFER_S) {
+      int r = gzwrite(_gzFiles[t], _outBuffers[t], _outBufPos[t]);
+      if (r != (int)_outBufPos[t]) {
+        gzclose(_gzFiles[t]);
+        std::stringstream ss;
+        ss << "Could not write to gz file '"
            << partFilename(t) << "':\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
@@ -266,7 +312,7 @@ void osm2rdf::util::Output::write(const char c, size_t t) {
   assert(t < _partCount);
   if (_toStdOut) {
     // on output to stdout, we only flush on newlines
-  } else if (_config.outputCompress) {
+  } else if (_config.outputCompress == BZ2) {
     if (_outBufPos[t] + 2 >= BUFFER_S) {
       int err = 0;
       BZ2_bzWrite(&err, _files[t], _outBuffers[t], _outBufPos[t]);
@@ -274,6 +320,19 @@ void osm2rdf::util::Output::write(const char c, size_t t) {
         BZ2_bzWriteClose(&err, _files[t], 0, 0, 0);
         std::stringstream ss;
         ss << "Could not write to bzip2 file '"
+           << partFilename(t) << "':\n";
+        ss << strerror(errno) << std::endl;
+        throw std::runtime_error(ss.str());
+      }
+      _outBufPos[t] = 0;
+    }
+  } else if (_config.outputCompress == GZ) {
+    if (_outBufPos[t] + 2 >= BUFFER_S) {
+      int r = gzwrite(_gzFiles[t], _outBuffers[t], _outBufPos[t]);
+      if (r != (int)_outBufPos[t]) {
+        gzclose(_gzFiles[t]);
+        std::stringstream ss;
+        ss << "Could not write to gz file '"
            << partFilename(t) << "':\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
@@ -320,13 +379,23 @@ void osm2rdf::util::Output::flush(size_t i) {
     _lines[i] = 0;
     _outBuffers[i][_outBufPos[i]] = '\0';
     std::cout << reinterpret_cast<const char*>(_outBuffers[i]);
-  } else if (_config.outputCompress) {
+  } else if (_config.outputCompress == BZ2) {
     int err = 0;
     BZ2_bzWrite(&err, _files[i], _outBuffers[i], _outBufPos[i]);
     if (err == BZ_IO_ERROR) {
       BZ2_bzWriteClose(&err, _files[i], 0, 0, 0);
       std::stringstream ss;
       ss << "Could not write to bzip2 file '"
+         << partFilename(i) << "':\n";
+      ss << strerror(errno) << std::endl;
+      throw std::runtime_error(ss.str());
+    }
+  } else if (_config.outputCompress == GZ) {
+    int r = gzwrite(_gzFiles[i], _outBuffers[i], _outBufPos[i]);
+    if (r != (int)_outBufPos[i]) {
+          gzclose(_gzFiles[i]);
+      std::stringstream ss;
+      ss << "Could not write to gz file '"
          << partFilename(i) << "':\n";
       ss << strerror(errno) << std::endl;
       throw std::runtime_error(ss.str());

--- a/src/util/ProgressBar.cpp
+++ b/src/util/ProgressBar.cpp
@@ -36,6 +36,7 @@ osm2rdf::util::ProgressBar::ProgressBar(std::size_t maxValue, bool show)
   if (maxValue == 0) {
     _countWidth = 1;
   }
+  _show = false;
   _width = kTerminalWidth - _countWidth * 2 - 4 - 5 - 2;
 }
 

--- a/src/util/ProgressBar.cpp
+++ b/src/util/ProgressBar.cpp
@@ -36,7 +36,6 @@ osm2rdf::util::ProgressBar::ProgressBar(std::size_t maxValue, bool show)
   if (maxValue == 0) {
     _countWidth = 1;
   }
-  _show = false;
   _width = kTerminalWidth - _countWidth * 2 - 4 - 5 - 2;
 }
 

--- a/tests/Baseline.cpp
+++ b/tests/Baseline.cpp
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
+#include <algorithm>
 #include "gtest/gtest.h"
 
 namespace osm2rdf {

--- a/tests/E2E.cpp
+++ b/tests/E2E.cpp
@@ -56,7 +56,7 @@ TEST(E2E, singleNode) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -126,7 +126,7 @@ TEST(E2E, singleNodeWithTags) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -247,7 +247,7 @@ TEST(E2E, singleWayWithTagsAndNodes) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -355,7 +355,7 @@ TEST(E2E, osmWikiExample) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -454,7 +454,7 @@ TEST(E2E, building51NT) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -627,7 +627,7 @@ TEST(E2E, building51TTL) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -763,7 +763,7 @@ TEST(E2E, building51QLEVER) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -899,7 +899,7 @@ TEST(E2E, tf) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -995,7 +995,7 @@ TEST(E2E, building51inTF) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addAreaWayLinestrings = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 

--- a/tests/E2E.cpp
+++ b/tests/E2E.cpp
@@ -73,11 +73,11 @@ TEST(E2E, singleNode) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -154,11 +154,11 @@ TEST(E2E, singleNodeWithTags) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -275,11 +275,11 @@ TEST(E2E, singleWayWithTagsAndNodes) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -795,11 +795,11 @@ TEST(E2E, building51QLEVER) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -931,11 +931,11 @@ TEST(E2E, tf) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -1031,11 +1031,11 @@ TEST(E2E, building51inTF) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();

--- a/tests/E2E.cpp
+++ b/tests/E2E.cpp
@@ -76,7 +76,10 @@ TEST(E2E, singleNode) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
 
   output.flush();
@@ -154,7 +157,10 @@ TEST(E2E, singleNodeWithTags) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
 
   output.flush();
@@ -272,7 +278,10 @@ TEST(E2E, singleWayWithTagsAndNodes) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
 
   output.flush();
@@ -393,7 +402,10 @@ TEST(E2E, osmWikiExample) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
 
   output.flush();
@@ -477,8 +489,12 @@ TEST(E2E, building51NT) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
+  geomHandler.calculateRelations();
 
   output.flush();
   output.close();
@@ -646,8 +662,12 @@ TEST(E2E, building51TTL) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
+  geomHandler.calculateRelations();
 
   output.flush();
   output.close();
@@ -778,8 +798,12 @@ TEST(E2E, building51QLEVER) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
+  geomHandler.calculateRelations();
 
   output.flush();
   output.close();
@@ -910,7 +934,10 @@ TEST(E2E, tf) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
 
   output.flush();
@@ -1007,8 +1034,12 @@ TEST(E2E, building51inTF) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
+  geomHandler.calculateRelations();
 
   output.flush();
   output.close();

--- a/tests/E2E.cpp
+++ b/tests/E2E.cpp
@@ -73,11 +73,11 @@ TEST(E2E, singleNode) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -154,11 +154,11 @@ TEST(E2E, singleNodeWithTags) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -275,11 +275,11 @@ TEST(E2E, singleWayWithTagsAndNodes) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -795,11 +795,11 @@ TEST(E2E, building51QLEVER) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -931,11 +931,11 @@ TEST(E2E, tf) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -1031,11 +1031,11 @@ TEST(E2E, building51inTF) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();

--- a/tests/E2E.cpp
+++ b/tests/E2E.cpp
@@ -571,7 +571,7 @@ TEST(E2E, building51NT) {
       printedData,
       ::testing::HasSubstr(
           "<https://osm2rdf.cs.uni-freiburg.de/rdf/geom#osm_wayarea_98284318> "
-          "<http://www.opengis.net/ont/geosparql#asWKT> \"MULTIPOLYGON(((7"));
+          "<http://www.opengis.net/ont/geosparql#asWKT> \"POLYGON((7"));
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
@@ -722,7 +722,7 @@ TEST(E2E, building51TTL) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osm2rdfgeom:osm_wayarea_98284318 geo:asWKT \"MULTIPOLYGON(((7"));
+          "osm2rdfgeom:osm_wayarea_98284318 geo:asWKT \"POLYGON((7"));
   ASSERT_THAT(printedData, ::testing::HasSubstr("))\"^^geo:wktLiteral .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
@@ -858,8 +858,8 @@ TEST(E2E, building51QLEVER) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osm2rdfgeom:osm_wayarea_98284318 geo:asWKT \"MULTIPOLYGON(((7"));
-  ASSERT_THAT(printedData, ::testing::HasSubstr(")))\"^^geo:wktLiteral .\n"));
+          "osm2rdfgeom:osm_wayarea_98284318 geo:asWKT \"POLYGON((7"));
+  ASSERT_THAT(printedData, ::testing::HasSubstr("))\"^^geo:wktLiteral .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "osmway:98284318 ogc:sfIntersects osmnode:2110601105 .\n"));
@@ -972,7 +972,7 @@ TEST(E2E, tf) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osm2rdfgeom:osm_wayarea_4498466 geo:asWKT \"MULTIPOLYGON(((7"));
+          "osm2rdfgeom:osm_wayarea_4498466 geo:asWKT \"POLYGON((7"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -1093,7 +1093,7 @@ TEST(E2E, building51inTF) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osm2rdfgeom:osm_wayarea_98284318 geo:asWKT \"MULTIPOLYGON(((7"));
+          "osm2rdfgeom:osm_wayarea_98284318 geo:asWKT \"POLYGON((7"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr("osmway:4498466 rdf:type osm:way .\n"));
   ASSERT_THAT(printedData,
@@ -1110,7 +1110,7 @@ TEST(E2E, building51inTF) {
                                "osmway:4498466 osmkey:wheelchair \"yes\" .\n"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
-                  "osm2rdfgeom:osm_wayarea_4498466 geo:asWKT \"MULTIPOLYGON(((7"));
+                  "osm2rdfgeom:osm_wayarea_4498466 geo:asWKT \"POLYGON((7"));
   ASSERT_THAT(printedData,
               ::testing::HasSubstr(
                   "osmway:4498466 ogc:sfCovers osmway:98284318 .\n"));

--- a/tests/config/Config.cpp
+++ b/tests/config/Config.cpp
@@ -31,7 +31,7 @@ namespace osm2rdf::config {
 void assertDefaultConfig(const osm2rdf::config::Config& config) {
   ASSERT_FALSE(config.noFacts);
   ASSERT_FALSE(config.noGeometricRelations);
-  ASSERT_TRUE(config.storeLocationsOnDisk.empty());
+  ASSERT_TRUE(config.storeLocations.empty());
 
   ASSERT_FALSE(config.noAreaFacts);
   ASSERT_FALSE(config.noNodeFacts);
@@ -335,53 +335,37 @@ TEST(CONFIG_Config, fromArgsNoFactsLong) {
 }
 
 // ____________________________________________________________________________
-TEST(CONFIG_Config, fromArgsStoreLocationsOnDiskLongImplicit) {
-  osm2rdf::config::Config config;
-  assertDefaultConfig(config);
-  osm2rdf::util::CacheFile cf("/tmp/dummyInput");
-
-  const auto arg =
-      "--" + osm2rdf::config::constants::STORE_LOCATIONS_ON_DISK_LONG;
-  const int argc = 3;
-  char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
-                      const_cast<char*>("/tmp/dummyInput")};
-  config.fromArgs(argc, argv);
-  ASSERT_EQ("", config.output.string());
-  ASSERT_EQ("sparse", config.storeLocationsOnDisk);
-}
-
-// ____________________________________________________________________________
-TEST(CONFIG_Config, fromArgsStoreLocationsOnDiskLongSparse) {
+TEST(CONFIG_Config, fromArgsStoreLocationsLongSparse) {
   osm2rdf::config::Config config;
   assertDefaultConfig(config);
   osm2rdf::util::CacheFile cf("/tmp/dummyInput");
 
   const auto arg = "--" +
-                   osm2rdf::config::constants::STORE_LOCATIONS_ON_DISK_LONG +
+                   osm2rdf::config::constants::STORE_LOCATIONS_LONG +
                    "=sparse";
   const int argc = 3;
   char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
                       const_cast<char*>("/tmp/dummyInput")};
   config.fromArgs(argc, argv);
   ASSERT_EQ("", config.output.string());
-  ASSERT_EQ("sparse", config.storeLocationsOnDisk);
+  ASSERT_EQ("sparse", config.storeLocations);
 }
 
 // ____________________________________________________________________________
-TEST(CONFIG_Config, fromArgsStoreLocationsOnDiskLongDense) {
+TEST(CONFIG_Config, fromArgsStoreLocationsLongDense) {
   osm2rdf::config::Config config;
   assertDefaultConfig(config);
   osm2rdf::util::CacheFile cf("/tmp/dummyInput");
 
   const auto arg = "--" +
-                   osm2rdf::config::constants::STORE_LOCATIONS_ON_DISK_LONG +
+                   osm2rdf::config::constants::STORE_LOCATIONS_LONG +
                    "=dense";
   const int argc = 3;
   char* argv[argc] = {const_cast<char*>(""), const_cast<char*>(arg.c_str()),
                       const_cast<char*>("/tmp/dummyInput")};
   config.fromArgs(argc, argv);
   ASSERT_EQ("", config.output.string());
-  ASSERT_EQ("dense", config.storeLocationsOnDisk);
+  ASSERT_EQ("dense", config.storeLocations);
 }
 
 // ____________________________________________________________________________

--- a/tests/issues/Issue15.cpp
+++ b/tests/issues/Issue15.cpp
@@ -51,7 +51,10 @@ TEST(Issue15, Relation_8291361_expected) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
 
   output.flush();
@@ -101,7 +104,10 @@ TEST(Issue15, Relation_8291361_failed) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
 
   output.flush();
@@ -152,7 +158,10 @@ TEST(Issue15, Way_201387026_expected) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
 
   output.flush();
@@ -202,7 +211,10 @@ TEST(Issue15, Way_201387026_failed) {
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
 
   output.flush();

--- a/tests/issues/Issue15.cpp
+++ b/tests/issues/Issue15.cpp
@@ -48,11 +48,11 @@ TEST(Issue15, Relation_8291361_expected) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -101,11 +101,11 @@ TEST(Issue15, Relation_8291361_failed) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -155,11 +155,11 @@ TEST(Issue15, Way_201387026_expected) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -208,11 +208,11 @@ TEST(Issue15, Way_201387026_failed) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();

--- a/tests/issues/Issue15.cpp
+++ b/tests/issues/Issue15.cpp
@@ -41,7 +41,7 @@ TEST(Issue15, Relation_8291361_expected) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.input = "tests/issues/issue15_osmrel_8291361.xml";
   config.simplifyWKT = 0;
@@ -95,7 +95,7 @@ TEST(Issue15, Relation_8291361_failed) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.input = "tests/issues/issue15_osmrel_8291361.xml";
 
@@ -148,7 +148,7 @@ TEST(Issue15, Way_201387026_expected) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.input = "tests/issues/issue15_osmway_201387026.xml";
   config.simplifyWKT = 0;
@@ -202,7 +202,7 @@ TEST(Issue15, Way_201387026_failed) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.input = "tests/issues/issue15_osmway_201387026.xml";
 

--- a/tests/issues/Issue15.cpp
+++ b/tests/issues/Issue15.cpp
@@ -180,7 +180,7 @@ TEST(Issue15, Way_201387026_expected) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osm2rdfgeom:osm_wayarea_201387026 geo:asWKT \"MULTIPOLYGON(((1"));
+          "osm2rdfgeom:osm_wayarea_201387026 geo:asWKT \"POLYGON((1"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);
@@ -233,7 +233,7 @@ TEST(Issue15, Way_201387026_failed) {
   ASSERT_THAT(
       printedData,
       ::testing::HasSubstr(
-          "osm2rdfgeom:osm_wayarea_201387026 geo:asWKT \"MULTIPOLYGON(((1"));
+          "osm2rdfgeom:osm_wayarea_201387026 geo:asWKT \"POLYGON((1"));
 
   // Reset std::cerr and std::cout
   std::cerr.rdbuf(cerrBufferOrig);

--- a/tests/issues/Issue15.cpp
+++ b/tests/issues/Issue15.cpp
@@ -48,11 +48,11 @@ TEST(Issue15, Relation_8291361_expected) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -101,11 +101,11 @@ TEST(Issue15, Relation_8291361_failed) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -155,11 +155,11 @@ TEST(Issue15, Way_201387026_expected) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
@@ -208,11 +208,11 @@ TEST(Issue15, Way_201387026_failed) {
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
-  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::QLEVER> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::QLEVER> geomHandler(config, &writer);
 
   osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();

--- a/tests/issues/Issue24.cpp
+++ b/tests/issues/Issue24.cpp
@@ -245,7 +245,7 @@ TEST(Issue24, relationWithGeometryHasGeometryAsGeoSPARQL) {
 
   osm2rdf::osm::RelationHandler rh = osm2rdf::osm::RelationHandler(config);
   osm2rdf::osm::LocationHandler* lh =
-      osm2rdf::osm::LocationHandler::create(config);
+      osm2rdf::osm::LocationHandler::create(config, 0, 0);
   // Create osm2rdf object from osmium object
   osm2rdf::osm::Relation r{osmiumBuffer1.get<osmium::Relation>(0)};
   rh.relation(osmiumBuffer1.get<osmium::Relation>(0));

--- a/tests/issues/Issue24.cpp
+++ b/tests/issues/Issue24.cpp
@@ -74,7 +74,7 @@ TEST(Issue24, areaFromWayHasGeometryAsGeoSPARQL) {
       "osm2rdfgeom:envelope \"POLYGON((48 7.5,48.1 7.5,48.1 7.6,48 7.6,48 "
       "7.5))\"^^geo:wktLiteral .\nosmway:21 osm2rdfgeom:obb \"POLYGON((48 7.5,"
       "48 7.6,48.1 7.6,48.1 7.5,48 7.5))\"^^geo:wktLiteral .\nosmway:21 "
-      "osm2rdf:area \"0.010000000000\"^^xsd:double .\n",
+      "osm2rdf:area \"0.01\"^^xsd:double .\n",
       buffer.str());
 
   // Cleanup
@@ -132,7 +132,7 @@ TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
       "\"POLYGON((48 7.5,48.1 7.5,48.1 7.6,48 7.6,48 "
       "7.5))\"^^geo:wktLiteral .\nosmrel:10 osm2rdfgeom:obb \"POLYGON((48 7.5,"
       "48 7.6,48.1 7.6,48.1 7.5,48 7.5))\"^^geo:wktLiteral .\nosmrel:10 "
-      "osm2rdf:area \"0.010000000000\"^^xsd:double .\n",
+      "osm2rdf:area \"0.01\"^^xsd:double .\n",
       buffer.str());
 
   // Cleanup

--- a/tests/issues/Issue24.cpp
+++ b/tests/issues/Issue24.cpp
@@ -67,8 +67,8 @@ TEST(Issue24, areaFromWayHasGeometryAsGeoSPARQL) {
 
   ASSERT_EQ(
       "osmway:21 geo:hasGeometry osm2rdfgeom:osm_wayarea_21 "
-      ".\nosm2rdfgeom:osm_wayarea_21 geo:asWKT \"MULTIPOLYGON(((48 7.5,48 "
-      "7.6,48.1 7.6,48.1 7.5,48 7.5)))\"^^geo:wktLiteral "
+      ".\nosm2rdfgeom:osm_wayarea_21 geo:asWKT \"POLYGON((48 7.5,48 "
+      "7.6,48.1 7.6,48.1 7.5,48 7.5))\"^^geo:wktLiteral "
       ".\nosmway:21 osm2rdfgeom:convex_hull \"POLYGON((48 7.5,48 7.6,"
       "48.1 7.6,48.1 7.5,48 7.5))\"^^geo:wktLiteral .\nosmway:21 "
       "osm2rdfgeom:envelope \"POLYGON((48 7.5,48.1 7.5,48.1 7.6,48 7.6,48 "
@@ -125,8 +125,8 @@ TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
 
   ASSERT_EQ(
       "osmrel:10 geo:hasGeometry osm2rdfgeom:osm_relarea_10 "
-      ".\nosm2rdfgeom:osm_relarea_10 geo:asWKT \"MULTIPOLYGON(((48 7.5,48 "
-      "7.6,48.1 7.6,48.1 7.5,48 7.5)))\"^^geo:wktLiteral .\nosmrel:10 "
+      ".\nosm2rdfgeom:osm_relarea_10 geo:asWKT \"POLYGON((48 7.5,48 "
+      "7.6,48.1 7.6,48.1 7.5,48 7.5))\"^^geo:wktLiteral .\nosmrel:10 "
       "osm2rdfgeom:convex_hull \"POLYGON((48 7.5,48 7.6,48.1 7.6,48.1 7.5,"
       "48 7.5))\"^^geo:wktLiteral .\nosmrel:10 osm2rdfgeom:envelope "
       "\"POLYGON((48 7.5,48.1 7.5,48.1 7.6,48 7.6,48 "
@@ -318,7 +318,8 @@ TEST(Issue24, wayHasGeometryAsGeoSPARQL) {
                            }));
 
   // Create osm2rdf object from osmium object
-  const osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  w.finalize();
 
   dh.way(w);
   output.flush();

--- a/tests/issues/Issue24.cpp
+++ b/tests/issues/Issue24.cpp
@@ -34,7 +34,7 @@ TEST(Issue24, areaFromWayHasGeometryAsGeoSPARQL) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -92,7 +92,7 @@ TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -150,7 +150,7 @@ TEST(Issue24, nodeHasGeometryAsGeoSPARQL) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -202,7 +202,7 @@ TEST(Issue24, relationWithGeometryHasGeometryAsGeoSPARQL) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -297,7 +297,7 @@ TEST(Issue24, wayHasGeometryAsGeoSPARQL) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;

--- a/tests/issues/Issue28.cpp
+++ b/tests/issues/Issue28.cpp
@@ -35,7 +35,7 @@ TEST(Issue28, OpenReadonlyOutputFile) {
   config.output =
       config.getTempPath("TEST_ISSUES_Issue28", "OpenReadonlyOutputFile");
   config.mergeOutput = OutputMergeMode::CONCATENATE;
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   ASSERT_FALSE(std::filesystem::exists(config.output));
   std::filesystem::create_directories(config.output);
   ASSERT_TRUE(std::filesystem::exists(config.output));
@@ -69,7 +69,7 @@ TEST(Issue28, OutputfileTruncatedOnOpenConcatenate) {
   config.output = config.getTempPath("TEST_ISSUES_Issue28",
                                      "OutputfileTruncatedOnOpenConcatenate");
   config.mergeOutput = OutputMergeMode::CONCATENATE;
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.outputKeepFiles = true;
   ASSERT_FALSE(std::filesystem::exists(config.output));
   std::filesystem::create_directories(config.output);

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -54,7 +54,7 @@ TEST(OSM_FactHandler, areaFromWay) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -113,7 +113,7 @@ TEST(OSM_FactHandler, areaFromRelation) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -172,7 +172,7 @@ TEST(OSM_FactHandler, node) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -225,7 +225,7 @@ TEST(OSM_FactHandler, relation) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -283,7 +283,7 @@ TEST(OSM_FactHandler, relationHandler) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -373,7 +373,7 @@ TEST(OSM_FactHandler, relationWithGeometry) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -471,7 +471,7 @@ TEST(OSM_FactHandler, way) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -529,7 +529,7 @@ TEST(OSM_FactHandler, wayAddWayNodeGeoemtry) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -597,7 +597,7 @@ TEST(OSM_FactHandler, wayAddWayNodeOrder) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -659,7 +659,7 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataShortWay) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -724,7 +724,7 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataLongerWay) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -794,7 +794,7 @@ TEST(OSM_FactHandler, wayAddWayMetaData) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -859,7 +859,7 @@ TEST(OSM_FactHandler, writeGeometryWay) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -900,7 +900,7 @@ TEST(OSM_FactHandler, writeGeometryWaySimplify1) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -948,7 +948,7 @@ TEST(OSM_FactHandler, writeGeometryWaySimplify2) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -992,7 +992,7 @@ TEST(OSM_FactHandler, writeGeometryWaySimplify3) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -1037,7 +1037,7 @@ TEST(OSM_FactHandler, writeBoxPrecision1) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
@@ -1077,7 +1077,7 @@ TEST(OSM_FactHandler, writeBoxPrecision2) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 2;
@@ -1117,7 +1117,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1157,7 +1157,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger2) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1196,7 +1196,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger3) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1235,7 +1235,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_Integer) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1275,7 +1275,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerPositive) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1315,7 +1315,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerNegative) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1355,7 +1355,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerWS) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1395,7 +1395,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerWS2) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1435,7 +1435,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1474,7 +1474,7 @@ TEST(OSM_FactHandler, writeTag_KeyIRI) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1513,7 +1513,7 @@ TEST(OSM_FactHandler, writeTag_KeyNotIRI) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1554,7 +1554,7 @@ TEST(OSM_FactHandler, writeTagList) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1606,7 +1606,7 @@ TEST(OSM_FactHandler, writeTagListRefSingle) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1649,7 +1649,7 @@ TEST(OSM_FactHandler, writeTagListRefDouble) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.semicolonTagKeys.insert("ref");
@@ -1696,7 +1696,7 @@ TEST(OSM_FactHandler, writeTagListRefMultiple) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.semicolonTagKeys.insert("ref");
@@ -1746,7 +1746,7 @@ TEST(OSM_FactHandler, writeTagListWikidata) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1795,7 +1795,7 @@ TEST(OSM_FactHandler, writeTagListWikidataMultiple) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1844,7 +1844,7 @@ TEST(OSM_FactHandler, writeTagListWikipediaWithLang) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1893,7 +1893,7 @@ TEST(OSM_FactHandler, writeTagListWikipediaWithoutLang) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1942,7 +1942,7 @@ TEST(OSM_FactHandler, writeTagListSkipWikiLinks) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.skipWikiLinks = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
@@ -1997,7 +1997,7 @@ TEST(OSM_FactHandler, writeTagListStartDateInvalid) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2041,7 +2041,7 @@ TEST(OSM_FactHandler, writeTagListStartDateInvalid2) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2085,7 +2085,7 @@ TEST(OSM_FactHandler, writeTagListStartDateInvalid3) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2129,7 +2129,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYear1) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2178,7 +2178,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYear2) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2227,7 +2227,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYear3) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2276,7 +2276,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYear4) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2325,7 +2325,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth1) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2374,7 +2374,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth2) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2423,7 +2423,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth3) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2472,7 +2472,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth4) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2521,7 +2521,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth5) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2571,7 +2571,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay1) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2620,7 +2620,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay2) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2669,7 +2669,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay3) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2718,7 +2718,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay4) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2767,7 +2767,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay5) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.addCentroids = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -2817,7 +2817,7 @@ TEST(OSM_FactHandler, writeSecondsAsISO) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -1437,7 +1437,7 @@ TEST(OSM_FactHandler, writeTag_KeyNotIRI) {
   const std::string subject = "subject";
   dh.writeTag(subject, osm2rdf::osm::Tag{tagKey, tagValue});
   const std::string expected = subject +
-                               " osm:tag _:0_0 .\n"
+                               " osmkey:tag _:0_0 .\n"
                                "_:0_0 osmkey:key \"" +
                                tagKey +
                                "\" .\n"

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -88,8 +88,8 @@ TEST(OSM_FactHandler, areaFromWay) {
 
   ASSERT_EQ(
       "osmway:21 geo:hasGeometry osm2rdfgeom:osm_wayarea_21 "
-      ".\nosm2rdfgeom:osm_wayarea_21 geo:asWKT \"MULTIPOLYGON(((48 7.5,48 "
-      "7.6,48.1 7.6,48.1 7.5,48 7.5)))\"^^geo:wktLiteral .\nosmway:21 "
+      ".\nosm2rdfgeom:osm_wayarea_21 geo:asWKT \"POLYGON((48 7.5,48 "
+      "7.6,48.1 7.6,48.1 7.5,48 7.5))\"^^geo:wktLiteral .\nosmway:21 "
       "osm2rdfgeom:convex_hull \"POLYGON((48 7.5,48 7.6,48.1 7.6,48.1 7.5,48 "
       "7.5))\"^^geo:wktLiteral .\nosmway:21 osm2rdfgeom:envelope \"POLYGON((48 "
       "7.5,48.1 7.5,48.1 7.6,48 7.6,48 7.5))\"^^geo:wktLiteral .\nosmway:21 "
@@ -147,8 +147,8 @@ TEST(OSM_FactHandler, areaFromRelation) {
 
   ASSERT_EQ(
       "osmrel:10 geo:hasGeometry osm2rdfgeom:osm_relarea_10 "
-      ".\nosm2rdfgeom:osm_relarea_10 geo:asWKT \"MULTIPOLYGON(((48 7.5,48 "
-      "7.6,48.1 7.6,48.1 7.5,48 7.5)))\"^^geo:wktLiteral .\nosmrel:10 "
+      ".\nosm2rdfgeom:osm_relarea_10 geo:asWKT \"POLYGON((48 7.5,48 "
+      "7.6,48.1 7.6,48.1 7.5,48 7.5))\"^^geo:wktLiteral .\nosmrel:10 "
       "osm2rdfgeom:convex_hull \"POLYGON((48 7.5,48 7.6,48.1 7.6,48.1 7.5,48 "
       "7.5))\"^^geo:wktLiteral .\nosmrel:10 osm2rdfgeom:envelope \"POLYGON((48 "
       "7.5,48.1 7.5,48.1 7.6,48 7.6,48 7.5))\"^^geo:wktLiteral .\nosmrel:10 "
@@ -408,7 +408,8 @@ TEST(OSM_FactHandler, way) {
                            osmium::builder::attr::_tag("city", "Freiburg"));
 
   // Create osm2rdf object from osmium object
-  const osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  w.finalize();
 
   dh.way(w);
   output.flush();
@@ -467,7 +468,8 @@ TEST(OSM_FactHandler, wayAddWayNodeGeoemtry) {
                            osmium::builder::attr::_tag("city", "Freiburg"));
 
   // Create osm2rdf object from osmium object
-  const osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  w.finalize();
 
   dh.way(w);
   output.flush();
@@ -533,7 +535,8 @@ TEST(OSM_FactHandler, wayAddWayNodeOrder) {
                            osmium::builder::attr::_tag("city", "Freiburg"));
 
   // Create osm2rdf object from osmium object
-  const osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  w.finalize();
 
   dh.way(w);
   output.flush();
@@ -595,7 +598,8 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataShortWay) {
                            osmium::builder::attr::_tag("city", "Freiburg"));
 
   // Create osm2rdf object from osmium object
-  const osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  w.finalize();
 
   dh.way(w);
   output.flush();
@@ -662,7 +666,8 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataLongerWay) {
                            osmium::builder::attr::_tag("city", "Freiburg"));
 
   // Create osm2rdf object from osmium object
-  const osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  w.finalize();
 
   dh.way(w);
   output.flush();
@@ -727,7 +732,8 @@ TEST(OSM_FactHandler, wayAddWayMetaData) {
                            osmium::builder::attr::_tag("city", "Freiburg"));
 
   // Create osm2rdf object from osmium object
-  const osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  osm2rdf::osm::Way w{osmiumBuffer.get<osmium::Way>(0)};
+  w.finalize();
 
   dh.way(w);
   output.flush();
@@ -1437,7 +1443,7 @@ TEST(OSM_FactHandler, writeTag_KeyNotIRI) {
   const std::string subject = "subject";
   dh.writeTag(subject, osm2rdf::osm::Tag{tagKey, tagValue});
   const std::string expected = subject +
-                               " osmkey:tag _:0_0 .\n"
+                               " osm:tag _:0_0 .\n"
                                "_:0_0 osmkey:key \"" +
                                tagKey +
                                "\" .\n"
@@ -1487,8 +1493,8 @@ TEST(OSM_FactHandler, writeTagList) {
   const std::string object2 = writer.generateLiteral(tag2Value, "");
 
   osm2rdf::osm::TagList tagList;
-  tagList[tag1Key] = tag1Value;
-  tagList[tag2Key] = tag2Value;
+  tagList.push_back({tag1Key, tag1Value});
+  tagList.push_back({tag2Key, tag2Value});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -1533,7 +1539,7 @@ TEST(OSM_FactHandler, writeTagListRefSingle) {
   const std::string object1 = writer.generateLiteral(tagValue, "");
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -1578,7 +1584,7 @@ TEST(OSM_FactHandler, writeTagListRefDouble) {
   const std::string object2 = writer.generateLiteral("B 294", "");
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -1626,7 +1632,7 @@ TEST(OSM_FactHandler, writeTagListRefMultiple) {
   const std::string object3 = writer.generateLiteral("K 4917", "");
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -1677,7 +1683,7 @@ TEST(OSM_FactHandler, writeTagListWikidata) {
       osm2rdf::ttl::constants::NAMESPACE__WIKIDATA_ENTITY, "Q42");
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -1726,7 +1732,7 @@ TEST(OSM_FactHandler, writeTagListWikidataMultiple) {
       osm2rdf::ttl::constants::NAMESPACE__WIKIDATA_ENTITY, "Q42");
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -1775,7 +1781,7 @@ TEST(OSM_FactHandler, writeTagListWikipediaWithLang) {
   const std::string object2 = "<https://de.wikipedia.org/wiki/" + value + ">";
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -1824,7 +1830,7 @@ TEST(OSM_FactHandler, writeTagListWikipediaWithoutLang) {
       "<https://www.wikipedia.org/wiki/" + tagValue + ">";
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -1877,8 +1883,8 @@ TEST(OSM_FactHandler, writeTagListSkipWikiLinks) {
       osm2rdf::ttl::constants::NAMESPACE__OSM2RDF_TAG, tag1Key);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tag1Key] = tag1Value;
-  tagList[tag2Key] = tag2Value;
+  tagList.push_back({tag1Key, tag1Value});
+  tagList.push_back({tag2Key, tag2Value});
 
   dh.writeTagList("subject", tagList);
   output.flush();
@@ -1924,7 +1930,7 @@ TEST(OSM_FactHandler, writeTagListStartDateInvalid) {
   const std::string object1 = writer.generateLiteral(tagValue, "");
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -1968,7 +1974,7 @@ TEST(OSM_FactHandler, writeTagListStartDateInvalid2) {
   const std::string object1 = writer.generateLiteral(tagValue, "");
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2012,7 +2018,7 @@ TEST(OSM_FactHandler, writeTagListStartDateInvalid3) {
   const std::string object1 = writer.generateLiteral(tagValue, "");
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2060,7 +2066,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYear1) {
       "0011", "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2109,7 +2115,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYear2) {
       "-0011", "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2158,7 +2164,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYear3) {
       tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2207,7 +2213,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYear4) {
       tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2256,7 +2262,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth1) {
       "0011-01", "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR_MONTH);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2305,7 +2311,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth2) {
       "-0011-01", "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR_MONTH);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2354,7 +2360,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth3) {
       tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR_MONTH);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2403,7 +2409,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth4) {
       tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR_MONTH);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2452,7 +2458,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth5) {
       tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_YEAR_MONTH);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2502,7 +2508,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay1) {
       "0011-01-01", "^^" + osm2rdf::ttl::constants::IRI__XSD_DATE);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2551,7 +2557,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay2) {
       "-0011-01-01", "^^" + osm2rdf::ttl::constants::IRI__XSD_DATE);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2600,7 +2606,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay3) {
       tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_DATE);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2649,7 +2655,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay4) {
       tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_DATE);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();
@@ -2698,7 +2704,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay5) {
       tagValue, "^^" + osm2rdf::ttl::constants::IRI__XSD_DATE);
 
   osm2rdf::osm::TagList tagList;
-  tagList[tagKey] = tagValue;
+  tagList.push_back({tagKey, tagValue});
 
   dh.writeTagList(subject, tagList);
   output.flush();

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -95,7 +95,7 @@ TEST(OSM_FactHandler, areaFromWay) {
       "7.5,48.1 7.5,48.1 7.6,48 7.6,48 7.5))\"^^geo:wktLiteral .\nosmway:21 "
       "osm2rdfgeom:obb \"POLYGON((48 7.5,48 7.6,48.1 7.6,48.1 7.5,48 "
       "7.5))\"^^geo:wktLiteral .\nosmway:21 osm2rdf:area "
-      "\"0.010000000000\"^^xsd:double .\n",
+      "\"0.01\"^^xsd:double .\n",
       buffer.str());
 
   // Cleanup
@@ -154,7 +154,7 @@ TEST(OSM_FactHandler, areaFromRelation) {
       "7.5,48.1 7.5,48.1 7.6,48 7.6,48 7.5))\"^^geo:wktLiteral .\nosmrel:10 "
       "osm2rdfgeom:obb \"POLYGON((48 7.5,48 7.6,48.1 7.6,48.1 7.5,48 "
       "7.5))\"^^geo:wktLiteral .\nosmrel:10 osm2rdf:area "
-      "\"0.010000000000\"^^xsd:double .\n",
+      "\"0.01\"^^xsd:double .\n",
       buffer.str());
 
   // Cleanup

--- a/tests/osm/Node.cpp
+++ b/tests/osm/Node.cpp
@@ -63,9 +63,8 @@ TEST(OSM_Node, FromNodeWithTags) {
   ASSERT_DOUBLE_EQ(48.0, n.geom().getY());
 
   ASSERT_EQ(1, n.tags().size());
-  ASSERT_EQ(0, n.tags().count("tag"));
-  ASSERT_EQ(1, n.tags().count("city"));
-  ASSERT_STREQ("Freiburg", n.tags().at("city").c_str());
+  ASSERT_STREQ("city", n.tags()[0].first.c_str());
+  ASSERT_STREQ("Freiburg", n.tags()[0].second.c_str());
 }
 
 // ____________________________________________________________________________

--- a/tests/osm/OsmiumHandler.cpp
+++ b/tests/osm/OsmiumHandler.cpp
@@ -131,20 +131,23 @@ TEST(OSM_OsmiumHandler, constructor) {
   osm2rdf::util::Output output{config, config.output};
   output.open();
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT> writer{config, &output};
-  osm2rdf::osm::OsmiumHandler oh{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT> geomHandler(config, &writer);
 
-  ASSERT_EQ(0, oh.areasSeen());
-  ASSERT_EQ(0, oh.areasDumped());
-  ASSERT_EQ(0, oh.areaGeometriesHandled());
-  ASSERT_EQ(0, oh.nodesSeen());
-  ASSERT_EQ(0, oh.nodesDumped());
-  ASSERT_EQ(0, oh.nodeGeometriesHandled());
-  ASSERT_EQ(0, oh.relationsSeen());
-  ASSERT_EQ(0, oh.relationsDumped());
-  ASSERT_EQ(0, oh.relationGeometriesHandled());
-  ASSERT_EQ(0, oh.waysSeen());
-  ASSERT_EQ(0, oh.waysDumped());
-  ASSERT_EQ(0, oh.wayGeometriesHandled());
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
+
+  ASSERT_EQ(0, osmiumHandler.areasSeen());
+  ASSERT_EQ(0, osmiumHandler.areasDumped());
+  ASSERT_EQ(0, osmiumHandler.areaGeometriesHandled());
+  ASSERT_EQ(0, osmiumHandler.nodesSeen());
+  ASSERT_EQ(0, osmiumHandler.nodesDumped());
+  ASSERT_EQ(0, osmiumHandler.nodeGeometriesHandled());
+  ASSERT_EQ(0, osmiumHandler.relationsSeen());
+  ASSERT_EQ(0, osmiumHandler.relationsDumped());
+  ASSERT_EQ(0, osmiumHandler.relationGeometriesHandled());
+  ASSERT_EQ(0, osmiumHandler.waysSeen());
+  ASSERT_EQ(0, osmiumHandler.waysDumped());
+  ASSERT_EQ(0, osmiumHandler.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -168,22 +171,25 @@ TEST(OSM_OsmiumHandler, noFacts) {
   osm2rdf::util::Output output{config, config.output};
   output.open();
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT> writer{config, &output};
-  osm2rdf::osm::OsmiumHandler oh{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT> geomHandler(config, &writer);
 
-  addOsmiumItems(&oh);
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
 
-  ASSERT_EQ(2, oh.areasSeen());
-  ASSERT_EQ(0, oh.areasDumped());
-  ASSERT_EQ(2, oh.areaGeometriesHandled());
-  ASSERT_EQ(2, oh.nodesSeen());
-  ASSERT_EQ(0, oh.nodesDumped());
-  ASSERT_EQ(1, oh.nodeGeometriesHandled());
-  ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(0, oh.relationsDumped());
-  ASSERT_EQ(0, oh.relationGeometriesHandled());
-  ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(0, oh.waysDumped());
-  ASSERT_EQ(2, oh.wayGeometriesHandled());
+  addOsmiumItems(&osmiumHandler);
+
+  ASSERT_EQ(2, osmiumHandler.areasSeen());
+  ASSERT_EQ(0, osmiumHandler.areasDumped());
+  ASSERT_EQ(2, osmiumHandler.areaGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.nodesSeen());
+  ASSERT_EQ(0, osmiumHandler.nodesDumped());
+  ASSERT_EQ(1, osmiumHandler.nodeGeometriesHandled());
+  ASSERT_EQ(3, osmiumHandler.relationsSeen());
+  ASSERT_EQ(0, osmiumHandler.relationsDumped());
+  ASSERT_EQ(0, osmiumHandler.relationGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.waysSeen());
+  ASSERT_EQ(0, osmiumHandler.waysDumped());
+  ASSERT_EQ(2, osmiumHandler.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -207,22 +213,25 @@ TEST(OSM_OsmiumHandler, noGeometricRelations) {
   osm2rdf::util::Output output{config, config.output};
   output.open();
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT> writer{config, &output};
-  osm2rdf::osm::OsmiumHandler oh{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT> geomHandler(config, &writer);
 
-  addOsmiumItems(&oh);
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
 
-  ASSERT_EQ(2, oh.areasSeen());
-  ASSERT_EQ(2, oh.areasDumped());
-  ASSERT_EQ(0, oh.areaGeometriesHandled());
-  ASSERT_EQ(2, oh.nodesSeen());
-  ASSERT_EQ(1, oh.nodesDumped());
-  ASSERT_EQ(0, oh.nodeGeometriesHandled());
-  ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(3, oh.relationsDumped());
-  ASSERT_EQ(0, oh.relationGeometriesHandled());
-  ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(2, oh.waysDumped());
-  ASSERT_EQ(0, oh.wayGeometriesHandled());
+  addOsmiumItems(&osmiumHandler);
+
+  ASSERT_EQ(2, osmiumHandler.areasSeen());
+  ASSERT_EQ(2, osmiumHandler.areasDumped());
+  ASSERT_EQ(0, osmiumHandler.areaGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.nodesSeen());
+  ASSERT_EQ(1, osmiumHandler.nodesDumped());
+  ASSERT_EQ(0, osmiumHandler.nodeGeometriesHandled());
+  ASSERT_EQ(3, osmiumHandler.relationsSeen());
+  ASSERT_EQ(3, osmiumHandler.relationsDumped());
+  ASSERT_EQ(0, osmiumHandler.relationGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.waysSeen());
+  ASSERT_EQ(2, osmiumHandler.waysDumped());
+  ASSERT_EQ(0, osmiumHandler.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -246,22 +255,25 @@ TEST(OSM_OsmiumHandler, noAreaFacts) {
   osm2rdf::util::Output output{config, config.output};
   output.open();
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT> writer{config, &output};
-  osm2rdf::osm::OsmiumHandler oh{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT> geomHandler(config, &writer);
 
-  addOsmiumItems(&oh);
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
 
-  ASSERT_EQ(2, oh.areasSeen());
-  ASSERT_EQ(0, oh.areasDumped());
-  ASSERT_EQ(2, oh.areaGeometriesHandled());
-  ASSERT_EQ(2, oh.nodesSeen());
-  ASSERT_EQ(1, oh.nodesDumped());
-  ASSERT_EQ(1, oh.nodeGeometriesHandled());
-  ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(3, oh.relationsDumped());
-  ASSERT_EQ(0, oh.relationGeometriesHandled());
-  ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(2, oh.waysDumped());
-  ASSERT_EQ(2, oh.wayGeometriesHandled());
+  addOsmiumItems(&osmiumHandler);
+
+  ASSERT_EQ(2, osmiumHandler.areasSeen());
+  ASSERT_EQ(0, osmiumHandler.areasDumped());
+  ASSERT_EQ(2, osmiumHandler.areaGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.nodesSeen());
+  ASSERT_EQ(1, osmiumHandler.nodesDumped());
+  ASSERT_EQ(1, osmiumHandler.nodeGeometriesHandled());
+  ASSERT_EQ(3, osmiumHandler.relationsSeen());
+  ASSERT_EQ(3, osmiumHandler.relationsDumped());
+  ASSERT_EQ(0, osmiumHandler.relationGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.waysSeen());
+  ASSERT_EQ(2, osmiumHandler.waysDumped());
+  ASSERT_EQ(2, osmiumHandler.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -285,22 +297,25 @@ TEST(OSM_OsmiumHandler, noNodeFacts) {
   osm2rdf::util::Output output{config, config.output};
   output.open();
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT> writer{config, &output};
-  osm2rdf::osm::OsmiumHandler oh{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT> geomHandler(config, &writer);
 
-  addOsmiumItems(&oh);
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
 
-  ASSERT_EQ(2, oh.areasSeen());
-  ASSERT_EQ(2, oh.areasDumped());
-  ASSERT_EQ(2, oh.areaGeometriesHandled());
-  ASSERT_EQ(2, oh.nodesSeen());
-  ASSERT_EQ(0, oh.nodesDumped());
-  ASSERT_EQ(1, oh.nodeGeometriesHandled());
-  ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(3, oh.relationsDumped());
-  ASSERT_EQ(0, oh.relationGeometriesHandled());
-  ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(2, oh.waysDumped());
-  ASSERT_EQ(2, oh.wayGeometriesHandled());
+  addOsmiumItems(&osmiumHandler);
+
+  ASSERT_EQ(2, osmiumHandler.areasSeen());
+  ASSERT_EQ(2, osmiumHandler.areasDumped());
+  ASSERT_EQ(2, osmiumHandler.areaGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.nodesSeen());
+  ASSERT_EQ(0, osmiumHandler.nodesDumped());
+  ASSERT_EQ(1, osmiumHandler.nodeGeometriesHandled());
+  ASSERT_EQ(3, osmiumHandler.relationsSeen());
+  ASSERT_EQ(3, osmiumHandler.relationsDumped());
+  ASSERT_EQ(0, osmiumHandler.relationGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.waysSeen());
+  ASSERT_EQ(2, osmiumHandler.waysDumped());
+  ASSERT_EQ(2, osmiumHandler.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -324,22 +339,25 @@ TEST(OSM_OsmiumHandler, noRelationFacts) {
   osm2rdf::util::Output output{config, config.output};
   output.open();
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT> writer{config, &output};
-  osm2rdf::osm::OsmiumHandler oh{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT> geomHandler(config, &writer);
 
-  addOsmiumItems(&oh);
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
 
-  ASSERT_EQ(2, oh.areasSeen());
-  ASSERT_EQ(2, oh.areasDumped());
-  ASSERT_EQ(2, oh.areaGeometriesHandled());
-  ASSERT_EQ(2, oh.nodesSeen());
-  ASSERT_EQ(1, oh.nodesDumped());
-  ASSERT_EQ(1, oh.nodeGeometriesHandled());
-  ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(0, oh.relationsDumped());
-  ASSERT_EQ(0, oh.relationGeometriesHandled());
-  ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(2, oh.waysDumped());
-  ASSERT_EQ(2, oh.wayGeometriesHandled());
+  addOsmiumItems(&osmiumHandler);
+
+  ASSERT_EQ(2, osmiumHandler.areasSeen());
+  ASSERT_EQ(2, osmiumHandler.areasDumped());
+  ASSERT_EQ(2, osmiumHandler.areaGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.nodesSeen());
+  ASSERT_EQ(1, osmiumHandler.nodesDumped());
+  ASSERT_EQ(1, osmiumHandler.nodeGeometriesHandled());
+  ASSERT_EQ(3, osmiumHandler.relationsSeen());
+  ASSERT_EQ(0, osmiumHandler.relationsDumped());
+  ASSERT_EQ(0, osmiumHandler.relationGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.waysSeen());
+  ASSERT_EQ(2, osmiumHandler.waysDumped());
+  ASSERT_EQ(2, osmiumHandler.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -363,22 +381,25 @@ TEST(OSM_OsmiumHandler, noWayFacts) {
   osm2rdf::util::Output output{config, config.output};
   output.open();
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT> writer{config, &output};
-  osm2rdf::osm::OsmiumHandler oh{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT> geomHandler(config, &writer);
 
-  addOsmiumItems(&oh);
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
 
-  ASSERT_EQ(2, oh.areasSeen());
-  ASSERT_EQ(2, oh.areasDumped());
-  ASSERT_EQ(2, oh.areaGeometriesHandled());
-  ASSERT_EQ(2, oh.nodesSeen());
-  ASSERT_EQ(1, oh.nodesDumped());
-  ASSERT_EQ(1, oh.nodeGeometriesHandled());
-  ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(3, oh.relationsDumped());
-  ASSERT_EQ(0, oh.relationGeometriesHandled());
-  ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(0, oh.waysDumped());
-  ASSERT_EQ(2, oh.wayGeometriesHandled());
+  addOsmiumItems(&osmiumHandler);
+
+  ASSERT_EQ(2, osmiumHandler.areasSeen());
+  ASSERT_EQ(2, osmiumHandler.areasDumped());
+  ASSERT_EQ(2, osmiumHandler.areaGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.nodesSeen());
+  ASSERT_EQ(1, osmiumHandler.nodesDumped());
+  ASSERT_EQ(1, osmiumHandler.nodeGeometriesHandled());
+  ASSERT_EQ(3, osmiumHandler.relationsSeen());
+  ASSERT_EQ(3, osmiumHandler.relationsDumped());
+  ASSERT_EQ(0, osmiumHandler.relationGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.waysSeen());
+  ASSERT_EQ(0, osmiumHandler.waysDumped());
+  ASSERT_EQ(2, osmiumHandler.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -402,22 +423,25 @@ TEST(OSM_OsmiumHandler, noAreaGeometricRelations) {
   osm2rdf::util::Output output{config, config.output};
   output.open();
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT> writer{config, &output};
-  osm2rdf::osm::OsmiumHandler oh{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT> geomHandler(config, &writer);
 
-  addOsmiumItems(&oh);
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
 
-  ASSERT_EQ(2, oh.areasSeen());
-  ASSERT_EQ(2, oh.areasDumped());
-  ASSERT_EQ(0, oh.areaGeometriesHandled());
-  ASSERT_EQ(2, oh.nodesSeen());
-  ASSERT_EQ(1, oh.nodesDumped());
-  ASSERT_EQ(1, oh.nodeGeometriesHandled());
-  ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(3, oh.relationsDumped());
-  ASSERT_EQ(0, oh.relationGeometriesHandled());
-  ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(2, oh.waysDumped());
-  ASSERT_EQ(2, oh.wayGeometriesHandled());
+  addOsmiumItems(&osmiumHandler);
+
+  ASSERT_EQ(2, osmiumHandler.areasSeen());
+  ASSERT_EQ(2, osmiumHandler.areasDumped());
+  ASSERT_EQ(0, osmiumHandler.areaGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.nodesSeen());
+  ASSERT_EQ(1, osmiumHandler.nodesDumped());
+  ASSERT_EQ(1, osmiumHandler.nodeGeometriesHandled());
+  ASSERT_EQ(3, osmiumHandler.relationsSeen());
+  ASSERT_EQ(3, osmiumHandler.relationsDumped());
+  ASSERT_EQ(0, osmiumHandler.relationGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.waysSeen());
+  ASSERT_EQ(2, osmiumHandler.waysDumped());
+  ASSERT_EQ(2, osmiumHandler.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -441,22 +465,25 @@ TEST(OSM_OsmiumHandler, noNodeGeometricRelations) {
   osm2rdf::util::Output output{config, config.output};
   output.open();
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT> writer{config, &output};
-  osm2rdf::osm::OsmiumHandler oh{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT> geomHandler(config, &writer);
 
-  addOsmiumItems(&oh);
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
 
-  ASSERT_EQ(2, oh.areasSeen());
-  ASSERT_EQ(2, oh.areasDumped());
-  ASSERT_EQ(2, oh.areaGeometriesHandled());
-  ASSERT_EQ(2, oh.nodesSeen());
-  ASSERT_EQ(1, oh.nodesDumped());
-  ASSERT_EQ(0, oh.nodeGeometriesHandled());
-  ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(3, oh.relationsDumped());
-  ASSERT_EQ(0, oh.relationGeometriesHandled());
-  ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(2, oh.waysDumped());
-  ASSERT_EQ(2, oh.wayGeometriesHandled());
+  addOsmiumItems(&osmiumHandler);
+
+  ASSERT_EQ(2, osmiumHandler.areasSeen());
+  ASSERT_EQ(2, osmiumHandler.areasDumped());
+  ASSERT_EQ(2, osmiumHandler.areaGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.nodesSeen());
+  ASSERT_EQ(1, osmiumHandler.nodesDumped());
+  ASSERT_EQ(0, osmiumHandler.nodeGeometriesHandled());
+  ASSERT_EQ(3, osmiumHandler.relationsSeen());
+  ASSERT_EQ(3, osmiumHandler.relationsDumped());
+  ASSERT_EQ(0, osmiumHandler.relationGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.waysSeen());
+  ASSERT_EQ(2, osmiumHandler.waysDumped());
+  ASSERT_EQ(2, osmiumHandler.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -480,22 +507,25 @@ TEST(OSM_OsmiumHandler, noWayGeometricRelations) {
   osm2rdf::util::Output output{config, config.output};
   output.open();
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::NT> writer{config, &output};
-  osm2rdf::osm::OsmiumHandler oh{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::NT> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::NT> geomHandler(config, &writer);
 
-  addOsmiumItems(&oh);
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
 
-  ASSERT_EQ(2, oh.areasSeen());
-  ASSERT_EQ(2, oh.areasDumped());
-  ASSERT_EQ(2, oh.areaGeometriesHandled());
-  ASSERT_EQ(2, oh.nodesSeen());
-  ASSERT_EQ(1, oh.nodesDumped());
-  ASSERT_EQ(1, oh.nodeGeometriesHandled());
-  ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(3, oh.relationsDumped());
-  ASSERT_EQ(0, oh.relationGeometriesHandled());
-  ASSERT_EQ(2, oh.waysSeen());
-  ASSERT_EQ(2, oh.waysDumped());
-  ASSERT_EQ(0, oh.wayGeometriesHandled());
+  addOsmiumItems(&osmiumHandler);
+
+  ASSERT_EQ(2, osmiumHandler.areasSeen());
+  ASSERT_EQ(2, osmiumHandler.areasDumped());
+  ASSERT_EQ(2, osmiumHandler.areaGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.nodesSeen());
+  ASSERT_EQ(1, osmiumHandler.nodesDumped());
+  ASSERT_EQ(1, osmiumHandler.nodeGeometriesHandled());
+  ASSERT_EQ(3, osmiumHandler.relationsSeen());
+  ASSERT_EQ(3, osmiumHandler.relationsDumped());
+  ASSERT_EQ(0, osmiumHandler.relationGeometriesHandled());
+  ASSERT_EQ(2, osmiumHandler.waysSeen());
+  ASSERT_EQ(2, osmiumHandler.waysDumped());
+  ASSERT_EQ(0, osmiumHandler.wayGeometriesHandled());
 
   // Cleanup
   output.close();
@@ -526,7 +556,10 @@ TEST(OSM_OsmiumHandler, handleEmptyPBF) {
   osm2rdf::util::Output output{config, config.output};
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   ASSERT_THROW(osmiumHandler.handle(), osmium::pbf_error);
 
   // Reset std::cerr and std::cout
@@ -559,7 +592,10 @@ TEST(OSM_OsmiumHandler, handleEmptyOSM) {
   osm2rdf::util::Output output{config, config.output};
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   ASSERT_THROW(osmiumHandler.handle(), osmium::xml_error);
 
   // Reset std::cerr and std::cout
@@ -592,7 +628,10 @@ TEST(OSM_OsmiumHandler, handleEmptyBzip2OSM) {
   osm2rdf::util::Output output{config, config.output};
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   ASSERT_THROW(osmiumHandler.handle(), osmium::bzip2_error);
 
   // Reset std::cerr and std::cout
@@ -625,7 +664,10 @@ TEST(OSM_OsmiumHandler, handleEmptyOPL) {
   osm2rdf::util::Output output{config, config.output};
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
 
   // Reset std::cerr and std::cout
@@ -658,7 +700,10 @@ TEST(OSM_OsmiumHandler, handleEmptyBzip2OPL) {
   osm2rdf::util::Output output{config, config.output};
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   ASSERT_THROW(osmiumHandler.handle(), osmium::bzip2_error);
 
   // Reset std::cerr and std::cout
@@ -691,7 +736,10 @@ TEST(OSM_OsmiumHandler, handleEmptyO5M) {
   osm2rdf::util::Output output{config, config.output};
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   ASSERT_THROW(osmiumHandler.handle(), osmium::o5m_error);
 
   // Reset std::cerr and std::cout
@@ -724,7 +772,10 @@ TEST(OSM_OsmiumHandler, handleEmptyBzip2O5M) {
   osm2rdf::util::Output output{config, config.output};
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   ASSERT_THROW(osmiumHandler.handle(), osmium::bzip2_error);
 
   // Reset std::cerr and std::cout
@@ -766,7 +817,10 @@ TEST(OSM_OsmiumHandler, handleSingleNode) {
   output.open();
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
 
   output.flush();
@@ -848,7 +902,10 @@ TEST(OSM_OsmiumHandler, handleOSMWikiExample) {
   output.open();
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> writer{config, &output};
 
-  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &writer};
+  osm2rdf::osm::FactHandler<osm2rdf::ttl::format::TTL> factHandler(config, &writer);
+  osm2rdf::osm::GeometryHandler<osm2rdf::ttl::format::TTL> geomHandler(config, &writer);
+
+  osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler, &geomHandler};
   osmiumHandler.handle();
 
   output.flush();

--- a/tests/osm/OsmiumHandler.cpp
+++ b/tests/osm/OsmiumHandler.cpp
@@ -218,7 +218,7 @@ TEST(OSM_OsmiumHandler, noGeometricRelations) {
   ASSERT_EQ(1, oh.nodesDumped());
   ASSERT_EQ(0, oh.nodeGeometriesHandled());
   ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(2, oh.relationsDumped());
+  ASSERT_EQ(3, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
   ASSERT_EQ(2, oh.waysDumped());
@@ -257,7 +257,7 @@ TEST(OSM_OsmiumHandler, noAreaFacts) {
   ASSERT_EQ(1, oh.nodesDumped());
   ASSERT_EQ(1, oh.nodeGeometriesHandled());
   ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(2, oh.relationsDumped());
+  ASSERT_EQ(3, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
   ASSERT_EQ(2, oh.waysDumped());
@@ -296,7 +296,7 @@ TEST(OSM_OsmiumHandler, noNodeFacts) {
   ASSERT_EQ(0, oh.nodesDumped());
   ASSERT_EQ(1, oh.nodeGeometriesHandled());
   ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(2, oh.relationsDumped());
+  ASSERT_EQ(3, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
   ASSERT_EQ(2, oh.waysDumped());
@@ -374,7 +374,7 @@ TEST(OSM_OsmiumHandler, noWayFacts) {
   ASSERT_EQ(1, oh.nodesDumped());
   ASSERT_EQ(1, oh.nodeGeometriesHandled());
   ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(2, oh.relationsDumped());
+  ASSERT_EQ(3, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
   ASSERT_EQ(0, oh.waysDumped());
@@ -413,7 +413,7 @@ TEST(OSM_OsmiumHandler, noAreaGeometricRelations) {
   ASSERT_EQ(1, oh.nodesDumped());
   ASSERT_EQ(1, oh.nodeGeometriesHandled());
   ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(2, oh.relationsDumped());
+  ASSERT_EQ(3, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
   ASSERT_EQ(2, oh.waysDumped());
@@ -452,7 +452,7 @@ TEST(OSM_OsmiumHandler, noNodeGeometricRelations) {
   ASSERT_EQ(1, oh.nodesDumped());
   ASSERT_EQ(0, oh.nodeGeometriesHandled());
   ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(2, oh.relationsDumped());
+  ASSERT_EQ(3, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
   ASSERT_EQ(2, oh.waysDumped());
@@ -491,7 +491,7 @@ TEST(OSM_OsmiumHandler, noWayGeometricRelations) {
   ASSERT_EQ(1, oh.nodesDumped());
   ASSERT_EQ(1, oh.nodeGeometriesHandled());
   ASSERT_EQ(3, oh.relationsSeen());
-  ASSERT_EQ(2, oh.relationsDumped());
+  ASSERT_EQ(3, oh.relationsDumped());
   ASSERT_EQ(0, oh.relationGeometriesHandled());
   ASSERT_EQ(2, oh.waysSeen());
   ASSERT_EQ(2, oh.waysDumped());

--- a/tests/osm/OsmiumHandler.cpp
+++ b/tests/osm/OsmiumHandler.cpp
@@ -126,7 +126,7 @@ TEST(OSM_OsmiumHandler, constructor) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -165,7 +165,7 @@ TEST(OSM_OsmiumHandler, noFacts) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.noFacts = true;
   osm2rdf::util::Output output{config, config.output};
@@ -207,7 +207,7 @@ TEST(OSM_OsmiumHandler, noGeometricRelations) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.noGeometricRelations = true;
   osm2rdf::util::Output output{config, config.output};
@@ -249,7 +249,7 @@ TEST(OSM_OsmiumHandler, noAreaFacts) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.noAreaFacts = true;
   osm2rdf::util::Output output{config, config.output};
@@ -291,7 +291,7 @@ TEST(OSM_OsmiumHandler, noNodeFacts) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.noNodeFacts = true;
   osm2rdf::util::Output output{config, config.output};
@@ -333,7 +333,7 @@ TEST(OSM_OsmiumHandler, noRelationFacts) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.noRelationFacts = true;
   osm2rdf::util::Output output{config, config.output};
@@ -375,7 +375,7 @@ TEST(OSM_OsmiumHandler, noWayFacts) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.noWayFacts = true;
   osm2rdf::util::Output output{config, config.output};
@@ -417,7 +417,7 @@ TEST(OSM_OsmiumHandler, noAreaGeometricRelations) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.noAreaGeometricRelations = true;
   osm2rdf::util::Output output{config, config.output};
@@ -459,7 +459,7 @@ TEST(OSM_OsmiumHandler, noNodeGeometricRelations) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.noNodeGeometricRelations = true;
   osm2rdf::util::Output output{config, config.output};
@@ -501,7 +501,7 @@ TEST(OSM_OsmiumHandler, noWayGeometricRelations) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.noWayGeometricRelations = true;
   osm2rdf::util::Output output{config, config.output};
@@ -546,7 +546,7 @@ TEST(OSM_OsmiumHandler, handleEmptyPBF) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -582,7 +582,7 @@ TEST(OSM_OsmiumHandler, handleEmptyOSM) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -618,7 +618,7 @@ TEST(OSM_OsmiumHandler, handleEmptyBzip2OSM) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -654,7 +654,7 @@ TEST(OSM_OsmiumHandler, handleEmptyOPL) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -690,7 +690,7 @@ TEST(OSM_OsmiumHandler, handleEmptyBzip2OPL) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -726,7 +726,7 @@ TEST(OSM_OsmiumHandler, handleEmptyO5M) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -762,7 +762,7 @@ TEST(OSM_OsmiumHandler, handleEmptyBzip2O5M) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -798,7 +798,7 @@ TEST(OSM_OsmiumHandler, handleSingleNode) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file
@@ -856,7 +856,7 @@ TEST(OSM_OsmiumHandler, handleOSMWikiExample) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   // Create empty input file

--- a/tests/osm/Relation.cpp
+++ b/tests/osm/Relation.cpp
@@ -56,9 +56,8 @@ TEST(OSM_Relation, FromRelationWithTags) {
   ASSERT_EQ(42, r.id());
 
   ASSERT_EQ(1, r.tags().size());
-  ASSERT_EQ(0, r.tags().count("tag"));
-  ASSERT_EQ(1, r.tags().count("city"));
-  ASSERT_STREQ("Freiburg", r.tags().at("city").c_str());
+  ASSERT_STREQ("city", r.tags()[0].first.c_str());
+  ASSERT_STREQ("Freiburg", r.tags()[0].second.c_str());
 
   ASSERT_EQ(0, r.members().size());
 }
@@ -106,9 +105,8 @@ TEST(OSM_Relation, FromRelationWithMembersAndTags) {
   ASSERT_EQ(42, r.id());
 
   ASSERT_EQ(1, r.tags().size());
-  ASSERT_EQ(0, r.tags().count("tag"));
-  ASSERT_EQ(1, r.tags().count("city"));
-  ASSERT_STREQ("Freiburg", r.tags().at("city").c_str());
+  ASSERT_STREQ("city", r.tags()[0].first.c_str());
+  ASSERT_STREQ("Freiburg", r.tags()[0].second.c_str());
 
   ASSERT_EQ(2, r.members().size());
   ASSERT_EQ(osm2rdf::osm::RelationMemberType::NODE, r.members().at(0).type());

--- a/tests/osm/TagList.cpp
+++ b/tests/osm/TagList.cpp
@@ -33,7 +33,6 @@ TEST(OSM_TagList, convertTagList) {
   osmium::builder::add_node(
       osmiumBuffer, osmium::builder::attr::_id(42),
       osmium::builder::attr::_location(osmium::Location(7.51, 48.0)),
-      osmium::builder::attr::_tag("city", "Freiburg"),
       osmium::builder::attr::_tag("city", "Freiburg"));
 
   // Create osm2rdf object from osmium object
@@ -41,7 +40,8 @@ TEST(OSM_TagList, convertTagList) {
       osm2rdf::osm::convertTagList(osmiumBuffer.get<osmium::Node>(0).tags());
 
   ASSERT_EQ(1, tl.size());
-  ASSERT_EQ("Freiburg", tl["city"]);
+  ASSERT_EQ("city", tl[0].first);
+  ASSERT_EQ("Freiburg", tl[0].second);
 }
 
 // ____________________________________________________________________________
@@ -61,8 +61,10 @@ TEST(OSM_TagList, convertTagListWithSpaceInKey) {
       osm2rdf::osm::convertTagList(osmiumBuffer.get<osmium::Node>(0).tags());
 
   ASSERT_EQ(2, tl.size());
-  ASSERT_EQ("Freiburg", tl["city_name"]);
-  ASSERT_EQ("Freiburg", tl["name_of_city"]);
+  ASSERT_EQ("city_name", tl[0].first);
+  ASSERT_EQ("Freiburg", tl[0].second);
+  ASSERT_EQ("name_of_city", tl[1].first);
+  ASSERT_EQ("Freiburg", tl[1].second);
 }
 
 }  // namespace osm2rdf::osm

--- a/tests/osm/Way.cpp
+++ b/tests/osm/Way.cpp
@@ -78,9 +78,8 @@ TEST(OSM_Way, FromWayWithTags) {
   ASSERT_FALSE(w.closed());
 
   ASSERT_EQ(1, w.tags().size());
-  ASSERT_EQ(0, w.tags().count("tag"));
-  ASSERT_EQ(1, w.tags().count("city"));
-  ASSERT_STREQ("Freiburg", w.tags().at("city").c_str());
+  ASSERT_EQ("city", w.tags()[0].first);
+  ASSERT_EQ("Freiburg", w.tags()[0].second);
 
   ASSERT_EQ(2, w.nodes().size());
   ASSERT_EQ(1, w.nodes().at(0).id());
@@ -236,7 +235,8 @@ TEST(OSM_Way, isAreaTrueForTriangle) {
                            }));
 
   // Create osm2rdf object from osmium object
-  const osm2rdf::osm::Way w{buffer.get<osmium::Way>(0)};
+  osm2rdf::osm::Way w{buffer.get<osmium::Way>(0)};
+  w.finalize();
   ASSERT_TRUE(w.closed());
 
   ASSERT_TRUE(w.isArea());

--- a/tests/ttl/Writer-Grammar.cpp
+++ b/tests/ttl/Writer-Grammar.cpp
@@ -247,9 +247,7 @@ TEST(TTL_WriterGrammarTTL, RULE_136s_PREFIXEDNAME) {
   ASSERT_EQ("prefix:\\.bc", w.PrefixedName("prefix", ".bc"));
   ASSERT_EQ("prefix:a.c", w.PrefixedName("prefix", "a.c"));
   ASSERT_EQ("prefix:ab\\.", w.PrefixedName("prefix", "ab."));
-  ASSERT_THROW(w.PrefixedName(".refix", ".bc"), std::domain_error);
   ASSERT_EQ("pref.x:\\.bc", w.PrefixedName("pref.x", ".bc"));
-  ASSERT_THROW(w.PrefixedName("prefi.", ".bc"), std::domain_error);
 }
 
 // ____________________________________________________________________________

--- a/tests/ttl/Writer-Grammar.cpp
+++ b/tests/ttl/Writer-Grammar.cpp
@@ -386,6 +386,22 @@ TEST(TTL_WriterGrammarTTL, RULE_170s_PERCENT_UTF8) {
 // ____________________________________________________________________________
 // ____________________________________________________________________________
 // ____________________________________________________________________________
+TEST(TTL_WriterGrammarQLEVER, RULE_18_IRIREF_CONVERT) {
+  // TTL: [18]   IRIREF (same as NT)
+  //      https://www.w3.org/TR/turtle/#grammar-production-IRIREF
+  osm2rdf::config::Config config;
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> w{config, nullptr};
+
+  ASSERT_EQ("", w.encodeIRIREF(""));
+  ASSERT_EQ("allöwed", w.encodeIRIREF("allöwed"));
+  ASSERT_EQ("%3c%3e%22%7b%7d%7c%5e%60%5c", w.encodeIRIREF("<>\"{}|^`\\"));
+  using namespace std::literals::string_literals;
+  ASSERT_EQ("%00%01%19%20", w.encodeIRIREF("\u0000\u0001\u0019\u0020"s));
+}
+
+// ____________________________________________________________________________
+// ____________________________________________________________________________
+// ____________________________________________________________________________
 TEST(TTL_WriterGrammar, UTF8_LENGTH_ASCII) {
   osm2rdf::config::Config config;
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> w{config, nullptr};

--- a/tests/ttl/Writer-Grammar.cpp
+++ b/tests/ttl/Writer-Grammar.cpp
@@ -386,22 +386,6 @@ TEST(TTL_WriterGrammarTTL, RULE_170s_PERCENT_UTF8) {
 // ____________________________________________________________________________
 // ____________________________________________________________________________
 // ____________________________________________________________________________
-TEST(TTL_WriterGrammarQLEVER, RULE_18_IRIREF_CONVERT) {
-  // TTL: [18]   IRIREF (same as NT)
-  //      https://www.w3.org/TR/turtle/#grammar-production-IRIREF
-  osm2rdf::config::Config config;
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> w{config, nullptr};
-
-  ASSERT_EQ("", w.encodeIRIREF(""));
-  ASSERT_EQ("allöwed", w.encodeIRIREF("allöwed"));
-  ASSERT_EQ("%3c%3e%22%7b%7d%7c%5e%60%5c", w.encodeIRIREF("<>\"{}|^`\\"));
-  using namespace std::literals::string_literals;
-  ASSERT_EQ("%00%01%19%20", w.encodeIRIREF("\u0000\u0001\u0019\u0020"s));
-}
-
-// ____________________________________________________________________________
-// ____________________________________________________________________________
-// ____________________________________________________________________________
 TEST(TTL_WriterGrammar, UTF8_LENGTH_ASCII) {
   osm2rdf::config::Config config;
   osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> w{config, nullptr};

--- a/tests/ttl/Writer.cpp
+++ b/tests/ttl/Writer.cpp
@@ -183,7 +183,7 @@ TEST(TTL_WriterQLEVER, writeHeader) {
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> w{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> w{config, &output};
 
   w.writeHeader();
 
@@ -237,7 +237,7 @@ TEST(TTL_WriterTTL, generateBlankNode) {
 // ____________________________________________________________________________
 TEST(TTL_WriterQLEVER, generateBlankNode) {
   osm2rdf::config::Config config;
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> w{config, nullptr};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> w{config, nullptr};
   {
     const std::string res = w.generateBlankNode();
     ASSERT_STREQ("_:0_0", res.c_str());
@@ -316,7 +316,7 @@ TEST(TTL_WriterTTL, generateIRI_ID) {
 // ____________________________________________________________________________
 TEST(TTL_WriterQLEVER, generateIRI_ID) {
   osm2rdf::config::Config config;
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> w{config, nullptr};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> w{config, nullptr};
   {
     const std::string res =
         w.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_NODE, 23);
@@ -401,7 +401,7 @@ TEST(TTL_WriterTTL, generateIRI_String) {
 // ____________________________________________________________________________
 TEST(TTL_WriterQLEVER, generateIRI_String) {
   osm2rdf::config::Config config;
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> w{config, nullptr};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> w{config, nullptr};
   {
     const std::string res =
         w.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_NODE, "a");
@@ -728,7 +728,7 @@ TEST(TTL_WriterQLEVER, writeStatisticJson) {
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> w{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> w{config, &output};
 
   // Setup temp dir and stats file
   std::filesystem::path tmpDir =

--- a/tests/ttl/Writer.cpp
+++ b/tests/ttl/Writer.cpp
@@ -126,7 +126,7 @@ TEST(TTL_WriterNT, writeHeader) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -151,7 +151,7 @@ TEST(TTL_WriterTTL, writeHeader) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -179,7 +179,7 @@ TEST(TTL_WriterQLEVER, writeHeader) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -601,7 +601,7 @@ TEST(TTL_WriterNT, writeStatisticJson) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -662,7 +662,7 @@ TEST(TTL_WriterTTL, writeStatisticJson) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -724,7 +724,7 @@ TEST(TTL_WriterQLEVER, writeStatisticJson) {
 
   osm2rdf::config::Config config;
   config.output = "";
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
   output.open();

--- a/tests/ttl/Writer.cpp
+++ b/tests/ttl/Writer.cpp
@@ -159,6 +159,7 @@ TEST(TTL_WriterTTL, writeHeader) {
 
   w.writeHeader();
 
+  output.flush();
   output.close();
 
   ASSERT_THAT(buffer.str(),
@@ -186,6 +187,7 @@ TEST(TTL_WriterQLEVER, writeHeader) {
 
   w.writeHeader();
 
+  output.flush();
   output.close();
 
   ASSERT_THAT(buffer.str(),

--- a/tests/ttl/Writer.cpp
+++ b/tests/ttl/Writer.cpp
@@ -183,7 +183,7 @@ TEST(TTL_WriterQLEVER, writeHeader) {
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> w{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> w{config, &output};
 
   w.writeHeader();
 
@@ -237,7 +237,7 @@ TEST(TTL_WriterTTL, generateBlankNode) {
 // ____________________________________________________________________________
 TEST(TTL_WriterQLEVER, generateBlankNode) {
   osm2rdf::config::Config config;
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> w{config, nullptr};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> w{config, nullptr};
   {
     const std::string res = w.generateBlankNode();
     ASSERT_STREQ("_:0_0", res.c_str());
@@ -316,7 +316,7 @@ TEST(TTL_WriterTTL, generateIRI_ID) {
 // ____________________________________________________________________________
 TEST(TTL_WriterQLEVER, generateIRI_ID) {
   osm2rdf::config::Config config;
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> w{config, nullptr};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> w{config, nullptr};
   {
     const std::string res =
         w.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_NODE, 23);
@@ -401,7 +401,7 @@ TEST(TTL_WriterTTL, generateIRI_String) {
 // ____________________________________________________________________________
 TEST(TTL_WriterQLEVER, generateIRI_String) {
   osm2rdf::config::Config config;
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> w{config, nullptr};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> w{config, nullptr};
   {
     const std::string res =
         w.generateIRI(osm2rdf::ttl::constants::NAMESPACE__OSM_NODE, "a");
@@ -728,7 +728,7 @@ TEST(TTL_WriterQLEVER, writeStatisticJson) {
   config.mergeOutput = util::OutputMergeMode::NONE;
   osm2rdf::util::Output output{config, config.output};
   output.open();
-  osm2rdf::ttl::Writer<osm2rdf::ttl::format::QLEVER> w{config, &output};
+  osm2rdf::ttl::Writer<osm2rdf::ttl::format::TTL> w{config, &output};
 
   // Setup temp dir and stats file
   std::filesystem::path tmpDir =

--- a/tests/util/DirectedGraph.cpp
+++ b/tests/util/DirectedGraph.cpp
@@ -18,6 +18,7 @@
 
 #include "osm2rdf/util/DirectedGraph.h"
 
+#include <algorithm>
 #include "gtest/gtest.h"
 
 namespace osm2rdf::util {

--- a/tests/util/Output.cpp
+++ b/tests/util/Output.cpp
@@ -116,7 +116,7 @@ TEST(UTIL_Output, WriteIntoCurrentPartStdOut) {
   config.output = "";
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
-  config.outputCompress = false;
+  config.outputCompress = osm2rdf::config::NONE;
   config.mergeOutput = OutputMergeMode::NONE;
 
   size_t parts = 4;


### PR DESCRIPTION
This PR

* uses an updated libutil, in which WKTs are generated by using the `fmt` library for (much) faster `double` to `string` conversion
* removes unnecessary string copying by introducing`writeLiteralTripleUnsafe()`. This in particular avoids copying of all WKT strings just to wrap them in quotes and add "^^wktLiteral".
* introduces a method `IREREFUnsafe` in `Writer`, which is faster than `IREREF`, but is only to be called with safe strings.
* removes all usages of `std::ostringstream` at critical places
* does *not* store ways which are only members of area relations in `RelationHandler`. These are only needed to build their geometries, and we do not build relation geometries for areas (these are completely handled by `libosmium`)
* moves the scopes around a bit so that everything `libosmium`-related should be destroyed by the time the spatial relations are build.

On my machine, this speeds the triple writing up by a factor of 4 on the Malta dataset.