### PR TITLE
Better progress bar, fix progress percentage, decreased disk IO by spatialjoin during dump phase

### DIFF
--- a/include/osm2rdf/util/ProgressBar.h
+++ b/include/osm2rdf/util/ProgressBar.h
@@ -23,6 +23,7 @@ static const int k100Percent = 100;
 static const int kTerminalWidth = 80;
 #include <cstdio>
 #include <ctime>
+#include <string>
 
 namespace osm2rdf::util {
 
@@ -34,6 +35,10 @@ class ProgressBar {
   ProgressBar() = default;
   // Updates the progress bar.
   void update(std::size_t count);
+
+  // Updates the progress bar, sets a phase.
+  void update(std::size_t count, char phase);
+
   // Marks progress bar as done (calling update with _maxValue).
   void done();
 
@@ -55,6 +60,8 @@ class ProgressBar {
   std::time_t _last;
   // Print to std::cerr or not.
   bool _show = false;
+
+  char _phase = 0;
 };
 
 }  // namespace osm2rdf::util

--- a/src/osm/OsmiumHandler.cpp
+++ b/src/osm/OsmiumHandler.cpp
@@ -205,25 +205,26 @@ void osm2rdf::osm::OsmiumHandler<W>::node(const osmium::Node& node) {
 #pragma omp critical(progress)
         {
           _nodesDumped++;
-          _progressBar.update(_numTasksDone++);
+          _progressBar.update(_numTasksDone++, 'N');
         }
       }
-      if (!_config.noGeometricRelations && !_config.noNodeGeometricRelations &&
-          (!osmNode.tags().empty() || _config.addSpatialRelsForUntaggedNodes)) {
-        _geometryHandler->node(osmNode);
+      if (!_config.noGeometricRelations && !_config.noNodeGeometricRelations) {
+        if (!osmNode.tags().empty() || _config.addSpatialRelsForUntaggedNodes) {
+          _geometryHandler->node(osmNode);
+        }
 #pragma omp critical(progress)
         {
           _nodeGeometriesHandled++;
-          _progressBar.update(_numTasksDone++);
+          _progressBar.update(_numTasksDone++, 'N');
         }
       }
     };
   } catch (const osmium::invalid_location& e) {
     if (!_config.noFacts && !_config.noNodeFacts) {
-      _progressBar.update(_numTasksDone++);
+      _progressBar.update(_numTasksDone++, 'N');
     }
     if (!_config.noGeometricRelations && !_config.noNodeGeometricRelations) {
-      _progressBar.update(_numTasksDone++);
+      _progressBar.update(_numTasksDone++, 'N');
     }
     return;
   }
@@ -254,7 +255,7 @@ void osm2rdf::osm::OsmiumHandler<W>::relation(
 #pragma omp critical(progress)
         {
           _relationsDumped++;
-          _progressBar.update(_numTasksDone++);
+          _progressBar.update(_numTasksDone++, 'R');
         }
       }
 
@@ -266,18 +267,18 @@ void osm2rdf::osm::OsmiumHandler<W>::relation(
         if (osmRelation.isArea() || osmRelation.hasGeometry()) {
           _relationGeometriesHandled++;
         }
-        _progressBar.update(_numTasksDone++);
+        _progressBar.update(_numTasksDone++, 'R');
 }
       }
     }
   } catch (const osmium::invalid_location& e) {
     if (!_config.noFacts && !_config.noRelationFacts) {
-      _progressBar.update(_numTasksDone++);
+      _progressBar.update(_numTasksDone++, 'R');
     }
 
     if (!_config.noGeometricRelations &&
         !_config.noRelationGeometricRelations) {
-      _progressBar.update(_numTasksDone++);
+      _progressBar.update(_numTasksDone++, 'R');
     }
     return;
   }
@@ -305,7 +306,7 @@ void osm2rdf::osm::OsmiumHandler<W>::way(const osmium::Way& way) {
 #pragma omp critical(progress)
         {
           _waysDumped++;
-          _progressBar.update(_numTasksDone++);
+          _progressBar.update(_numTasksDone++, 'W');
         }
       }
 
@@ -314,16 +315,16 @@ void osm2rdf::osm::OsmiumHandler<W>::way(const osmium::Way& way) {
 #pragma omp critical(progress)
         {
           _wayGeometriesHandled++;
-          _progressBar.update(_numTasksDone++);
+          _progressBar.update(_numTasksDone++, 'W');
         }
       }
     }
   } catch (const osmium::invalid_location& e) {
     if (!_config.noFacts && !_config.noWayFacts) {
-      _progressBar.update(_numTasksDone++);
+      _progressBar.update(_numTasksDone++, 'W');
     }
     if (!_config.noGeometricRelations && !_config.noWayGeometricRelations) {
-      _progressBar.update(_numTasksDone++);
+      _progressBar.update(_numTasksDone++, 'W');
     }
     return;
   }

--- a/src/util/ProgressBar.cpp
+++ b/src/util/ProgressBar.cpp
@@ -17,6 +17,7 @@
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "osm2rdf/util/ProgressBar.h"
+#include "osm2rdf/util/Time.h"
 
 #include <cassert>
 #include <chrono>
@@ -37,7 +38,7 @@ osm2rdf::util::ProgressBar::ProgressBar(std::size_t maxValue, bool show)
   if (maxValue == 0) {
     _countWidth = 1;
   }
-  _width = kTerminalWidth - _countWidth * 2 - 4 - 5 - 2;
+  _width = kTerminalWidth - _countWidth * 2 - 4 - 5 - 2 - 4 - 20;
 }
 
 // ____________________________________________________________________________
@@ -66,6 +67,10 @@ void osm2rdf::util::ProgressBar::update(std::size_t count) {
   // Store new values.
   _percent = percent;
   _oldValue = count;
+
+  // Add time
+  std::cerr << osm2rdf::util::currentTimeFormatted();
+
   // Open progress bar part with [ ...
   std::cerr << '[';
   // ... add = to indicate done parts ...

--- a/src/util/ProgressBar.cpp
+++ b/src/util/ProgressBar.cpp
@@ -24,6 +24,7 @@
 #include <cstdio>
 #include <iomanip>
 #include <iostream>
+#include <string>
 
 // ____________________________________________________________________________
 osm2rdf::util::ProgressBar::ProgressBar(std::size_t maxValue, bool show)
@@ -37,6 +38,12 @@ osm2rdf::util::ProgressBar::ProgressBar(std::size_t maxValue, bool show)
     _countWidth = 1;
   }
   _width = kTerminalWidth - _countWidth * 2 - 4 - 5 - 2;
+}
+
+// ____________________________________________________________________________
+void osm2rdf::util::ProgressBar::update(std::size_t count, char phase) {
+  _phase = phase;
+  update(count);
 }
 
 // ____________________________________________________________________________
@@ -79,12 +86,19 @@ void osm2rdf::util::ProgressBar::update(std::size_t count) {
   // Add percentage display %
   std::cerr << ' ' << std::setw(3) << std::right << percent << "%";
 
-  // Add absolute progress [x/y]
-  std::cerr << " [" << std::setw(_countWidth) << std::right << count << "/"
-            << _maxValue << "]\r";
-
   // Update last update time
   _last = std::time(nullptr);
+
+  // Add absolute progress [x/y]
+  std::cerr << " [" << std::setw(_countWidth) << std::right << count << "/"
+            << _maxValue << "]";
+
+  // Add phase
+  if (_phase) std::cerr << " [" << _phase << "]";
+  else std::cerr << "    ";
+
+  std::cerr << "\r";
+
 }
 
 // ____________________________________________________________________________


### PR DESCRIPTION
- Output a "state" postfix during Phase 2 (dump) at the end of the progress bar, either `N` (node parsing), `W` (way parsing), or `R` (relation parsing).
- Prefix our progress bar with a timestamp
- Fix the percentage output - the max value was computed incorrectly and was off by a factor of 2
- Update libspatialjoin, which now sets a 4MB write buffer in the `GeometryCache`. The default seems to be 8 KB (`cat /usr/include/stdio.h | grep -i bufsiz`). Reasoning: during a multithreaded phase 2, many threads are doing concurrent random reads on the disk. Previously, the `GeometryCache` (which is also filled by these threads) was also writing 8 KB blocks concurrently.