### PR TITLE
No longer add centroid, envelope, obb, convex hull by default

### DIFF
--- a/.github/workflows/docker-build-bz2.yml
+++ b/.github/workflows/docker-build-bz2.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: End-to-end test, BZ2 output (docker build)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-build-gz.yml
+++ b/.github/workflows/docker-build-gz.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: End-to-end test, GZ output (docker build)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-build-stdout.yml
+++ b/.github/workflows/docker-build-stdout.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: End-to-end test, stdout output (docker build)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-build-uncompressed.yml
+++ b/.github/workflows/docker-build-uncompressed.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: End-to-end test, uncompressed output (docker build)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -2,23 +2,6 @@ name: Native build
 'on':
   - push
 jobs:
-  ubuntu-20-04-build-gcc:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout repository code
-        uses: actions/checkout@v2
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: update apt
-        run: sudo apt update
-      - name: install dependencies
-        run: sudo apt install -y gcc g++ libboost-dev libboost-serialization-dev libexpat1-dev cmake libbz2-dev zlib1g-dev libomp-dev
-      - name: cmake
-        run: mkdir build && cd build && cmake ..
-      - name: make
-        run: cd build && make
-      - name: tests
-        run: cd build && ctest --output-on-failure
   ubuntu-latest-build-gcc:
     runs-on: ubuntu-latest
     steps:
@@ -32,27 +15,6 @@ jobs:
         run: sudo apt install -y gcc g++ libboost-dev libboost-serialization-dev libexpat1-dev cmake libbz2-dev zlib1g-dev libomp-dev
       - name: cmake
         run: mkdir build && cd build && cmake ..
-      - name: make
-        run: cd build && make
-      - name: tests
-        run: cd build && ctest --output-on-failure
-  ubuntu-20-04-build-clang:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout repository code
-        uses: actions/checkout@v2
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
-      - name: update apt
-        run: sudo apt update
-      - name: install dependencies
-        run: sudo apt install -y clang libboost-dev libboost-serialization-dev libexpat1-dev cmake libbz2-dev zlib1g-dev libomp-dev
-      - name: cmake
-        run: mkdir build && cd build && cmake ..
-        shell: bash
-        env:
-          CC: clang
-          CXX: clang++
       - name: make
         run: cd build && make
       - name: tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git clang clang-tidy g++ libboost-dev libboost-serialization-dev libexpat1-dev cmake libbz2-dev zlib1g-dev libomp-dev
 COPY . /app/

--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -69,7 +69,10 @@ struct Config {
 
   // Select amount to dump
   bool addAreaWayLinestrings = false;
-  bool addCentroids = true;
+  bool addCentroid = false;
+  bool addEnvelope = false;
+  bool addObb = false;
+  bool addConvexHull = false;
   bool addWayMetadata = false;
   bool addMemberTriples = true;
   bool addWayNodeSpatialMetadata = false;

--- a/include/osm2rdf/config/Config.h
+++ b/include/osm2rdf/config/Config.h
@@ -57,6 +57,7 @@ struct Config {
   bool noNodeFacts = false;
   bool noRelationFacts = false;
   bool noWayFacts = false;
+  bool addZeroFactNumber = false;
 
   bool noGeometricRelations = false;
   bool noAreaGeometricRelations = false;

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -183,6 +183,16 @@ const static inline std::string NO_WAY_GEOM_RELATIONS_OPTION_LONG =
 const static inline std::string NO_WAY_GEOM_RELATIONS_OPTION_HELP =
     "Do not dump way geometric relations";
 
+const static inline std::string ADD_ZERO_FACT_NUMBER_INFO =
+  "Also output osm2rdf:fact triples with fact number 0";
+const static inline std::string ADD_ZERO_FACT_NUMBER_OPTION_SHORT = "";
+const static inline std::string ADD_ZERO_FACT_NUMBER_OPTION_LONG =
+  "add-zero-fact-number-triples";
+const static inline std::string ADD_ZERO_FACT_NUMBER_OPTION_HELP =
+  "Also output osm2rdf:fact triples with fact number 0, that is, "
+  "for untagged nodes, ways, relations and areas";
+
+
 const static inline std::string UNTAGGED_NODES_SPATIAL_RELS_INFO =
     "Compute spatial relations involving untagged nodes";
 const static inline std::string UNTAGGED_NODES_SPATIAL_RELS_OPTION_SHORT = "";

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -231,12 +231,34 @@ const static inline std::string ADD_AREA_WAY_LINESTRINGS_OPTION_LONG =
 const static inline std::string ADD_AREA_WAY_LINESTRINGS_OPTION_HELP =
     "Add linestrings for ways which form areas";
 
-const static inline std::string NO_ADD_CENTROIDS_INFO =
-    "Do not add centroid information";
-const static inline std::string NO_ADD_CENTROIDS_OPTION_SHORT = "";
-const static inline std::string NO_ADD_CENTROIDS_OPTION_LONG = "no-hascentroid";
-const static inline std::string NO_ADD_CENTROIDS_OPTION_HELP =
-    "Don't add geo:hasCentroid triples";
+const static inline std::string ADD_CENTROID_INFO =
+    "Adding a geo:hasCentroid triple for each geometry";
+const static inline std::string ADD_CENTROID_OPTION_SHORT = "";
+const static inline std::string ADD_CENTROID_OPTION_LONG = "add-hascentroid";
+const static inline std::string ADD_CENTROID_OPTION_HELP =
+    "Add a geo:hasCentroid triple for each geometry";
+
+const static inline std::string ADD_ENVELOPE_INFO =
+  "Adding a geo:hasEnvelope triple for each geometry";
+const static inline std::string ADD_ENVELOPE_OPTION_SHORT = "";
+const static inline std::string ADD_ENVELOPE_OPTION_LONG = "add-hasenvelope";
+const static inline std::string ADD_ENVELOPE_OPTION_HELP =
+    "Add a geo:hasEnvelope triple for each geometry";
+
+const static inline std::string ADD_OBB_INFO =
+  "Adding a geo:hasObb triple for each geometry";
+const static inline std::string ADD_OBB_OPTION_SHORT = "";
+const static inline std::string ADD_OBB_OPTION_LONG = "add-hasobb";
+const static inline std::string ADD_OBB_OPTION_HELP =
+    "Add a geo:hasObb triple for each geometry";
+
+const static inline std::string ADD_CONVEX_HULL_INFO =
+  "Adding a geo:hasConvexHull triple for each geometry";
+const static inline std::string ADD_CONVEX_HULL_OPTION_SHORT = "";
+const static inline std::string ADD_CONVEX_HULL_OPTION_LONG =
+    "add-hasconvexhull";
+const static inline std::string ADD_CONVEX_HULL_OPTION_HELP =
+  "Add a geo:hasConvexHull triple for each geometry";
 
 const static inline std::string ADD_WAY_METADATA_INFO = "Adding way metadata";
 const static inline std::string ADD_WAY_METADATA_OPTION_SHORT = "";

--- a/include/osm2rdf/config/Constants.h
+++ b/include/osm2rdf/config/Constants.h
@@ -187,7 +187,7 @@ const static inline std::string ADD_ZERO_FACT_NUMBER_INFO =
   "Also output osm2rdf:fact triples with fact number 0";
 const static inline std::string ADD_ZERO_FACT_NUMBER_OPTION_SHORT = "";
 const static inline std::string ADD_ZERO_FACT_NUMBER_OPTION_LONG =
-  "add-zero-fact-number-triples";
+  "add-zero-fact-number";
 const static inline std::string ADD_ZERO_FACT_NUMBER_OPTION_HELP =
   "Also output osm2rdf:fact triples with fact number 0, that is, "
   "for untagged nodes, ways, relations and areas";

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -242,6 +242,12 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
       osm2rdf::config::constants::NO_WAY_FACTS_OPTION_LONG,
       osm2rdf::config::constants::NO_WAY_FACTS_OPTION_HELP);
 
+  auto addZeroFactNumberOp =
+      parser.add<popl::Switch, popl::Attribute::expert>(
+          osm2rdf::config::constants::ADD_ZERO_FACT_NUMBER_OPTION_SHORT,
+          osm2rdf::config::constants::ADD_ZERO_FACT_NUMBER_OPTION_LONG,
+          osm2rdf::config::constants::ADD_ZERO_FACT_NUMBER_OPTION_HELP);
+
   auto sourceDatasetOp =
       parser.add<popl::Value<std::string>, popl::Attribute::advanced>(
           osm2rdf::config::constants::SOURCE_DATASET_OPTION_SHORT,
@@ -453,6 +459,7 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
     noNodeFacts = noNodeFactsOp->is_set();
     noRelationFacts = noRelationFactsOp->is_set();
     noWayFacts = noWayFactsOp->is_set();
+    addZeroFactNumber = addZeroFactNumberOp->is_set();
 
     noAreaGeometricRelations = noAreaGeometricRelationsOp->is_set();
     noNodeGeometricRelations = noNodeGeometricRelationsOp->is_set();

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -274,10 +274,25 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
           osm2rdf::config::constants::OGC_GEO_TRIPLES_OPTION_LONG,
           osm2rdf::config::constants::OGC_GEO_TRIPLES_OPTION_HELP, "full");
 
-  auto noAddCentroidsOp = parser.add<popl::Switch, popl::Attribute::advanced>(
-      osm2rdf::config::constants::NO_ADD_CENTROIDS_OPTION_SHORT,
-      osm2rdf::config::constants::NO_ADD_CENTROIDS_OPTION_LONG,
-      osm2rdf::config::constants::NO_ADD_CENTROIDS_OPTION_HELP);
+  auto addCentroidsOp = parser.add<popl::Switch, popl::Attribute::advanced>(
+      osm2rdf::config::constants::ADD_CENTROID_OPTION_SHORT,
+      osm2rdf::config::constants::ADD_CENTROID_OPTION_LONG,
+      osm2rdf::config::constants::ADD_CENTROID_OPTION_HELP);
+
+  auto addEnvelopeOp = parser.add<popl::Switch, popl::Attribute::advanced>(
+      osm2rdf::config::constants::ADD_ENVELOPE_OPTION_SHORT,
+      osm2rdf::config::constants::ADD_ENVELOPE_OPTION_LONG,
+      osm2rdf::config::constants::ADD_ENVELOPE_OPTION_HELP);
+
+  auto addObbOp = parser.add<popl::Switch, popl::Attribute::advanced>(
+      osm2rdf::config::constants::ADD_OBB_OPTION_SHORT,
+      osm2rdf::config::constants::ADD_OBB_OPTION_LONG,
+      osm2rdf::config::constants::ADD_OBB_OPTION_HELP);
+
+  auto addConvexHullOp = parser.add<popl::Switch, popl::Attribute::advanced>(
+      osm2rdf::config::constants::ADD_CONVEX_HULL_OPTION_SHORT,
+      osm2rdf::config::constants::ADD_CONVEX_HULL_OPTION_LONG,
+      osm2rdf::config::constants::ADD_CONVEX_HULL_OPTION_HELP);
 
   auto addAreaWayLinestringsOp =
       parser.add<popl::Switch, popl::Attribute::expert>(
@@ -484,7 +499,10 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
 
     // Select amount to dump
     addAreaWayLinestrings = addAreaWayLinestringsOp->is_set();
-    addCentroids = !noAddCentroidsOp->is_set();
+    addCentroid = addCentroidsOp->is_set();
+    addEnvelope = addEnvelopeOp->is_set();
+    addObb = addObbOp->is_set();
+    addConvexHull = addConvexHullOp->is_set();
     addWayMetadata = addWayMetadataOp->is_set();
     addOsmMetadata = !noOsmMetadataOp->is_set();
     addMemberTriples = !noMemberTriplesOp->is_set();

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -280,7 +280,7 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
           osm2rdf::config::constants::OGC_GEO_TRIPLES_OPTION_LONG,
           osm2rdf::config::constants::OGC_GEO_TRIPLES_OPTION_HELP, "full");
 
-  auto addCentroidsOp = parser.add<popl::Switch, popl::Attribute::advanced>(
+  auto addCentroidOp = parser.add<popl::Switch, popl::Attribute::advanced>(
       osm2rdf::config::constants::ADD_CENTROID_OPTION_SHORT,
       osm2rdf::config::constants::ADD_CENTROID_OPTION_LONG,
       osm2rdf::config::constants::ADD_CENTROID_OPTION_HELP);
@@ -506,7 +506,7 @@ void osm2rdf::config::Config::fromArgs(int argc, char** argv) {
 
     // Select amount to dump
     addAreaWayLinestrings = addAreaWayLinestringsOp->is_set();
-    addCentroid = addCentroidsOp->is_set();
+    addCentroid = addCentroidOp->is_set();
     addEnvelope = addEnvelopeOp->is_set();
     addObb = addObbOp->is_set();
     addConvexHull = addConvexHullOp->is_set();

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -642,10 +642,12 @@ void osm2rdf::osm::FactHandler<W>::writeTagList(
               "^^" + typeString[resultType - 1]));
     }
   }
-  _writer->writeTriple(
-      subj, _writer->generateIRIUnsafe(NAMESPACE__OSM2RDF, "facts"),
-      _writer->generateLiteralUnsafe(std::to_string(tagTripleCount),
-                                     "^^" + IRI__XSD__INTEGER));
+  if (tagTripleCount > 0 || _config.addZeroFactNumber) {
+    _writer->writeTriple(
+        subj, _writer->generateIRIUnsafe(NAMESPACE__OSM2RDF, "facts"),
+        _writer->generateLiteralUnsafe(std::to_string(tagTripleCount),
+                                       "^^" + IRI__XSD__INTEGER));
+  }
 }
 
 // ____________________________________________________________________________

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -115,7 +115,7 @@ void osm2rdf::osm::FactHandler<W>::area(const osm2rdf::osm::Area& area) {
     writeGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, area.geom());
   }
 
-  if (_config.addCentroids) {
+  if (_config.addCentroid) {
     const std::string& centroidObj = _writer->generateIRIUnsafe(
         NAMESPACE__OSM2RDF_GEOM, DATASET_ID[_config.sourceDataset] +
                                      "_area_centroid_" +
@@ -123,9 +123,15 @@ void osm2rdf::osm::FactHandler<W>::area(const osm2rdf::osm::Area& area) {
     _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_CENTROID, centroidObj);
     writeGeometry(centroidObj, IRI__GEOSPARQL__AS_WKT, area.centroid());
   }
-  writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, area.convexHull());
-  writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, area.envelope());
-  writeGeometry(subj, IRI__OSM2RDF_GEOM__OBB, area.orientedBoundingBox());
+  if (_config.addEnvelope) {
+    writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, area.envelope());
+  }
+  if (_config.addObb) {
+    writeGeometry(subj, IRI__OSM2RDF_GEOM__OBB, area.orientedBoundingBox());
+  }
+  if (_config.addConvexHull) {
+    writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, area.convexHull());
+  }
 
   // Increase default precision as areas in regbez freiburg have a 0 area
   // otherwise.
@@ -155,7 +161,7 @@ void osm2rdf::osm::FactHandler<W>::node(const osm2rdf::osm::Node& node) {
   _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
   writeGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, node.geom());
 
-  if (_config.addCentroids) {
+  if (_config.addCentroid) {
     const std::string& centroidObj = _writer->generateIRIUnsafe(
         NAMESPACE__OSM2RDF_GEOM, DATASET_ID[_config.sourceDataset] +
                                      "_node_centroid_" +
@@ -164,16 +170,24 @@ void osm2rdf::osm::FactHandler<W>::node(const osm2rdf::osm::Node& node) {
     writeGeometry(centroidObj, IRI__GEOSPARQL__AS_WKT, node.geom());
   }
 
-  const auto& hullWKT = ::util::geo::getWKT(
-      ::util::geo::DPolygon{{node.geom()}, {}}, _config.wktPrecision);
-
-  _writer->writeLiteralTripleUnsafe(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL,
-                                    hullWKT,
-                                    "^^" + IRI__GEOSPARQL__WKT_LITERAL);
-  writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE,
-           ::util::geo::DBox{node.geom(), node.geom()});
-  _writer->writeLiteralTripleUnsafe(subj, IRI__OSM2RDF_GEOM__OBB, hullWKT,
-                                    "^^" + IRI__GEOSPARQL__WKT_LITERAL);
+  if (_config.addEnvelope) {
+    writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE,
+             ::util::geo::DBox{node.geom(), node.geom()});
+  }
+  if (_config.addObb || _config.addConvexHull) {
+    const auto& hullWKT = ::util::geo::getWKT(
+        ::util::geo::DPolygon{{node.geom()}, {}}, _config.wktPrecision);
+    if (_config.addObb) {
+      _writer->writeLiteralTripleUnsafe(
+          subj, IRI__OSM2RDF_GEOM__OBB, hullWKT,
+          "^^" + IRI__GEOSPARQL__WKT_LITERAL);
+    }
+    if (_config.addConvexHull) {
+      _writer->writeLiteralTripleUnsafe(
+          subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, hullWKT,
+          "^^" + IRI__GEOSPARQL__WKT_LITERAL);
+    }
+  }
 }
 
 // ____________________________________________________________________________
@@ -232,7 +246,7 @@ void osm2rdf::osm::FactHandler<W>::relation(
     _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_GEOMETRY, geomObj);
     writeGeometry(geomObj, IRI__GEOSPARQL__AS_WKT, relation.geom());
 
-    if (_config.addCentroids) {
+    if (_config.addCentroid) {
       const std::string& centroidObj = _writer->generateIRIUnsafe(
           NAMESPACE__OSM2RDF_GEOM, DATASET_ID[_config.sourceDataset] +
                                        "_relation_centroid_" +
@@ -240,10 +254,18 @@ void osm2rdf::osm::FactHandler<W>::relation(
       _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_CENTROID, centroidObj);
       writeGeometry(centroidObj, IRI__GEOSPARQL__AS_WKT, relation.centroid());
     }
-    writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, relation.convexHull());
-    writeBox(subj, osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__ENVELOPE,
-             relation.envelope());
-    writeGeometry(subj, IRI__OSM2RDF_GEOM__OBB, relation.orientedBoundingBox());
+    if (_config.addEnvelope) {
+      writeBox(subj, osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__ENVELOPE,
+               relation.envelope());
+    }
+    if (_config.addObb) {
+      writeGeometry(subj, IRI__OSM2RDF_GEOM__OBB,
+                    relation.orientedBoundingBox());
+    }
+    if (_config.addConvexHull) {
+      writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL,
+                    relation.convexHull());
+    }
 
     _writer->writeTriple(
         subj,
@@ -325,7 +347,7 @@ void osm2rdf::osm::FactHandler<W>::way(const osm2rdf::osm::Way& way) {
   if (!way.isArea()) {
     // only write these triples if the way is not an area, otherwise they
     // are already written in the area handler
-    if (_config.addCentroids) {
+    if (_config.addCentroid) {
       const std::string& centroidObj = _writer->generateIRIUnsafe(
           NAMESPACE__OSM2RDF_GEOM, DATASET_ID[_config.sourceDataset] +
                                        "_way_centroid_" +
@@ -333,9 +355,15 @@ void osm2rdf::osm::FactHandler<W>::way(const osm2rdf::osm::Way& way) {
       _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_CENTROID, centroidObj);
       writeGeometry(centroidObj, IRI__GEOSPARQL__AS_WKT, way.centroid());
     }
-    writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, way.convexHull());
-    writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, way.envelope());
-    writeGeometry(subj, IRI__OSM2RDF_GEOM__OBB, way.orientedBoundingBox());
+    if (_config.addEnvelope) {
+      writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, way.envelope());
+    }
+    if (_config.addObb) {
+      writeGeometry(subj, IRI__OSM2RDF_GEOM__OBB, way.orientedBoundingBox());
+    }
+    if (_config.addConvexHull) {
+      writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, way.convexHull());
+    }
   }
 
   if (_config.addWayMetadata) {

--- a/src/osm/FactHandler.cpp
+++ b/src/osm/FactHandler.cpp
@@ -123,14 +123,17 @@ void osm2rdf::osm::FactHandler<W>::area(const osm2rdf::osm::Area& area) {
     _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_CENTROID, centroidObj);
     writeGeometry(centroidObj, IRI__GEOSPARQL__AS_WKT, area.centroid());
   }
+
+  if (_config.addConvexHull) {
+    writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, area.convexHull());
+  }
+
   if (_config.addEnvelope) {
     writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, area.envelope());
   }
+
   if (_config.addObb) {
     writeGeometry(subj, IRI__OSM2RDF_GEOM__OBB, area.orientedBoundingBox());
-  }
-  if (_config.addConvexHull) {
-    writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, area.convexHull());
   }
 
   // Increase default precision as areas in regbez freiburg have a 0 area
@@ -170,10 +173,6 @@ void osm2rdf::osm::FactHandler<W>::node(const osm2rdf::osm::Node& node) {
     writeGeometry(centroidObj, IRI__GEOSPARQL__AS_WKT, node.geom());
   }
 
-  if (_config.addEnvelope) {
-    writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE,
-             ::util::geo::DBox{node.geom(), node.geom()});
-  }
   if (_config.addObb || _config.addConvexHull) {
     const auto& hullWKT = ::util::geo::getWKT(
         ::util::geo::DPolygon{{node.geom()}, {}}, _config.wktPrecision);
@@ -187,6 +186,11 @@ void osm2rdf::osm::FactHandler<W>::node(const osm2rdf::osm::Node& node) {
           subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, hullWKT,
           "^^" + IRI__GEOSPARQL__WKT_LITERAL);
     }
+  }
+
+  if (_config.addEnvelope) {
+    writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE,
+             ::util::geo::DBox{node.geom(), node.geom()});
   }
 }
 
@@ -254,17 +258,20 @@ void osm2rdf::osm::FactHandler<W>::relation(
       _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_CENTROID, centroidObj);
       writeGeometry(centroidObj, IRI__GEOSPARQL__AS_WKT, relation.centroid());
     }
+
+    if (_config.addConvexHull) {
+      writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL,
+                    relation.convexHull());
+    }
+
     if (_config.addEnvelope) {
       writeBox(subj, osm2rdf::ttl::constants::IRI__OSM2RDF_GEOM__ENVELOPE,
                relation.envelope());
     }
+
     if (_config.addObb) {
       writeGeometry(subj, IRI__OSM2RDF_GEOM__OBB,
                     relation.orientedBoundingBox());
-    }
-    if (_config.addConvexHull) {
-      writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL,
-                    relation.convexHull());
     }
 
     _writer->writeTriple(
@@ -355,14 +362,17 @@ void osm2rdf::osm::FactHandler<W>::way(const osm2rdf::osm::Way& way) {
       _writer->writeTriple(subj, IRI__GEOSPARQL__HAS_CENTROID, centroidObj);
       writeGeometry(centroidObj, IRI__GEOSPARQL__AS_WKT, way.centroid());
     }
+
+    if (_config.addConvexHull) {
+      writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, way.convexHull());
+    }
+
     if (_config.addEnvelope) {
       writeBox(subj, IRI__OSM2RDF_GEOM__ENVELOPE, way.envelope());
     }
+
     if (_config.addObb) {
       writeGeometry(subj, IRI__OSM2RDF_GEOM__OBB, way.orientedBoundingBox());
-    }
-    if (_config.addConvexHull) {
-      writeGeometry(subj, IRI__OSM2RDF_GEOM__CONVEX_HULL, way.convexHull());
     }
   }
 

--- a/tests/issues/Issue24.cpp
+++ b/tests/issues/Issue24.cpp
@@ -35,7 +35,7 @@ TEST(Issue24, areaFromWayHasGeometryAsGeoSPARQL) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -93,7 +93,7 @@ TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -151,7 +151,7 @@ TEST(Issue24, nodeHasGeometryAsGeoSPARQL) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -205,7 +205,7 @@ TEST(Issue24, relationWithGeometryHasGeometryAsGeoSPARQL) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -302,7 +302,7 @@ TEST(Issue24, wayHasGeometryAsGeoSPARQL) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.addMemberTriples = false;

--- a/tests/issues/Issue24.cpp
+++ b/tests/issues/Issue24.cpp
@@ -36,6 +36,9 @@ TEST(Issue24, areaFromWayHasGeometryAsGeoSPARQL) {
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
   config.addCentroid = false;
+  config.addEnvelope = true;
+  config.addConvexHull = true;
+  config.addObb = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -94,6 +97,9 @@ TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
   config.addCentroid = false;
+  config.addEnvelope = false;
+  config.addConvexHull = false;
+  config.addObb = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -124,15 +130,8 @@ TEST(Issue24, areaFromRelationHasGeometryAsGeoSPARQL) {
   output.close();
 
   ASSERT_EQ(
-      "osmrel:10 geo:hasGeometry osm2rdfgeom:osm_relarea_10 "
-      ".\nosm2rdfgeom:osm_relarea_10 geo:asWKT \"POLYGON((48 7.5,48 "
-      "7.6,48.1 7.6,48.1 7.5,48 7.5))\"^^geo:wktLiteral .\nosmrel:10 "
-      "osm2rdfgeom:convex_hull \"POLYGON((48 7.5,48 7.6,48.1 7.6,48.1 7.5,"
-      "48 7.5))\"^^geo:wktLiteral .\nosmrel:10 osm2rdfgeom:envelope "
-      "\"POLYGON((48 7.5,48.1 7.5,48.1 7.6,48 7.6,48 "
-      "7.5))\"^^geo:wktLiteral .\nosmrel:10 osm2rdfgeom:obb \"POLYGON((48 7.5,"
-      "48 7.6,48.1 7.6,48.1 7.5,48 7.5))\"^^geo:wktLiteral .\nosmrel:10 "
-      "osm2rdf:area \"0.01\"^^xsd:double .\n",
+      "osmrel:10 geo:hasGeometry osm2rdfgeom:osm_relarea_10 .\nosm2rdfgeom:osm_relarea_10 geo:asWKT \"POLYGON((48 7.5,48 7.6,48.1 7.6,48.1 7.5,48 7.5))\"^^geo:wktLiteral .\nosmrel:10 osm2rdfgeom:obb \"POLYGON((48 7.5,48 7.6,48.1 7.6,48.1 7.5,48 7.5))\"^^geo:wktLiteral .\nosmrel:10 osm2rdf:area \"0.01\"^^xsd:double .\n"
+      ,
       buffer.str());
 
   // Cleanup
@@ -152,6 +151,10 @@ TEST(Issue24, nodeHasGeometryAsGeoSPARQL) {
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
   config.addCentroid = false;
+  config.addEnvelope = true;
+  config.addConvexHull = true;
+  config.addObb = true;
+  config.addZeroFactNumber = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -176,17 +179,7 @@ TEST(Issue24, nodeHasGeometryAsGeoSPARQL) {
   output.close();
 
   ASSERT_EQ(
-      "osmnode:42 rdf:type osm:node .\n"
-      "osmnode:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
-      "osmnode:42 osmmeta:version \"0\"^^xsd:integer .\n"
-      "osmnode:42 osm2rdf:facts \"0\"^^xsd:integer .\n"
-      "osmnode:42 geo:hasGeometry osm2rdfgeom:osm_node_42 .\n"
-      "osm2rdfgeom:osm_node_42 geo:asWKT "
-      "\"POINT(7.5 48)\"^^geo:wktLiteral .\nosmnode:42 osm2rdfgeom:convex_hull "
-      "\"POLYGON((7.5 48))\"^^geo:wktLiteral .\nosmnode:42 "
-      "osm2rdfgeom:envelope \"POLYGON((7.5 48,7.5 48,7.5 48,7.5 48,7.5 "
-      "48))\"^^geo:wktLiteral .\nosmnode:42 osm2rdfgeom:obb \"POLYGON((7.5 "
-      "48))\"^^geo:wktLiteral .\n",
+      "osmnode:42 rdf:type osm:node .\nosmnode:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\nosmnode:42 osmmeta:version \"0\"^^xsd:integer .\nosmnode:42 osm2rdf:facts \"0\"^^xsd:integer .\nosmnode:42 geo:hasGeometry osm2rdfgeom:osm_node_42 .\nosm2rdfgeom:osm_node_42 geo:asWKT \"POINT(7.5 48)\"^^geo:wktLiteral .\nosmnode:42 osm2rdfgeom:obb \"POLYGON((7.5 48))\"^^geo:wktLiteral .\nosmnode:42 osm2rdfgeom:convex_hull \"POLYGON((7.5 48))\"^^geo:wktLiteral .\nosmnode:42 osm2rdfgeom:envelope \"POLYGON((7.5 48,7.5 48,7.5 48,7.5 48,7.5 48))\"^^geo:wktLiteral .\n",
       buffer.str());
 
   // Cleanup
@@ -206,6 +199,10 @@ TEST(Issue24, relationWithGeometryHasGeometryAsGeoSPARQL) {
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
   config.addCentroid = false;
+  config.addEnvelope = true;
+  config.addConvexHull = true;
+  config.addObb = true;
+  config.addZeroFactNumber = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -306,6 +303,11 @@ TEST(Issue24, wayHasGeometryAsGeoSPARQL) {
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.addMemberTriples = false;
+
+  config.addEnvelope = true;
+  config.addConvexHull = true;
+  config.addObb = true;
+  config.addZeroFactNumber = true;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -55,7 +55,7 @@ TEST(OSM_FactHandler, areaFromWay) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -114,7 +114,7 @@ TEST(OSM_FactHandler, areaFromRelation) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -173,7 +173,7 @@ TEST(OSM_FactHandler, node) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -228,7 +228,7 @@ TEST(OSM_FactHandler, relation) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -287,7 +287,7 @@ TEST(OSM_FactHandler, relationHandler) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -377,7 +377,7 @@ TEST(OSM_FactHandler, relationWithGeometry) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -477,7 +477,7 @@ TEST(OSM_FactHandler, way) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.addMemberTriples = false;
@@ -540,7 +540,7 @@ TEST(OSM_FactHandler, wayAddWayNodeOrder) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.addMemberTriples = true;
@@ -604,7 +604,7 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataShortWay) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.addMemberTriples = true;
@@ -671,7 +671,7 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataLongerWay) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.addMemberTriples = true;
@@ -743,7 +743,7 @@ TEST(OSM_FactHandler, wayAddWayMetaData) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.addWayMetadata = true;
@@ -810,7 +810,7 @@ TEST(OSM_FactHandler, writeGeometryWay) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -851,7 +851,7 @@ TEST(OSM_FactHandler, writeGeometryWaySimplify1) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.simplifyWKT = 2;
@@ -899,7 +899,7 @@ TEST(OSM_FactHandler, writeGeometryWaySimplify2) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.simplifyWKT = 2;
@@ -943,7 +943,7 @@ TEST(OSM_FactHandler, writeGeometryWaySimplify3) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.simplifyWKT = 2;
@@ -988,7 +988,7 @@ TEST(OSM_FactHandler, writeBoxPrecision1) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -1028,7 +1028,7 @@ TEST(OSM_FactHandler, writeBoxPrecision2) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 2;
 
@@ -1068,7 +1068,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1108,7 +1108,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger2) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1147,7 +1147,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger3) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1186,7 +1186,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_Integer) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1226,7 +1226,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerPositive) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1266,7 +1266,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerNegative) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1306,7 +1306,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerWS) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1346,7 +1346,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerWS2) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1386,7 +1386,7 @@ TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1425,7 +1425,7 @@ TEST(OSM_FactHandler, writeTag_KeyIRI) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1464,7 +1464,7 @@ TEST(OSM_FactHandler, writeTag_KeyNotIRI) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1505,7 +1505,7 @@ TEST(OSM_FactHandler, writeTagList) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1557,7 +1557,7 @@ TEST(OSM_FactHandler, writeTagListRefSingle) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1600,7 +1600,7 @@ TEST(OSM_FactHandler, writeTagListRefDouble) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.semicolonTagKeys.insert("ref");
 
@@ -1647,7 +1647,7 @@ TEST(OSM_FactHandler, writeTagListRefMultiple) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.semicolonTagKeys.insert("ref");
 
@@ -1697,7 +1697,7 @@ TEST(OSM_FactHandler, writeTagListWikidata) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1746,7 +1746,7 @@ TEST(OSM_FactHandler, writeTagListWikidataMultiple) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1795,7 +1795,7 @@ TEST(OSM_FactHandler, writeTagListWikipediaWithLang) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1844,7 +1844,7 @@ TEST(OSM_FactHandler, writeTagListWikipediaWithoutLang) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1893,7 +1893,7 @@ TEST(OSM_FactHandler, writeTagListSkipWikiLinks) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.skipWikiLinks = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
@@ -1948,7 +1948,7 @@ TEST(OSM_FactHandler, writeTagListStartDateInvalid) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -1992,7 +1992,7 @@ TEST(OSM_FactHandler, writeTagListStartDateInvalid2) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2036,7 +2036,7 @@ TEST(OSM_FactHandler, writeTagListStartDateInvalid3) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2080,7 +2080,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYear1) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2129,7 +2129,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYear2) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2178,7 +2178,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYear3) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2227,7 +2227,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYear4) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2276,7 +2276,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth1) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2325,7 +2325,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth2) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2374,7 +2374,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth3) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2423,7 +2423,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth4) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2472,7 +2472,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonth5) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2522,7 +2522,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay1) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2571,7 +2571,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay2) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2620,7 +2620,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay3) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2669,7 +2669,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay4) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};
@@ -2718,7 +2718,7 @@ TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay5) {
   config.numThreads = 1;  // set to one to avoid concurrency issues with the
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
-  config.addCentroids = false;
+  config.addCentroid = false;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
 
   osm2rdf::util::Output output{config, config.output};

--- a/tests/osm/FactHandler.cpp
+++ b/tests/osm/FactHandler.cpp
@@ -56,6 +56,10 @@ TEST(OSM_FactHandler, areaFromWay) {
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
   config.addCentroid = false;
+  config.addEnvelope = true;
+  config.addConvexHull = true;
+  config.addObb = true;
+  config.addZeroFactNumber = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -115,6 +119,10 @@ TEST(OSM_FactHandler, areaFromRelation) {
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
   config.addCentroid = false;
+  config.addEnvelope = true;
+  config.addConvexHull = true;
+  config.addObb = true;
+  config.addZeroFactNumber = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -174,6 +182,10 @@ TEST(OSM_FactHandler, node) {
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
   config.addCentroid = false;
+  config.addEnvelope = true;
+  config.addConvexHull = true;
+  config.addObb = true;
+  config.addZeroFactNumber = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -199,17 +211,7 @@ TEST(OSM_FactHandler, node) {
   output.close();
 
   ASSERT_EQ(
-      "osmnode:42 rdf:type osm:node .\n"
-      "osmnode:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\n"
-      "osmnode:42 osmmeta:version \"0\"^^xsd:integer .\n"
-      "osmnode:42 osmkey:city \"Freiburg\" .\n"
-      "osmnode:42 osm2rdf:facts \"1\"^^xsd:integer "
-      ".\nosmnode:42 geo:hasGeometry osm2rdfgeom:osm_node_42 "
-      ".\nosm2rdfgeom:osm_node_42 geo:asWKT \"POINT(7.5 48)\"^^geo:wktLiteral "
-      ".\nosmnode:42 osm2rdfgeom:convex_hull \"POLYGON((7.5 "
-      "48))\"^^geo:wktLiteral .\nosmnode:42 osm2rdfgeom:envelope "
-      "\"POLYGON((7.5 48,7.5 48,7.5 48,7.5 48,7.5 48))\"^^geo:wktLiteral "
-      ".\nosmnode:42 osm2rdfgeom:obb \"POLYGON((7.5 48))\"^^geo:wktLiteral .\n",
+      "osmnode:42 rdf:type osm:node .\nosmnode:42 osmmeta:timestamp \"1970-01-01T00:00:00\"^^xsd:dateTime .\nosmnode:42 osmmeta:version \"0\"^^xsd:integer .\nosmnode:42 osmkey:city \"Freiburg\" .\nosmnode:42 osm2rdf:facts \"1\"^^xsd:integer .\nosmnode:42 geo:hasGeometry osm2rdfgeom:osm_node_42 .\nosm2rdfgeom:osm_node_42 geo:asWKT \"POINT(7.5 48)\"^^geo:wktLiteral .\nosmnode:42 osm2rdfgeom:obb \"POLYGON((7.5 48))\"^^geo:wktLiteral .\nosmnode:42 osm2rdfgeom:convex_hull \"POLYGON((7.5 48))\"^^geo:wktLiteral .\nosmnode:42 osm2rdfgeom:envelope \"POLYGON((7.5 48,7.5 48,7.5 48,7.5 48,7.5 48))\"^^geo:wktLiteral .\n",
       buffer.str());
 
   // Cleanup
@@ -378,6 +380,10 @@ TEST(OSM_FactHandler, relationWithGeometry) {
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
   config.addCentroid = false;
+  config.addEnvelope = true;
+  config.addConvexHull = true;
+  config.addObb = true;
+  config.addZeroFactNumber = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
 
@@ -481,6 +487,10 @@ TEST(OSM_FactHandler, way) {
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.addMemberTriples = false;
+  config.addEnvelope = true;
+  config.addConvexHull = true;
+  config.addObb = true;
+  config.addZeroFactNumber = true;
 
   osm2rdf::util::Output output{config, config.output};
   output.open();
@@ -541,6 +551,10 @@ TEST(OSM_FactHandler, wayAddWayNodeOrder) {
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
   config.addCentroid = false;
+  config.addEnvelope = true;
+  config.addConvexHull = true;
+  config.addObb = true;
+  config.addZeroFactNumber = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.addMemberTriples = true;
@@ -605,6 +619,10 @@ TEST(OSM_FactHandler, wayAddWayNodeSpatialMetadataShortWay) {
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
   config.addCentroid = false;
+  config.addEnvelope = true;
+  config.addConvexHull = true;
+  config.addObb = true;
+  config.addZeroFactNumber = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.addMemberTriples = true;
@@ -744,6 +762,10 @@ TEST(OSM_FactHandler, wayAddWayMetaData) {
                           // stringstream read buffer
   config.outputCompress = osm2rdf::config::NONE;
   config.addCentroid = false;
+  config.addEnvelope = true;
+  config.addConvexHull = true;
+  config.addObb = true;
+  config.addZeroFactNumber = true;
   config.mergeOutput = osm2rdf::util::OutputMergeMode::NONE;
   config.wktPrecision = 1;
   config.addWayMetadata = true;


### PR DESCRIPTION
So far, for each geometry, its centroid, axis-parallel bounding box, oriented bounding box, and convex hull were output by default. There was an option `--no-add-centroids`, but there was no option for the other three. Now, none of these features are added by default, and there are individual options to add each of them, namely (note the singular, the old option used the plural):
 `--add-centroid`, `--add-envelope`, `--add-obb`, and `--add-convex-hull`.

While at it, also no longer output the `osm2rdf:facts` triple when the value is zero, that is, do not output it for untagged nodes, ways, relations, and areas. Note that when the other `osm2rdf:facts` triples are present (which they are by default), the value `0` can be inferred by the triple not being present for a geometry. If the output of these triples is desired nevertheless, there is now the option `--add-zero-fact-number`.

NOTE: With https://github.com/ad-freiburg/qlever/pull/1974 and https://github.com/ad-freiburg/qlever/pull/2157, QLever now has an implementation for `geof:centroid` and `geof:envelope`, which can compute the respective features on the fly. There will also be an implementation for `geof:convexHull`. GeoSPARQL has no standard function for computing the oriented bounding box.