### PR TITLE
Fix issues with option `--output-compression`

### DIFF
--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -80,7 +80,7 @@ const static inline std::string OUTPUT_COMPRESS_OPTION_SHORT = "";
 const static inline std::string OUTPUT_COMPRESS_OPTION_LONG =
     "output-compression";
 const static inline std::string OUTPUT_COMPRESS_OPTION_HELP =
-    "Output file compression, valid values: none, bz2, gz2";
+    "Output file compression, valid values: none, bz2, gz";
 
 const static inline std::string STORE_LOCATIONS_INFO =
     "Storing locations osmium locations:";

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -507,9 +507,19 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
     // Output
     output = outputOp->value();
     outputFormat = outputFormatOp->value();
-    outputCompress = outputCompressOp->value() == "none"
-                         ? NONE
-                         : (outputCompressOp->value() == "gz" ? GZ : BZ2);
+    if (outputCompressOp->value() == "none") {
+      outputCompress = NONE;
+    } else if (outputCompressOp->value() == "gz") {
+      outputCompress = GZ;
+    } else if (outputCompressOp->value() == "bz2") {
+      outputCompress = BZ2;
+    } else {
+        throw popl::invalid_option(
+            outputCompressOp.get(),
+            popl::invalid_option::Error::invalid_argument,
+            popl::OptionName::long_name, outputCompressOp->value(), "");
+    }
+
     outputKeepFiles = outputKeepFilesOp->is_set();
     if (output.empty()) {
       outputCompress = NONE;


### PR DESCRIPTION
This PR fixes a typo in the `--help` text for `--output-compression` (which has listed `gz2` as a valid argument, but the supported argument is actually `gz`). It also changes the behavior when an unknown argument is supplied: previously, it silently fell back to `bz2`, with this PR, an error is thrown.