### PR TITLE
Faster dumping

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 [submodule "vendor/spatialjoin"]
 	path = vendor/spatialjoin
 	url = https://github.com/ad-freiburg/spatialjoin.git
+[submodule "vendor/zlib-ng/zlib-ng"]
+	path = vendor/zlib-ng/zlib-ng
+	url = https://github.com/zlib-ng/zlib-ng.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,14 @@ add_compile_options(-ffast-math)
 # ----------------------------------------------------------------------------
 find_package(EXPAT REQUIRED)
 find_package(BZip2 REQUIRED)
-find_package(ZLIB REQUIRED)
+#find_package(ZLIB REQUIRED)
 find_package(OpenMP)
+
+# zlib-ng
+option(ZLIB_COMPAT ON)
+option(WITH_GTEST OFF)
+option(ZLIB_ENABLE_TESTS OFF)
+add_subdirectory(vendor/zlib-ng/zlib-ng)
 
 # Disable installation of google stuff
 set(INSTALL_GMOCK OFF)

--- a/include/osm2rdf/osm/CountHandler.h
+++ b/include/osm2rdf/osm/CountHandler.h
@@ -35,6 +35,8 @@ class CountHandler : public osmium::handler::Handler {
   size_t numNodes() const;
   size_t numRelations() const;
   size_t numWays() const;
+  size_t weightedNumWays() const;
+  size_t weightedNumRelations() const;
 
   size_t minNodeId() const { return _minId; };
   size_t maxNodeId() const { return _maxId; };
@@ -43,6 +45,8 @@ class CountHandler : public osmium::handler::Handler {
   size_t _numNodes = 0;
   size_t _numRelations = 0;
   size_t _numWays = 0;
+  size_t _weightedNumWays = 0;
+  size_t _weightedNumRelations = 0;
   bool _firstPassDone = false;
   size_t _minId = std::numeric_limits<size_t>::max();
   size_t _maxId = 0;

--- a/include/osm2rdf/osm/FactHandler.h
+++ b/include/osm2rdf/osm/FactHandler.h
@@ -45,6 +45,7 @@ class FactHandler {
   // Add data
   void area(const osm2rdf::osm::Area& area);
   void node(const osm2rdf::osm::Node& node);
+  void node(const osmium::Node& node);
   void relation(const osm2rdf::osm::Relation& relation);
   void way(const osm2rdf::osm::Way& way);
 
@@ -61,7 +62,7 @@ class FactHandler {
   template <typename T>
   void writeMeta(const std::string& s, const T& object);
 
-  void writeTag(const std::string& s, const osm2rdf::osm::Tag& tag);
+  void writeTag(const std::string& s, const char* key, const char* val);
   FRIEND_TEST(OSM_FactHandler, writeTag_AdminLevel);
   FRIEND_TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger);
   FRIEND_TEST(OSM_FactHandler, writeTag_AdminLevel_nonInteger2);
@@ -73,6 +74,8 @@ class FactHandler {
   FRIEND_TEST(OSM_FactHandler, writeTag_AdminLevel_IntegerWS2);
   FRIEND_TEST(OSM_FactHandler, writeTag_KeyIRI);
   FRIEND_TEST(OSM_FactHandler, writeTag_KeyNotIRI);
+
+  void writeTagList(const std::string& s, const osmium::TagList& tags);
 
   void writeTagList(const std::string& s, const osm2rdf::osm::TagList& tags);
   FRIEND_TEST(OSM_FactHandler, writeTagList);

--- a/include/osm2rdf/osm/FactHandler.h
+++ b/include/osm2rdf/osm/FactHandler.h
@@ -44,7 +44,6 @@ class FactHandler {
               osm2rdf::ttl::Writer<W>* writer);
   // Add data
   void area(const osm2rdf::osm::Area& area);
-  void node(const osm2rdf::osm::Node& node);
   void node(const osmium::Node& node);
   void relation(const osm2rdf::osm::Relation& relation);
   void way(const osm2rdf::osm::Way& way);
@@ -76,6 +75,32 @@ class FactHandler {
   FRIEND_TEST(OSM_FactHandler, writeTag_KeyNotIRI);
 
   void writeTagList(const std::string& s, const osmium::TagList& tags);
+  FRIEND_TEST(OSM_FactHandler, writeTagList);
+  FRIEND_TEST(OSM_FactHandler, writeTagListWikidata);
+  FRIEND_TEST(OSM_FactHandler, writeTagListRefSingle);
+  FRIEND_TEST(OSM_FactHandler, writeTagListRefDouble);
+  FRIEND_TEST(OSM_FactHandler, writeTagListRefMultiple);
+  FRIEND_TEST(OSM_FactHandler, writeTagListWikidataMultiple);
+  FRIEND_TEST(OSM_FactHandler, writeTagListWikipediaWithLang);
+  FRIEND_TEST(OSM_FactHandler, writeTagListWikipediaWithoutLang);
+  FRIEND_TEST(OSM_FactHandler, writeTagListSkipWikiLinks);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateInvalid);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateInvalid2);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateInvalid3);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYear1);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYear2);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYear3);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYear4);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonth1);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonth2);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonth3);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonth4);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonth5);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay1);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay2);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay3);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay4);
+  FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay5);
 
   void writeTagList(const std::string& s, const osm2rdf::osm::TagList& tags);
   FRIEND_TEST(OSM_FactHandler, writeTagList);
@@ -106,6 +131,7 @@ class FactHandler {
   FRIEND_TEST(OSM_FactHandler, writeTagListStartDateYearMonthDay5);
 
   bool hasSuffix(const std::string& s, const std::string& suffix) const;
+  bool hasSuffix(const char* s, const char* suffix, size_t suffixSize) const;
 
   const osm2rdf::config::Config _config;
   osm2rdf::ttl::Writer<W>* _writer;

--- a/include/osm2rdf/osm/GeometryHandler.h
+++ b/include/osm2rdf/osm/GeometryHandler.h
@@ -50,7 +50,7 @@ class GeometryHandler {
 
   // Add data
   void area(const osm2rdf::osm::Area& area);
-  void node(const osm2rdf::osm::Node& node);
+  void node(const osmium::Node& node);
   void relation(const osm2rdf::osm::Relation& relation);
   void way(const osm2rdf::osm::Way& way);
 

--- a/include/osm2rdf/osm/GeometryHandler.h
+++ b/include/osm2rdf/osm/GeometryHandler.h
@@ -75,6 +75,9 @@ class GeometryHandler {
   static ::util::geo::I32MultiPolygon transform(
       const ::util::geo::DMultiPolygon& area);
 
+  std::string getSweeperId(uint64_t oid, char type);
+  std::string getFullID(const std::string& id);
+
   void writeRelCb(size_t t, const std::string& a, const std::string& b,
                   const std::string& pred);
   void progressCb(size_t progr);

--- a/include/osm2rdf/osm/LocationHandler.h
+++ b/include/osm2rdf/osm/LocationHandler.h
@@ -40,6 +40,7 @@ class LocationHandler : public osmium::handler::Handler {
   virtual ~LocationHandler() {}
   virtual void node(const osmium::Node& node) = 0;
   virtual void way(osmium::Way& way) = 0;
+  virtual void finalizeNodes() = 0;
   [[nodiscard]] virtual osmium::Location get_node_location(
       const osmium::object_id_type id) const = 0;
   // Helper creating the correct instance.
@@ -54,12 +55,14 @@ class LocationHandlerImpl : public LocationHandler {
                                size_t nodeIdMin, size_t nodeIdMax);
   void node(const osmium::Node& node);
   void way(osmium::Way& way);
+  void finalizeNodes() {_nodesFinalized = true; };
   [[nodiscard]] osmium::Location get_node_location(
       const osmium::object_id_type nodeId) const;
 
  protected:
   T _index;
   osmium::handler::NodeLocationsForWays<T> _handler;
+  bool _nodesFinalized = false;
 };
 
 template <>
@@ -71,6 +74,7 @@ class LocationHandlerImpl<osmium::index::map::SparseFileArray<
                                size_t nodeIdMin, size_t nodeIdMax);
   void node(const osmium::Node& node);
   void way(osmium::Way& way);
+  void finalizeNodes() {_nodesFinalized = true; };
   [[nodiscard]] osmium::Location get_node_location(
       const osmium::object_id_type nodeId) const;
 
@@ -82,6 +86,7 @@ class LocationHandlerImpl<osmium::index::map::SparseFileArray<
   osmium::handler::NodeLocationsForWays<osmium::index::map::SparseFileArray<
       osmium::unsigned_object_id_type, osmium::Location>>
       _handler;
+  bool _nodesFinalized = false;
 };
 
 template <>
@@ -93,6 +98,7 @@ class LocationHandlerImpl<osmium::index::map::DenseFileArray<
                                size_t nodeIdMin, size_t nodeIdMax);
   void node(const osmium::Node& node);
   void way(osmium::Way& way);
+  void finalizeNodes() {_nodesFinalized = true; };
   [[nodiscard]] osmium::Location get_node_location(
       const osmium::object_id_type nodeId) const;
 
@@ -104,6 +110,7 @@ class LocationHandlerImpl<osmium::index::map::DenseFileArray<
   osmium::handler::NodeLocationsForWays<osmium::index::map::DenseFileArray<
       osmium::unsigned_object_id_type, osmium::Location>>
       _handler;
+  bool _nodesFinalized = false;
 };
 
 template <>
@@ -115,6 +122,7 @@ class LocationHandlerImpl<osm2rdf::osm::DenseMemIndex<
                                size_t nodeIdMin, size_t nodeIdMax);
   void node(const osmium::Node& node);
   void way(osmium::Way& way);
+  void finalizeNodes() {_nodesFinalized = true; };
   [[nodiscard]] osmium::Location get_node_location(
       const osmium::object_id_type nodeId) const;
 
@@ -124,6 +132,7 @@ class LocationHandlerImpl<osm2rdf::osm::DenseMemIndex<
   osmium::handler::NodeLocationsForWays<osm2rdf::osm::DenseMemIndex<
       osmium::unsigned_object_id_type, osmium::Location>>
       _handler;
+  bool _nodesFinalized = false;
 };
 
 using LocationHandlerRAMDense = LocationHandlerImpl<osm2rdf::osm::DenseMemIndex<

--- a/include/osm2rdf/osm/OsmiumHandler.h
+++ b/include/osm2rdf/osm/OsmiumHandler.h
@@ -29,6 +29,9 @@
 #include "osmium/osm/area.hpp"
 #include "osmium/osm/node.hpp"
 #include "osmium/osm/relation.hpp"
+#include "osmium/io/any_input.hpp"
+#include "osmium/area/multipolygon_manager.hpp"
+#include "osmium/area/assembler.hpp"
 #include "osmium/osm/way.hpp"
 
 namespace osm2rdf::osm {
@@ -43,7 +46,7 @@ class OsmiumHandler : public osmium::handler::Handler {
   void area(const osmium::Area& area);
   void node(const osmium::Node& node);
   void relation(const osmium::Relation& relation);
-  void way(const osmium::Way& way);
+  void way(osmium::Way& way);
 
   [[nodiscard]] size_t areasSeen() const;
   [[nodiscard]] size_t areasDumped() const;
@@ -62,6 +65,7 @@ class OsmiumHandler : public osmium::handler::Handler {
   osm2rdf::config::Config _config;
   osm2rdf::osm::FactHandler<W>* _factHandler;
   osm2rdf::osm::GeometryHandler<W>* _geometryHandler;
+  osm2rdf::osm::LocationHandler* _locationHandler;
 
   osm2rdf::osm::RelationHandler _relationHandler;
   osm2rdf::util::ProgressBar _progressBar;
@@ -79,6 +83,9 @@ class OsmiumHandler : public osmium::handler::Handler {
   size_t _wayGeometriesHandled = 0;
 
   size_t _numTasksDone = 0;
+ private:
+  void handleBuffers(std::vector<osmium::memory::Buffer>& buffers, size_t len, std::vector<osmium::memory::Buffer>& areaBuffers, size_t& ai, osmium::area::MultipolygonManager<osmium::area::Assembler>& mp_manager);
+  void handleAreaBuffers(std::vector<osmium::memory::Buffer>& areaBuffers, size_t len);
 };
 }  // namespace osm2rdf::osm
 

--- a/include/osm2rdf/osm/OsmiumHandler.h
+++ b/include/osm2rdf/osm/OsmiumHandler.h
@@ -25,13 +25,13 @@
 #include "osm2rdf/osm/GeometryHandler.h"
 #include "osm2rdf/ttl/Writer.h"
 #include "osm2rdf/util/ProgressBar.h"
+#include "osmium/area/assembler.hpp"
+#include "osmium/area/multipolygon_manager.hpp"
 #include "osmium/handler.hpp"
+#include "osmium/io/any_input.hpp"
 #include "osmium/osm/area.hpp"
 #include "osmium/osm/node.hpp"
 #include "osmium/osm/relation.hpp"
-#include "osmium/io/any_input.hpp"
-#include "osmium/area/multipolygon_manager.hpp"
-#include "osmium/area/assembler.hpp"
 #include "osmium/osm/way.hpp"
 
 namespace osm2rdf::osm {
@@ -69,23 +69,28 @@ class OsmiumHandler : public osmium::handler::Handler {
 
   osm2rdf::osm::RelationHandler _relationHandler;
   osm2rdf::util::ProgressBar _progressBar;
-  size_t _areasSeen = 0;
-  size_t _areasDumped = 0;
-  size_t _areaGeometriesHandled = 0;
-  size_t _nodesSeen = 0;
-  size_t _nodesDumped = 0;
-  size_t _nodeGeometriesHandled = 0;
-  size_t _relationsSeen = 0;
-  size_t _relationsDumped = 0;
-  size_t _relationGeometriesHandled = 0;
-  size_t _waysSeen = 0;
-  size_t _waysDumped = 0;
-  size_t _wayGeometriesHandled = 0;
+  std::atomic<size_t> _areasSeen = 0;
+  std::atomic<size_t> _areasDumped = 0;
+  std::atomic<size_t> _areaGeometriesHandled = 0;
+  std::atomic<size_t> _nodesSeen = 0;
+  std::atomic<size_t> _nodesDumped = 0;
+  std::atomic<size_t> _nodeGeometriesHandled = 0;
+  std::atomic<size_t> _relationsSeen = 0;
+  std::atomic<size_t> _relationsDumped = 0;
+  std::atomic<size_t> _relationGeometriesHandled = 0;
+  std::atomic<size_t> _waysSeen = 0;
+  std::atomic<size_t> _waysDumped = 0;
+  std::atomic<size_t> _wayGeometriesHandled = 0;
 
-  size_t _numTasksDone = 0;
+  std::atomic<size_t> _numTasksDone = 0;
+
  private:
-  void handleBuffers(std::vector<osmium::memory::Buffer>& buffers, size_t len, std::vector<osmium::memory::Buffer>& areaBuffers, size_t& ai, osmium::area::MultipolygonManager<osmium::area::Assembler>& mp_manager);
-  void handleAreaBuffers(std::vector<osmium::memory::Buffer>& areaBuffers, size_t len);
+  void handleBuffers(
+      std::vector<osmium::memory::Buffer>& buffers, size_t len,
+      std::vector<osmium::memory::Buffer>& areaBuffers, size_t& ai,
+      osmium::area::MultipolygonManager<osmium::area::Assembler>& mp_manager);
+  void handleAreaBuffers(std::vector<osmium::memory::Buffer>& areaBuffers,
+                         size_t len);
 };
 }  // namespace osm2rdf::osm
 

--- a/include/osm2rdf/osm/OsmiumHandler.h
+++ b/include/osm2rdf/osm/OsmiumHandler.h
@@ -86,11 +86,9 @@ class OsmiumHandler : public osmium::handler::Handler {
 
  private:
   void handleBuffers(
-      std::vector<osmium::memory::Buffer>& buffers, size_t len,
-      std::vector<osmium::memory::Buffer>& areaBuffers, size_t& ai,
+      osmium::memory::Buffer& buffer,
       osmium::area::MultipolygonManager<osmium::area::Assembler>& mp_manager);
-  void handleAreaBuffers(std::vector<osmium::memory::Buffer>& areaBuffers,
-                         size_t len);
+  void handleAreaBuffers(osmium::memory::Buffer& areaBuffer);
 };
 }  // namespace osm2rdf::osm
 

--- a/include/osm2rdf/osm/Way.h
+++ b/include/osm2rdf/osm/Way.h
@@ -45,33 +45,12 @@ class Way {
   [[nodiscard]] bool visible() const noexcept;
   [[nodiscard]] bool closed() const noexcept;
   [[nodiscard]] bool isArea() const noexcept;
-  [[nodiscard]] const ::util::geo::DBox& envelope() const noexcept;
-  [[nodiscard]] const ::util::geo::DLine& geom() const noexcept;
-  [[nodiscard]] const ::util::geo::DPolygon& convexHull() const noexcept;
-  [[nodiscard]] const ::util::geo::DPolygon& orientedBoundingBox()
-      const noexcept;
-  [[nodiscard]] const ::util::geo::DPoint centroid() const noexcept;
-  [[nodiscard]] const std::vector<osm2rdf::osm::Node>& nodes() const noexcept;
-  [[nodiscard]] const osm2rdf::osm::TagList& tags() const noexcept;
-
-  bool operator==(const osm2rdf::osm::Way& other) const noexcept;
-  bool operator!=(const osm2rdf::osm::Way& other) const noexcept;
+  [[nodiscard]] const ::util::geo::DLine geom() const noexcept;
+  [[nodiscard]] const osmium::WayNodeList& nodes() const noexcept;
+  [[nodiscard]] const osmium::TagList& tags() const noexcept;
 
  protected:
-  id_t _id;
-  osm2rdf::osm::generic::changeset_id_t _changeset;
-  std::time_t _timestamp;
-  std::string _user;
-  id_t _uid;
-  osm2rdf::osm::generic::version_t _version;
-  bool _visible;
-  std::vector<osm2rdf::osm::Node> _nodes;
-  ::util::geo::DLine _geom;
-  ::util::geo::DBox _envelope;
-  ::util::geo::DPolygon _convexHull;
-  ::util::geo::DPolygon _obb;
-  osm2rdf::osm::TagList _tags;
-  bool _hasAreaTag;
+  const osmium::Way* _w = 0;
 };
 
 }  // namespace osm2rdf::osm

--- a/include/osm2rdf/util/Output.h
+++ b/include/osm2rdf/util/Output.h
@@ -26,7 +26,7 @@
 
 #include "osm2rdf/config/Config.h"
 
-static const size_t BUFFER_S = 1024 * 1024 * 100;
+static const size_t BUFFER_S = 1024 * 1024 * 10;
 
 namespace osm2rdf::util {
 

--- a/include/osm2rdf/util/Output.h
+++ b/include/osm2rdf/util/Output.h
@@ -26,12 +26,11 @@
 
 #include "osm2rdf/config/Config.h"
 
-static const size_t BUFFER_S = 1024 * 1024 * 10;
+static const size_t BUFFER_S = 1024 * 1024 * 30;
 
 namespace osm2rdf::util {
 
-class Output {
- public:
+class Output { public:
   Output(const osm2rdf::config::Config& config, const std::string& prefix);
   Output(const osm2rdf::config::Config& config, const std::string& prefix,
          size_t partCount);
@@ -60,6 +59,8 @@ class Output {
   // Closes and concatenates all parts without decompressing and recompressing
   // streams.
   void concatenate();
+
+  void writeToFile(unsigned char* from, size_t len, size_t t);
   // Config instance.
   const osm2rdf::config::Config _config;
   // Prefix for all filenames.

--- a/include/osm2rdf/util/ProgressBar.h
+++ b/include/osm2rdf/util/ProgressBar.h
@@ -50,8 +50,6 @@ class ProgressBar {
   std::size_t _maxValue;
   // Current absolute value.
   std::size_t _oldValue;
-  // Number of digits required for _maxValue.
-  std::size_t _countWidth;
   // Width of whole progress bar.
   std::size_t _width;
   // Current percent value.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(osm2rdf_library PRIVATE
         Threads::Threads
         ${EXPAT_LIBRARIES}
         ${BZIP2_LIBRARIES}
-        ${ZLIB_LIBRARIES})
+        zlib)
 
 # Link OpenMP if found
 if (OpenMP_CXX_FOUND)

--- a/src/osm/CountHandler.cpp
+++ b/src/osm/CountHandler.cpp
@@ -16,9 +16,9 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
-#include <iostream>
-
 #include "osm2rdf/osm/CountHandler.h"
+
+#include <iostream>
 
 // ____________________________________________________________________________
 void osm2rdf::osm::CountHandler::prepare_for_lookup() { _firstPassDone = true; }
@@ -39,6 +39,7 @@ void osm2rdf::osm::CountHandler::relation(const osmium::Relation& rel) {
     return;
   }
   _numRelations++;
+  _weightedNumRelations += rel.members().size() * 2;
 }
 
 // ____________________________________________________________________________
@@ -47,6 +48,7 @@ void osm2rdf::osm::CountHandler::way(const osmium::Way& way) {
     return;
   }
   _numWays++;
+  _weightedNumWays += way.nodes().size();
 }
 
 // ____________________________________________________________________________
@@ -58,4 +60,14 @@ size_t osm2rdf::osm::CountHandler::numRelations() const {
 }
 
 // ____________________________________________________________________________
+size_t osm2rdf::osm::CountHandler::weightedNumRelations() const {
+  return _weightedNumRelations;
+}
+
+// ____________________________________________________________________________
 size_t osm2rdf::osm::CountHandler::numWays() const { return _numWays; }
+
+// ____________________________________________________________________________
+size_t osm2rdf::osm::CountHandler::weightedNumWays() const {
+  return _weightedNumWays;
+}

--- a/src/osm/DenseMemIndex.cpp
+++ b/src/osm/DenseMemIndex.cpp
@@ -25,6 +25,7 @@ template <typename TId, typename TValue>
 osm2rdf::osm::DenseMemIndex<TId, TValue>::DenseMemIndex(size_t minNodeId,
                                                         size_t maxNodeId)
     : _offset(minNodeId), _index(maxNodeId - minNodeId + 1) {
+      std::cerr << minNodeId << " " << maxNodeId << std::endl;
 }
 
 // ____________________________________________________________________________

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -139,7 +139,7 @@ template <typename W>
 void GeometryHandler<W>::writeRelCb(size_t t, const std::string& a,
                                     const std::string& b,
                                     const std::string& pred) {
-  _writer->writeTriple(getFullID(a), pred, getFullId(b), t);
+  _writer->writeTriple(getFullID(a), pred, getFullID(b), t);
 }
 
 // ____________________________________________________________________________
@@ -223,7 +223,7 @@ template <typename W>
 // ____________________________________________________________________________
 template <typename W>
 void GeometryHandler<W>::node(const osmium::Node& node) {
-  std::string id = getSweeperId(node.id(), 1);_
+  std::string id = getSweeperId(node.id(), 1);
   _sweeper.add(transform(::util::geo::DPoint{node.location().lon(),
                                              node.location().lat()}),
                id, false, _parseBatches[omp_get_thread_num()]);

--- a/src/osm/GeometryHandler.cpp
+++ b/src/osm/GeometryHandler.cpp
@@ -102,9 +102,7 @@ void GeometryHandler<W>::relation(const Relation& rel) {
 
   if (!rel.hasGeometry()) return;
 
-  const std::string id = _writer->generateIRI(
-      osm2rdf::ttl::constants::RELATION_NAMESPACE[_config.sourceDataset],
-      rel.id());
+  const std::string id = getSweeperId(rel.id(), 5);
 
   size_t subId = 0;
 
@@ -141,7 +139,7 @@ template <typename W>
 void GeometryHandler<W>::writeRelCb(size_t t, const std::string& a,
                                     const std::string& b,
                                     const std::string& pred) {
-  _writer->writeTriple(a, pred, b, t);
+  _writer->writeTriple(getFullID(a), pred, getFullId(b), t);
 }
 
 // ____________________________________________________________________________
@@ -201,9 +199,7 @@ template <typename W>
 // ____________________________________________________________________________
 template <typename W>
 void GeometryHandler<W>::area(const Area& area) {
-  const std::string id = _writer->generateIRI(
-      areaNS(area.fromWay() ? AreaFromType::WAY : AreaFromType::RELATION),
-      area.objId());
+  const std::string id = getSweeperId(area.objId(), area.fromWay() ? 3 : 4);
 
   _sweeper.add(transform(area.geom()), id, false,
                _parseBatches[omp_get_thread_num()]);
@@ -227,10 +223,7 @@ template <typename W>
 // ____________________________________________________________________________
 template <typename W>
 void GeometryHandler<W>::node(const osmium::Node& node) {
-  std::string id = _writer->generateIRI(
-      osm2rdf::ttl::constants::NODE_NAMESPACE[_config.sourceDataset],
-      node.id());
-
+  std::string id = getSweeperId(node.id(), 1);_
   _sweeper.add(transform(::util::geo::DPoint{node.location().lon(),
                                              node.location().lat()}),
                id, false, _parseBatches[omp_get_thread_num()]);
@@ -246,8 +239,7 @@ template <typename W>
 void GeometryHandler<W>::way(const Way& way) {
   if (way.isArea()) return;  // skip way relations, will be handled by area()
 
-  std::string id = _writer->generateIRI(
-      osm2rdf::ttl::constants::WAY_NAMESPACE[_config.sourceDataset], way.id());
+  std::string id = getSweeperId(way.id(), 2);
 
   _sweeper.add(transform(way.geom()), id, false,
                _parseBatches[omp_get_thread_num()]);
@@ -313,6 +305,62 @@ std::string GeometryHandler<W>::areaNS(AreaFromType type) const {
     default:
       return osm2rdf::ttl::constants::WAY_NAMESPACE[_config.sourceDataset];
   }
+}
+
+// ____________________________________________________________________________
+template <typename W>
+std::string GeometryHandler<W>::getFullID(const std::string& strid) {
+  uint64_t id = 0;
+
+  for (size_t i = strid.size() - 1; i > 0; i--) {
+    id |=
+        static_cast<uint64_t>(reinterpret_cast<const unsigned char&>(strid[i]))
+        << (8 * (strid.size() - 1 - i));
+  }
+
+  if (strid[0] == 1) {
+    return _writer->generateIRI(
+        osm2rdf::ttl::constants::NODE_NAMESPACE[_config.sourceDataset], id);
+  }
+
+  if (strid[0] == 2) {
+    return _writer->generateIRI(
+        osm2rdf::ttl::constants::WAY_NAMESPACE[_config.sourceDataset], id);
+  }
+
+  if (strid[0] == 3) {
+    return _writer->generateIRI(areaNS(AreaFromType::WAY), id);
+  }
+
+  if (strid[0] == 4) {
+    return _writer->generateIRI(areaNS(AreaFromType::RELATION), id);
+  }
+
+  if (strid[0] == 5) {
+    return _writer->generateIRI(
+        osm2rdf::ttl::constants::RELATION_NAMESPACE[_config.sourceDataset], id);
+  }
+
+  return strid;
+}
+
+// ____________________________________________________________________________
+template <typename W>
+std::string GeometryHandler<W>::getSweeperId(uint64_t oid, char type) {
+  unsigned char id[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  int a = 0;
+  uint64_t tmp;
+
+  while ((oid >> (a * 8))) {
+    tmp = (oid & (0xFFLL << (a * 8)));
+    id[8 - a] = tmp >> (a * 8);
+    a++;
+  }
+
+  id[8 - a] = type;
+
+  return std::string{reinterpret_cast<char*>(id + (8 - a)),
+                     static_cast<size_t>(a + 1)};
 }
 
 // ____________________________________________________________________________

--- a/src/osm/LocationHandler.cpp
+++ b/src/osm/LocationHandler.cpp
@@ -56,6 +56,7 @@ osmium::Location osm2rdf::osm::LocationHandlerImpl<T>::get_node_location(
 // ____________________________________________________________________________
 template <typename T>
 void osm2rdf::osm::LocationHandlerImpl<T>::node(const osmium::Node& node) {
+  if (_nodesFinalized) return;
   _handler.node(node);
 }
 
@@ -95,6 +96,7 @@ osm2rdf::osm::LocationHandlerImpl<osmium::index::map::SparseFileArray<
 void osm2rdf::osm::LocationHandlerImpl<osmium::index::map::SparseFileArray<
     osmium::unsigned_object_id_type,
     osmium::Location>>::node(const osmium::Node& node) {
+  if (_nodesFinalized) return;
   _handler.node(node);
 }
 
@@ -118,6 +120,7 @@ osm2rdf::osm::LocationHandlerImpl<osmium::index::map::DenseFileArray<
 void osm2rdf::osm::LocationHandlerImpl<osmium::index::map::DenseFileArray<
     osmium::unsigned_object_id_type,
     osmium::Location>>::node(const osmium::Node& node) {
+  if (_nodesFinalized) return;
   _handler.node(node);
 }
 
@@ -148,6 +151,7 @@ osm2rdf::osm::LocationHandlerImpl<osm2rdf::osm::DenseMemIndex<
 void osm2rdf::osm::LocationHandlerImpl<osm2rdf::osm::DenseMemIndex<
     osmium::unsigned_object_id_type,
     osmium::Location>>::node(const osmium::Node& node) {
+  if (_nodesFinalized) return;
   _handler.node(node);
 }
 

--- a/src/osm/Node.cpp
+++ b/src/osm/Node.cpp
@@ -38,7 +38,7 @@ osm2rdf::osm::Node::Node(const osmium::Node& node) {
   _visible = node.visible();
   const auto& loc = node.location();
   _geom = ::util::geo::DPoint{loc.lon(), loc.lat()};
-  _tags = std::move(osm2rdf::osm::convertTagList(node.tags()));
+  _tags = osm2rdf::osm::convertTagList(node.tags());
 }
 
 // ____________________________________________________________________________

--- a/src/osm/TagList.cpp
+++ b/src/osm/TagList.cpp
@@ -30,7 +30,7 @@ osm2rdf::osm::TagList osm2rdf::osm::convertTagList(
   for (const auto& tag : tagList) {
     std::string key{tag.key()};
     std::replace(key.begin(), key.end(), ' ', '_');
-    result.push_back({key, tag.value()});
+    result.push_back({tag.key(), tag.value()});
   }
   return result;
 }

--- a/src/ttl/Writer.cpp
+++ b/src/ttl/Writer.cpp
@@ -578,8 +578,6 @@ void osm2rdf::ttl::Writer<T>::writeUnsafeIRILiteralTriple(
 
 #if defined(_OPENMP)
   part = omp_get_thread_num();
-#else
-  part = 0;
 #endif
 
   writeUnsafeIRILiteralTriple(s, p, v, o, part);
@@ -645,8 +643,6 @@ void osm2rdf::ttl::Writer<T>::writeTriple(const std::string& s,
 
 #if defined(_OPENMP)
   part = omp_get_thread_num();
-#else
-  part = 0;
 #endif
 
   writeTriple(s, p, o, part);
@@ -677,8 +673,6 @@ void osm2rdf::ttl::Writer<T>::writeLiteralTripleUnsafe(const std::string& s,
 
 #if defined(_OPENMP)
   part = omp_get_thread_num();
-#else
-  part = 0;
 #endif
   writeLiteralTripleUnsafe(s, p, a, b, part);
 }

--- a/src/util/Output.cpp
+++ b/src/util/Output.cpp
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU General Public License
 // along with osm2rdf.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "osm2rdf/util/Output.h"
+
 #include <bzlib.h>
 #include <zlib.h>
 
@@ -27,10 +29,8 @@
 #include <thread>
 #include <vector>
 
-#include "osm2rdf/util/Time.h"
-
 #include "osm2rdf/config/Config.h"
-#include "osm2rdf/util/Output.h"
+#include "osm2rdf/util/Time.h"
 
 using osm2rdf::config::BZ2;
 using osm2rdf::config::GZ;
@@ -39,8 +39,7 @@ using osm2rdf::config::NONE;
 // ____________________________________________________________________________
 osm2rdf::util::Output::Output(const osm2rdf::config::Config& config,
                               const std::string& prefix)
-    : Output(config, prefix, config.numThreads + 1) {
-}
+    : Output(config, prefix, config.numThreads + 1) {}
 
 // ____________________________________________________________________________
 osm2rdf::util::Output::Output(const osm2rdf::config::Config& config,
@@ -60,6 +59,8 @@ osm2rdf::util::Output::~Output() { close(); }
 bool osm2rdf::util::Output::open() {
   assert(_partCount > 0);
 
+  std::cerr << zlibVersion() << std::endl;
+
   _rawFiles.resize(_partCount);
   _gzFiles.resize(_partCount);
   _files.resize(_partCount);
@@ -71,8 +72,7 @@ bool osm2rdf::util::Output::open() {
 
       if (_rawFiles[i] == NULL) {
         std::stringstream ss;
-        ss << "Could not open file '" << partFilename(i)
-           << "' for writing:\n";
+        ss << "Could not open file '" << partFilename(i) << "' for writing:\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
       }
@@ -136,8 +136,7 @@ void osm2rdf::util::Output::close() {
       if (err == BZ_IO_ERROR) {
         BZ2_bzWriteClose(&err, _files[i], 0, 0, 0);
         std::stringstream ss;
-        ss << "Could not write to bzip2 file '"
-           << partFilename(i) << "':\n";
+        ss << "Could not write to bzip2 file '" << partFilename(i) << "':\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
       }
@@ -151,8 +150,7 @@ void osm2rdf::util::Output::close() {
       if (r != (int)_outBufPos[i]) {
         gzclose(_gzFiles[i]);
         std::stringstream ss;
-        ss << "Could not write to gz file '"
-           << partFilename(i) << "':\n";
+        ss << "Could not write to gz file '" << partFilename(i) << "':\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
       }
@@ -165,8 +163,7 @@ void osm2rdf::util::Output::close() {
           fwrite(_outBuffers[i], sizeof(char), _outBufPos[i], _rawFiles[i]);
       if (r != _outBufPos[i]) {
         std::stringstream ss;
-        ss << "Could not write to file '"
-           << partFilename(i) << "':\n";
+        ss << "Could not write to file '" << partFilename(i) << "':\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
       }
@@ -246,43 +243,34 @@ void osm2rdf::util::Output::writeNewLine(size_t part) {
 // ____________________________________________________________________________
 void osm2rdf::util::Output::write(std::string_view strv, size_t t) {
   assert(t < _partCount);
-  if (_toStdOut) {
-    // on output to stdout, we only flush on newlines
-  } else if (_config.outputCompress == BZ2) {
-    if (_outBufPos[t] + strv.size() + 1 >= BUFFER_S) {
+  if (_outBufPos[t] + strv.size() + 1 >= BUFFER_S) {
+    if (_config.outputCompress == BZ2) {
       int err = 0;
       BZ2_bzWrite(&err, _files[t], _outBuffers[t], _outBufPos[t]);
       if (err == BZ_IO_ERROR) {
         BZ2_bzWriteClose(&err, _files[t], 0, 0, 0);
         std::stringstream ss;
-        ss << "Could not write to bzip2 file '"
-           << partFilename(t) << "':\n";
+        ss << "Could not write to bzip2 file '" << partFilename(t) << "':\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
       }
       _outBufPos[t] = 0;
-    }
-  } else if (_config.outputCompress == GZ) {
-    if (_outBufPos[t] + strv.size() + 1 >= BUFFER_S) {
+    } else if (_config.outputCompress == GZ) {
       int r = gzwrite(_gzFiles[t], _outBuffers[t], _outBufPos[t]);
       if (r != (int)_outBufPos[t]) {
         gzclose(_gzFiles[t]);
         std::stringstream ss;
-        ss << "Could not write to gz file '"
-           << partFilename(t) << "':\n";
+        ss << "Could not write to gz file '" << partFilename(t) << "':\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
       }
       _outBufPos[t] = 0;
-    }
-  } else {
-    if (_outBufPos[t] + strv.size() + 1 >= BUFFER_S) {
+    } else if (_config.outputCompress == NONE) {
       size_t r =
           fwrite(_outBuffers[t], sizeof(char), _outBufPos[t], _rawFiles[t]);
       if (r != _outBufPos[t]) {
         std::stringstream ss;
-        ss << "Could not write to file '"
-           << partFilename(t) << "':\n";
+        ss << "Could not write to file '" << partFilename(t) << "':\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
       }
@@ -291,14 +279,6 @@ void osm2rdf::util::Output::write(std::string_view strv, size_t t) {
   }
 
   if (_outBufPos[t] + strv.size() + 1 >= BUFFER_S) {
-    std::cerr << osm2rdf::util::currentTimeFormatted()
-              << "String to write: " << strv << std::endl;
-    std::cerr << osm2rdf::util::currentTimeFormatted()
-              << "String size: " << strv.size() << std::endl;
-    std::cerr << osm2rdf::util::currentTimeFormatted()
-              << "Buffer size: " << BUFFER_S << std::endl;
-    std::cerr << osm2rdf::util::currentTimeFormatted()
-              << "Buffer pos: " << _outBufPos[t] << std::endl;
     throw std::runtime_error("Write buffer too small to write " +
                              std::to_string(strv.size()) + " bytes");
   }
@@ -310,43 +290,34 @@ void osm2rdf::util::Output::write(std::string_view strv, size_t t) {
 // ____________________________________________________________________________
 void osm2rdf::util::Output::write(const char c, size_t t) {
   assert(t < _partCount);
-  if (_toStdOut) {
-    // on output to stdout, we only flush on newlines
-  } else if (_config.outputCompress == BZ2) {
-    if (_outBufPos[t] + 2 >= BUFFER_S) {
+  if (_outBufPos[t] + 2 >= BUFFER_S) {
+    if (_config.outputCompress == BZ2) {
       int err = 0;
       BZ2_bzWrite(&err, _files[t], _outBuffers[t], _outBufPos[t]);
       if (err == BZ_IO_ERROR) {
         BZ2_bzWriteClose(&err, _files[t], 0, 0, 0);
         std::stringstream ss;
-        ss << "Could not write to bzip2 file '"
-           << partFilename(t) << "':\n";
+        ss << "Could not write to bzip2 file '" << partFilename(t) << "':\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
       }
       _outBufPos[t] = 0;
-    }
-  } else if (_config.outputCompress == GZ) {
-    if (_outBufPos[t] + 2 >= BUFFER_S) {
+    } else if (_config.outputCompress == GZ) {
       int r = gzwrite(_gzFiles[t], _outBuffers[t], _outBufPos[t]);
       if (r != (int)_outBufPos[t]) {
         gzclose(_gzFiles[t]);
         std::stringstream ss;
-        ss << "Could not write to gz file '"
-           << partFilename(t) << "':\n";
+        ss << "Could not write to gz file '" << partFilename(t) << "':\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
       }
       _outBufPos[t] = 0;
-    }
-  } else {
-    if (_outBufPos[t] + 2 >= BUFFER_S) {
+    } else if (_config.outputCompress == NONE) {
       size_t r =
           fwrite(_outBuffers[t], sizeof(char), _outBufPos[t], _rawFiles[t]);
       if (r != _outBufPos[t]) {
         std::stringstream ss;
-        ss << "Could not write to file '"
-           << partFilename(t) << "':\n";
+        ss << "Could not write to file '" << partFilename(t) << "':\n";
         ss << strerror(errno) << std::endl;
         throw std::runtime_error(ss.str());
       }
@@ -355,10 +326,6 @@ void osm2rdf::util::Output::write(const char c, size_t t) {
   }
 
   if (_outBufPos[t] + 2 >= BUFFER_S) {
-    std::cerr << osm2rdf::util::currentTimeFormatted()
-              << "Buffer size: " << BUFFER_S << std::endl;
-    std::cerr << osm2rdf::util::currentTimeFormatted()
-              << "Buffer pos: " << _outBufPos[t] << std::endl;
     throw std::runtime_error("Write buffer too small to write 1 byte");
   }
 
@@ -385,18 +352,16 @@ void osm2rdf::util::Output::flush(size_t i) {
     if (err == BZ_IO_ERROR) {
       BZ2_bzWriteClose(&err, _files[i], 0, 0, 0);
       std::stringstream ss;
-      ss << "Could not write to bzip2 file '"
-         << partFilename(i) << "':\n";
+      ss << "Could not write to bzip2 file '" << partFilename(i) << "':\n";
       ss << strerror(errno) << std::endl;
       throw std::runtime_error(ss.str());
     }
   } else if (_config.outputCompress == GZ) {
     int r = gzwrite(_gzFiles[i], _outBuffers[i], _outBufPos[i]);
     if (r != (int)_outBufPos[i]) {
-          gzclose(_gzFiles[i]);
+      gzclose(_gzFiles[i]);
       std::stringstream ss;
-      ss << "Could not write to gz file '"
-         << partFilename(i) << "':\n";
+      ss << "Could not write to gz file '" << partFilename(i) << "':\n";
       ss << strerror(errno) << std::endl;
       throw std::runtime_error(ss.str());
     }
@@ -405,8 +370,7 @@ void osm2rdf::util::Output::flush(size_t i) {
         fwrite(_outBuffers[i], sizeof(char), _outBufPos[i], _rawFiles[i]);
     if (r != _outBufPos[i]) {
       std::stringstream ss;
-      ss << "Could not write to file '"
-         << partFilename(i) << "':\n";
+      ss << "Could not write to file '" << partFilename(i) << "':\n";
       ss << strerror(errno) << std::endl;
       throw std::runtime_error(ss.str());
     }

--- a/src/util/ProgressBar.cpp
+++ b/src/util/ProgressBar.cpp
@@ -30,15 +30,11 @@
 // ____________________________________________________________________________
 osm2rdf::util::ProgressBar::ProgressBar(std::size_t maxValue, bool show)
     : _maxValue(maxValue),
-      _countWidth(std::floor(std::log10(maxValue)) + 1),
       _percent(k100Percent + 1),
       _last(std::time(nullptr)),
       _show(show) {
   // Handle special case of 0 elements
-  if (maxValue == 0) {
-    _countWidth = 1;
-  }
-  _width = kTerminalWidth - _countWidth * 2 - 4 - 5 - 2 - 4 - 20;
+  _width = kTerminalWidth - - 4 - 5 - 2 - 4 - 20;
 }
 
 // ____________________________________________________________________________
@@ -94,10 +90,6 @@ void osm2rdf::util::ProgressBar::update(std::size_t count) {
   // Update last update time
   _last = std::time(nullptr);
 
-  // Add absolute progress [x/y]
-  std::cerr << " [" << std::setw(_countWidth) << std::right << count << "/"
-            << _maxValue << "]";
-
   // Add phase
   if (_phase) std::cerr << " [" << _phase << "]";
   else std::cerr << "    ";
@@ -113,9 +105,4 @@ void osm2rdf::util::ProgressBar::done() {
   }
   update(_maxValue);
   std::cerr << std::endl;
-}
-
-// ____________________________________________________________________________
-std::size_t osm2rdf::util::ProgressBar::countWidth() const {
-  return _countWidth;
 }


### PR DESCRIPTION
This is a rough draft of several experiments I did in the last days. The overall goal is to speed up the dump phase of `osm2rdf`.

1. Previously, `libosmium` objects were generated by a single thread in packages of one `osmium::Buffer`, and these objects were then distributed as tasks to several threads. Each object was exactly one task, adding a lot of synchronization overhead. Also, crucially, the internal `libosmium` objects (node, object, area etc.) had to be *copied* to a `osm2rdf` representation within each thread, because the original `libosmium` objects were only valid during the lifetime of the `osmium::Buffer` buffer object (think of the buffer as the thing that is directly read from the `pbf` file, and e.g. attributes of an object are than `const char*` pointers directly into this buffer and thus invalidated as soon as the buffer is filled again). This added a lot of copying overhead, especially for the attributes. `osmium::Buffer` nicely implements move semantics, so we can move each buffer object into a worker thread and operate on the original `libosmium` objects the entire time, eliminating the need to copy the elements into the thread. This was non-trivial to achieve, as several `libosmium` handlers were previously applied iteratively to a finished `osmium::Buffer` object which augmented the objects until they were finally given to the handler that task'ed them away. Several of these handlers assume that the objects come in ordered by their OSM id from the input dataset, which is no longer guaranteed when buffers are handled in parallel. We solved this by separating these handlers (for example, the location handler which stores the node position in a lookup index) into a separated internal pass. In total, this sped up the dump phase for `switzerland-latest.osm.pbf` using the default options from around 4 minutes to around 1:06 minutes (using gzip compression).**
2. For the gzip compression, we replaced our internal C-API calls to `zlib` by the drop-in replacement `zlib-ng`. This further sped up the dump phase by around 20%.
3. I did some minor adjustments in the handling of attributes, in particular I avoided some copies there by operating directly on the raw C-strings.
4. I cherry-picked the smaller spatialjoin IDs proposed in #108.

In total, the changes above **sped up the dump phase for `switzerland-latest.osm.pbf` (using default options) from around 4 minutes to around 50 seconds (using gzip compression).**

I strongly suggest that we switch to gzip compression as the default, as there does not seem to be a faster alternative to `libbz2`, which is notoriously slow.

On the side, I fixed the progress bars a bit by "weighting" individual tasks by their estimated duration. In particular, each way is now weighted by the number of its member nodes.