### PR TITLE
Fix centroids for small polygons

### DIFF
--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -62,6 +62,7 @@ GeometryHandler<W>::GeometryHandler(const osm2rdf::config::Config& config,
       _sweeper(
           {static_cast<size_t>(config.numThreads),
            static_cast<size_t>(config.numThreads),
+           10000,
            "",
            osm2rdf::ttl::constants::IRI__OPENGIS__INTERSECTS,
            osm2rdf::ttl::constants::IRI__OPENGIS__CONTAINS,
@@ -275,17 +276,17 @@ void GeometryHandler<W>::calculateRelations() {
       throw std::runtime_error("Could not read auxiliary geo file " + auxFile);
     }
 
-    ::util::JobQueue<ParseBatch> jobs(1000);             // the WKT parse jobs
+    ::util::JobQueue<sj::ParseBatch> jobs(1000);             // the WKT parse jobs
     std::vector<std::thread> thrds(_config.numThreads);  // the parse workers
     for (size_t i = 0; i < thrds.size(); i++)
-      thrds[i] = std::thread(&processQueue, &jobs, i, &_sweeper);
+      thrds[i] = std::thread(&sj::processQueue, &jobs, i, &_sweeper);
 
     ssize_t len;
     std::string dangling;
     size_t gid = 0;
 
     while ((len = ::util::readAll(file, buf, CACHE_SIZE)) > 0) {
-      parse(reinterpret_cast<char*>(buf), len, dangling, &gid, jobs, 0);
+      sj::parse(reinterpret_cast<char*>(buf), len, dangling, &gid, jobs, 0);
     }
 
     // end event


### PR DESCRIPTION
This PR fixes some issues with `hasCentroid` for smaller polygons. For such objects, the previous approach ran into numerical stability issues. Some centroids where more than 10 meters off; compare some centroids in [this query](https://qlever.cs.uni-freiburg.de/petrimaps/?query=PREFIX+geo%3A+%3Chttp%3A%2F%2Fwww.opengis.net%2Font%2Fgeosparql%23%3E+PREFIX+osmkey%3A+%3Chttps%3A%2F%2Fwww.openstreetmap.org%2Fwiki%2FKey%3A%3E+PREFIX+ogc%3A+%3Chttp%3A%2F%2Fwww.opengis.net%2Frdf%23%3E+PREFIX+osmrel%3A+%3Chttps%3A%2F%2Fwww.openstreetmap.org%2Frelation%2F%3E+SELECT+%3Fosm_id+%3Fhasgeometry+WHERE+%7B+osmrel%3A1960198+ogc%3AsfContains+%3Fosm_id+.+%3Fosm_id+geo%3AhasCentroid%2Fgeo%3AasWKT+%3Fhasgeometry+.+%3Fosm_id+osmkey%3Abuilding+%3Fbuilding+%7D&backend=https%3A%2F%2Fqlever.cs.uni-freiburg.de%2Fapi%2Fosm-planet#close). This has been fixed in `util` with https://github.com/ad-freiburg/util/commit/92a2e9f8c6b50e9b1095061ff6f6fee2fdcec02a, which this PR now uses.