### PR TITLE
Fix remaining memory issues during the last 0.5% of processing planet.osm with the dense memory cache

### DIFF
--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -80,6 +80,8 @@ struct Config {
   bool addUntaggedRelations = true;
   bool addUntaggedAreas = true;
 
+  bool addSpatialRelsForUntaggedNodes = true;
+
   int numThreads = std::thread::hardware_concurrency();
 
   // Default settings for data

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -175,6 +175,14 @@ const static inline std::string NO_WAY_GEOM_RELATIONS_OPTION_LONG =
 const static inline std::string NO_WAY_GEOM_RELATIONS_OPTION_HELP =
     "Do not dump way geometric relations";
 
+const static inline std::string NO_UNTAGGED_NODES_SPATIAL_RELS_INFO =
+    "Do not compute spatial relations involving untagged nodes";
+const static inline std::string NO_UNTAGGED_NODES_SPATIAL_RELS_OPTION_SHORT = "";
+const static inline std::string NO_UNTAGGED_NODES_SPATIAL_RELS_OPTION_LONG =
+    "no-untagged-nodes-geometric-relations";
+const static inline std::string NO_UNTAGGED_NODES_SPATIAL_RELS_OPTION_HELP =
+    "Do not compute spatial relations involving untagged nodes";
+
 const static inline std::string NO_UNTAGGED_NODES_INFO =
     "Do not output untagged nodes";
 const static inline std::string NO_UNTAGGED_NODES_OPTION_SHORT = "";

--- a/include/osm2rdf/osm/GeometryHandler.h
+++ b/include/osm2rdf/osm/GeometryHandler.h
@@ -79,6 +79,9 @@ class GeometryHandler {
                   const std::string& pred);
   void progressCb(size_t progr);
 
+  std::string getSweeperId(uint64_t oid, char type);
+  std::string getFullID(const std::string& id);
+
   osm2rdf::util::ProgressBar _progressBar;
 };
 

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -103,6 +103,11 @@ std::string osm2rdf::config::Config::getInfo(std::string_view prefix) const {
       oss << "\n"
           << prefix << osm2rdf::config::constants::NO_UNTAGGED_AREAS_INFO;
     }
+    if (!addSpatialRelsForUntaggedNodes) {
+      oss << "\n"
+          << prefix
+          << osm2rdf::config::constants::NO_UNTAGGED_NODES_SPATIAL_RELS_INFO;
+    }
     if (simplifyWKT > 0) {
       oss << "\n" << prefix << osm2rdf::config::constants::SIMPLIFY_WKT_INFO;
       oss << "\n"
@@ -280,17 +285,21 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
           osm2rdf::config::constants::ADD_AREA_WAY_LINESTRINGS_OPTION_LONG,
           osm2rdf::config::constants::ADD_AREA_WAY_LINESTRINGS_OPTION_HELP);
 
-  auto noUntaggedNodesOp =
-      parser.add<popl::Switch, popl::Attribute::expert>(
-          osm2rdf::config::constants::NO_UNTAGGED_NODES_OPTION_SHORT,
-          osm2rdf::config::constants::NO_UNTAGGED_NODES_OPTION_LONG,
-          osm2rdf::config::constants::NO_UNTAGGED_NODES_OPTION_HELP);
+  auto noUntaggedNodesSpatialRelsOp = parser.add<popl::Switch,
+                                                 popl::Attribute::expert>(
+      osm2rdf::config::constants::NO_UNTAGGED_NODES_SPATIAL_RELS_OPTION_SHORT,
+      osm2rdf::config::constants::NO_UNTAGGED_NODES_SPATIAL_RELS_OPTION_LONG,
+      osm2rdf::config::constants::NO_UNTAGGED_NODES_SPATIAL_RELS_OPTION_HELP);
 
-  auto noUntaggedWaysOp =
-      parser.add<popl::Switch, popl::Attribute::expert>(
-          osm2rdf::config::constants::NO_UNTAGGED_WAYS_OPTION_SHORT,
-          osm2rdf::config::constants::NO_UNTAGGED_WAYS_OPTION_LONG,
-          osm2rdf::config::constants::NO_UNTAGGED_WAYS_OPTION_HELP);
+  auto noUntaggedNodesOp = parser.add<popl::Switch, popl::Attribute::expert>(
+      osm2rdf::config::constants::NO_UNTAGGED_NODES_OPTION_SHORT,
+      osm2rdf::config::constants::NO_UNTAGGED_NODES_OPTION_LONG,
+      osm2rdf::config::constants::NO_UNTAGGED_NODES_OPTION_HELP);
+
+  auto noUntaggedWaysOp = parser.add<popl::Switch, popl::Attribute::expert>(
+      osm2rdf::config::constants::NO_UNTAGGED_WAYS_OPTION_SHORT,
+      osm2rdf::config::constants::NO_UNTAGGED_WAYS_OPTION_LONG,
+      osm2rdf::config::constants::NO_UNTAGGED_WAYS_OPTION_HELP);
 
   auto noUntaggedRelationsOp =
       parser.add<popl::Switch, popl::Attribute::expert>(
@@ -298,11 +307,10 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
           osm2rdf::config::constants::NO_UNTAGGED_RELATIONS_OPTION_LONG,
           osm2rdf::config::constants::NO_UNTAGGED_RELATIONS_OPTION_HELP);
 
-  auto noUntaggedAreasOp =
-      parser.add<popl::Switch, popl::Attribute::expert>(
-          osm2rdf::config::constants::NO_UNTAGGED_AREAS_OPTION_SHORT,
-          osm2rdf::config::constants::NO_UNTAGGED_AREAS_OPTION_LONG,
-          osm2rdf::config::constants::NO_UNTAGGED_AREAS_OPTION_HELP);
+  auto noUntaggedAreasOp = parser.add<popl::Switch, popl::Attribute::expert>(
+      osm2rdf::config::constants::NO_UNTAGGED_AREAS_OPTION_SHORT,
+      osm2rdf::config::constants::NO_UNTAGGED_AREAS_OPTION_LONG,
+      osm2rdf::config::constants::NO_UNTAGGED_AREAS_OPTION_HELP);
 
   auto addWayMetadataOp = parser.add<popl::Switch>(
       osm2rdf::config::constants::ADD_WAY_METADATA_OPTION_SHORT,
@@ -482,6 +490,8 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
     wktDeviation = wktDeviationOp->value();
     wktPrecision = wktPrecisionOp->value();
 
+    addSpatialRelsForUntaggedNodes = !noUntaggedNodesSpatialRelsOp->is_set();
+
     addUntaggedNodes = !noUntaggedNodesOp->is_set();
     addUntaggedWays = !noUntaggedWaysOp->is_set();
     addUntaggedRelations = !noUntaggedRelationsOp->is_set();
@@ -514,10 +524,9 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
     } else if (outputCompressOp->value() == "bz2") {
       outputCompress = BZ2;
     } else {
-        throw popl::invalid_option(
-            outputCompressOp.get(),
-            popl::invalid_option::Error::invalid_argument,
-            popl::OptionName::long_name, outputCompressOp->value(), "");
+      throw popl::invalid_option(
+          outputCompressOp.get(), popl::invalid_option::Error::invalid_argument,
+          popl::OptionName::long_name, outputCompressOp->value(), "");
     }
 
     outputKeepFiles = outputKeepFilesOp->is_set();

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -238,13 +238,11 @@ std::string GeometryHandler<W>::getFullID(const std::string& strid) {
   }
 
   if (strid[0] == 3) {
-    return _writer->generateIRI(
-        areaNS(AreaFromType::WAY), id);
+    return _writer->generateIRI(areaNS(AreaFromType::WAY), id);
   }
 
   if (strid[0] == 4) {
-    return _writer->generateIRI(
-        areaNS(AreaFromType::RELATION), id);
+    return _writer->generateIRI(areaNS(AreaFromType::RELATION), id);
   }
 
   if (strid[0] == 5) {
@@ -262,14 +260,16 @@ std::string GeometryHandler<W>::getSweeperId(uint64_t oid, char type) {
   int a = 0;
   uint64_t tmp;
 
-  while ((tmp = (oid & (0xFFLL << (a * 8))))) {
+  while ((oid >> (a * 8))) {
+    tmp = (oid & (0xFFLL << (a * 8)));
     id[8 - a] = tmp >> (a * 8);
     a++;
   }
 
   id[8 - a] = type;
 
-  return reinterpret_cast<char*>(id + (8 - a));
+  return std::string{reinterpret_cast<char*>(id + (8 - a)),
+                     static_cast<size_t>(a + 1)};
 }
 
 // ____________________________________________________________________________

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -208,7 +208,8 @@ void osm2rdf::osm::OsmiumHandler<W>::node(const osmium::Node& node) {
           _progressBar.update(_numTasksDone++);
         }
       }
-      if (!_config.noGeometricRelations && !_config.noNodeGeometricRelations) {
+      if (!_config.noGeometricRelations && !_config.noNodeGeometricRelations &&
+          (!osmNode.tags().empty() || _config.addSpatialRelsForUntaggedNodes)) {
         _geometryHandler->node(osmNode);
 #pragma omp critical(progress)
         {


### PR DESCRIPTION
This is an unfinished draft PR to fix the remaining memory issues when processing `planet.osm` with the dense RAM cache.

The current version attempts to further reduce the memory and disk space overhead of calculating the geospatial relations.

`libspatialjoin` requires string IDs to identify geometries. Previously, the full prefixed IRI (e.g. `osmnode:3454354544`) was used as an ID. With 492069c1e2fa54670d66c8511c6eeeb752e8038f, we use the more efficient schema

    [type][integer ID]

where `[type]` is a single byte identifier (1 for nodes, 2 for ways, 3 for way areas, 4 for relation area, and 5 for relations), and `[integer id]` is the OSM ID encoded as a variable-length integer. These bytes are directly stored in a `std::string` used as the ID for `spatialjoin` (`spatialjoin` never interprets these IDs, so they can contain arbitrary byte sequences. In particular, note that `libspatialjoin` stores them as `std::string`s, not C strings, so 0 bytes are allowed and will be returned from the cache correctly (otherwise, IDs like 128 would not be stored correctly).

This has the following benefits:

(1) the ID size of a typical OSM id goes down from around 18 bytes to around 5 bytes
(2) the disk space required for the geometry cache (where these IDs are stored in) is reduced, especially for nodes (where ONLY the id is stored on disk)
(3) the memory overhead of the relation tracking (via `libspatialjoin`s "collection of geometry refs" functionality) is greatly reduced. 

For a further reduction of the memory footprint in the final 0.5%, I am waiting for profiling results from massif.