### PR TITLE
Parallel sweepline event sorting 

### DIFF
--- a/apps/osm2rdf.cpp
+++ b/apps/osm2rdf.cpp
@@ -47,10 +47,11 @@ void run(const osm2rdf::config::Config& config) {
   osm2rdf::ttl::Writer<T> writer{config, &output};
   writer.writeHeader();
 
-  osm2rdf::osm::FactHandler<T> factHandler(config, &writer);
   osm2rdf::osm::GeometryHandler<T> geomHandler(config, &writer);
 
   {
+    osm2rdf::osm::FactHandler<T> factHandler(config, &writer);
+
     osm2rdf::osm::OsmiumHandler osmiumHandler{config, &factHandler,
                                               &geomHandler};
     osmiumHandler.handle();


### PR DESCRIPTION
This PR updates `libspatialjoin` to allow parallel sweepline event sorting, see https://github.com/ad-freiburg/util/commit/cd1721ddcc5498a8bce08624ce4bef9da60ef5d0